### PR TITLE
Add max_password_age for password policy

### DIFF
--- a/modules/iam-account/main.tf
+++ b/modules/iam-account/main.tf
@@ -9,6 +9,7 @@ resource "aws_iam_account_alias" "this" {
 resource "aws_iam_account_password_policy" "this" {
   count = "${var.create_account_password_policy ? 1 : 0}"
 
+  max_password_age               = "${var.max_password_age}"
   minimum_password_length        = "${var.minimum_password_length}"
   allow_users_to_change_password = "${var.allow_users_to_change_password}"
   hard_expiry                    = "${var.hard_expiry}"

--- a/modules/iam-account/variables.tf
+++ b/modules/iam-account/variables.tf
@@ -12,6 +12,11 @@ variable "create_account_password_policy" {
   default     = true
 }
 
+variable "max_password_age" {
+  description = "The number of days that an user password is valid."
+  default     = 0
+}
+
 variable "minimum_password_length" {
   description = "Minimum length to require for user passwords"
   default     = 8


### PR DESCRIPTION
Hi,

I wanted to set the password age with the module but couldn't find the required variable.
This is possible with terraform [aws_iam_account_password_policy](https://www.terraform.io/docs/providers/aws/r/iam_account_password_policy.html#max_password_age) ressource.