### PR TITLE
Additional Policies in Role

### DIFF
--- a/examples/iam-assumable-roles-with-saml/main.tf
+++ b/examples/iam-assumable-roles-with-saml/main.tf
@@ -33,10 +33,10 @@ module "iam_assumable_roles_with_saml_custom" {
 
   create_poweruser_role = true
 
-  create_poweruser_role                  = true
-  poweruser_role_name                    = "Billing-And-Support-Access"
-  poweruser_role_policy_arn              = "arn:aws:iam::aws:policy/job-function/Billing"
-  poweruser_role_additional_policies_arn = ["arn:aws:iam::aws:policy/AWSSupportAccess"]
+  create_poweruser_role                   = true
+  poweruser_role_name                     = "Billing-And-Support-Access"
+  poweruser_role_policy_arn               = "arn:aws:iam::aws:policy/job-function/Billing"
+  poweruser_role_additional_policies_arns = ["arn:aws:iam::aws:policy/AWSSupportAccess"]
 
   create_readonly_role = true
 

--- a/examples/iam-assumable-roles-with-saml/main.tf
+++ b/examples/iam-assumable-roles-with-saml/main.tf
@@ -24,3 +24,22 @@ module "iam_assumable_roles_with_saml" {
   provider_name = "${aws_iam_saml_provider.idp_saml.name}"
   provider_id   = "${aws_iam_saml_provider.idp_saml.id}"
 }
+
+#################################################################
+# Create custom role with SAML idp trust and additional policies
+#################################################################
+module "iam_assumable_roles_with_saml_custom" {
+  source = "../../../terraform-aws-iam/modules/iam-assumable-roles-with-saml"
+
+  create_poweruser_role = true
+
+  create_poweruser_role                  = true
+  poweruser_role_name                    = "Billing-And-Support-Access"
+  poweruser_role_policy_arn              = "arn:aws:iam::aws:policy/job-function/Billing"
+  poweruser_role_additional_policies_arn = ["arn:aws:iam::aws:policy/AWSSupportAccess"]
+
+  create_readonly_role = true
+
+  provider_name = "${aws_iam_saml_provider.idp_saml.name}"
+  provider_id   = "${aws_iam_saml_provider.idp_saml.id}"
+}

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -15,7 +15,8 @@ Creates single IAM role which can be assumed by trusted resources using SAML Fed
 | admin\_role\_path | Path of admin IAM role | string | `"/"` | no |
 | admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | string | `""` | no |
 | admin\_role\_policy\_arn | Policy ARN to use for admin role | string | `"arn:aws:iam::aws:policy/AdministratorAccess"` | no |
-| aws\_saml\_endpoint | AWS SAML Endpoint | list | `[ "https://signin.aws.amazon.com/saml" ]` | no |
+| admin\_role\_additional\_policies\_arn | Additional Policies ARN to use for admin role | list | `[]` | no |
+| admin\_role\_requires\_mfa | Whether admin role requires MFA | string | `"true"` | no |
 | create\_admin\_role | Whether to create admin role | string | `"false"` | no |
 | create\_poweruser\_role | Whether to create poweruser role | string | `"false"` | no |
 | create\_readonly\_role | Whether to create readonly role | string | `"false"` | no |
@@ -24,12 +25,17 @@ Creates single IAM role which can be assumed by trusted resources using SAML Fed
 | poweruser\_role\_path | Path of poweruser IAM role | string | `"/"` | no |
 | poweruser\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for poweruser role | string | `""` | no |
 | poweruser\_role\_policy\_arn | Policy ARN to use for poweruser role | string | `"arn:aws:iam::aws:policy/PowerUserAccess"` | no |
-| provider\_id | ID of the SAML Provider | string | n/a | yes |
-| provider\_name | Name of the SAML Provider | string | n/a | yes |
+| poweruser\_role\_additional\_policies\_arn | Additional Policies ARN to use for poweruser role | list | `[]` | no |
+| poweruser\_role\_requires\_mfa | Whether poweruser role requires MFA | string | `"true"` | no |
 | readonly\_role\_name | IAM role with readonly access | string | `"readonly"` | no |
 | readonly\_role\_path | Path of readonly IAM role | string | `"/"` | no |
 | readonly\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for readonly role | string | `""` | no |
 | readonly\_role\_policy\_arn | Policy ARN to use for readonly role | string | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
+| readonly\_role\_additional\_policies\_arn | Additional Policies ARN to use for readonly role | list | `[]` | no |
+| readonly\_role\_requires\_mfa | Whether readonly role requires MFA | string | `"true"` | no |
+| provider\_name | Name of the SAML Provider | string | `""` | yes |
+| provider\_id | ID of the SAML Provider | string | `""` | yes |
+| aws_saml_endpoint | AWS SAML Endpoint | list | `["https://signin.aws.amazon.com/saml"]` | no |
 
 ## Outputs
 
@@ -38,11 +44,14 @@ Creates single IAM role which can be assumed by trusted resources using SAML Fed
 | admin\_iam\_role\_arn | ARN of admin IAM role |
 | admin\_iam\_role\_name | Name of admin IAM role |
 | admin\_iam\_role\_path | Path of admin IAM role |
+| admin\_iam\_role\_requires\_mfa | Whether admin IAM role requires MFA |
 | poweruser\_iam\_role\_arn | ARN of poweruser IAM role |
 | poweruser\_iam\_role\_name | Name of poweruser IAM role |
 | poweruser\_iam\_role\_path | Path of poweruser IAM role |
+| poweruser\_iam\_role\_requires\_mfa | Whether poweruser IAM role requires MFA |
 | readonly\_iam\_role\_arn | ARN of readonly IAM role |
 | readonly\_iam\_role\_name | Name of readonly IAM role |
 | readonly\_iam\_role\_path | Path of readonly IAM role |
+| readonly\_iam\_role\_requires\_mfa | Whether readonly IAM role requires MFA |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -15,7 +15,7 @@ Creates single IAM role which can be assumed by trusted resources using SAML Fed
 | admin\_role\_path | Path of admin IAM role | string | `"/"` | no |
 | admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | string | `""` | no |
 | admin\_role\_policy\_arn | Policy ARN to use for admin role | string | `"arn:aws:iam::aws:policy/AdministratorAccess"` | no |
-| admin\_role\_additional\_policies\_arn | Additional Policies ARN to use for admin role | list | `[]` | no |
+| admin\_role\_additional\_policies\_arns | Additional Policies ARNs to use for admin role | list | `[]` | no |
 | admin\_role\_requires\_mfa | Whether admin role requires MFA | string | `"true"` | no |
 | create\_admin\_role | Whether to create admin role | string | `"false"` | no |
 | create\_poweruser\_role | Whether to create poweruser role | string | `"false"` | no |
@@ -25,13 +25,13 @@ Creates single IAM role which can be assumed by trusted resources using SAML Fed
 | poweruser\_role\_path | Path of poweruser IAM role | string | `"/"` | no |
 | poweruser\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for poweruser role | string | `""` | no |
 | poweruser\_role\_policy\_arn | Policy ARN to use for poweruser role | string | `"arn:aws:iam::aws:policy/PowerUserAccess"` | no |
-| poweruser\_role\_additional\_policies\_arn | Additional Policies ARN to use for poweruser role | list | `[]` | no |
+| poweruser\_role\_additional\_policies\_arns | Additional Policies ARNs to use for poweruser role | list | `[]` | no |
 | poweruser\_role\_requires\_mfa | Whether poweruser role requires MFA | string | `"true"` | no |
 | readonly\_role\_name | IAM role with readonly access | string | `"readonly"` | no |
 | readonly\_role\_path | Path of readonly IAM role | string | `"/"` | no |
 | readonly\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for readonly role | string | `""` | no |
 | readonly\_role\_policy\_arn | Policy ARN to use for readonly role | string | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
-| readonly\_role\_additional\_policies\_arn | Additional Policies ARN to use for readonly role | list | `[]` | no |
+| readonly\_role\_additional\_policies\_arns | Additional Policies ARNs to use for readonly role | list | `[]` | no |
 | readonly\_role\_requires\_mfa | Whether readonly role requires MFA | string | `"true"` | no |
 | provider\_name | Name of the SAML Provider | string | `""` | yes |
 | provider\_id | ID of the SAML Provider | string | `""` | yes |

--- a/modules/iam-assumable-roles-with-saml/main.tf
+++ b/modules/iam-assumable-roles-with-saml/main.tf
@@ -1,9 +1,3 @@
-locals {
-  admin_additional_policies     = "${length(var.admin_role_additional_policies_arn)}"
-  poweruser_additional_policies = "${length(var.poweruser_role_additional_policies_arn)}"
-  readonly_additional_policies  = "${length(var.readonly_role_additional_policies_arn)}"
-}
-
 data "aws_iam_policy_document" "assume_role_with_saml" {
   statement {
     effect = "Allow"
@@ -44,10 +38,10 @@ resource "aws_iam_role_policy_attachment" "admin" {
 }
 
 resource "aws_iam_role_policy_attachment" "admin_additional_policies" {
-  count = "${var.create_admin_role && local.admin_additional_policies > 0 ? 1 * local.admin_additional_policies  : 0}"
+  count = "${var.create_admin_role ? length(var.admin_role_additional_policies_arns) : 0}"
 
   role       = "${aws_iam_role.admin.name}"
-  policy_arn = "${element(var.admin_role_additional_policies_arn, count.index)}"
+  policy_arn = "${element(var.admin_role_additional_policies_arns, count.index)}"
 }
 
 # Poweruser
@@ -59,10 +53,10 @@ resource "aws_iam_role_policy_attachment" "poweruser" {
 }
 
 resource "aws_iam_role_policy_attachment" "poweruser_additional_policies" {
-  count = "${var.create_poweruser_role && local.poweruser_additional_policies > 0 ? 1 * local.poweruser_additional_policies  : 0}"
+  count = "${var.create_poweruser_role ? length(var.admin_role_additional_policies_arns) : 0}"
 
   role       = "${aws_iam_role.poweruser.name}"
-  policy_arn = "${element(var.poweruser_role_additional_policies_arn, count.index)}"
+  policy_arn = "${element(var.poweruser_role_additional_policies_arns, count.index)}"
 }
 
 resource "aws_iam_role" "poweruser" {
@@ -86,10 +80,10 @@ resource "aws_iam_role_policy_attachment" "readonly" {
 }
 
 resource "aws_iam_role_policy_attachment" "readonly_additional_policies" {
-  count = "${var.create_readonly_role && local.readonly_additional_policies > 0 ? 1 * local.readonly_additional_policies  : 0}"
+  count = "${var.create_readonly_role ? length(var.readonly_role_additional_policies_arns) : 0}"
 
   role       = "${aws_iam_role.readonly.name}"
-  policy_arn = "${element(var.readonly_role_additional_policies_arn, count.index)}"
+  policy_arn = "${element(var.readonly_role_additional_policies_arns, count.index)}"
 }
 
 resource "aws_iam_role" "readonly" {

--- a/modules/iam-assumable-roles-with-saml/main.tf
+++ b/modules/iam-assumable-roles-with-saml/main.tf
@@ -1,3 +1,9 @@
+locals {
+  admin_additional_policies     = "${length(var.admin_role_additional_policies_arn)}"
+  poweruser_additional_policies = "${length(var.poweruser_role_additional_policies_arn)}"
+  readonly_additional_policies  = "${length(var.readonly_role_additional_policies_arn)}"
+}
+
 data "aws_iam_policy_document" "assume_role_with_saml" {
   statement {
     effect = "Allow"
@@ -37,12 +43,26 @@ resource "aws_iam_role_policy_attachment" "admin" {
   policy_arn = "${var.admin_role_policy_arn}"
 }
 
+resource "aws_iam_role_policy_attachment" "admin_additional_policies" {
+  count = "${var.create_admin_role && local.admin_additional_policies > 0 ? 1 * local.admin_additional_policies  : 0}"
+
+  role       = "${aws_iam_role.admin.name}"
+  policy_arn = "${element(var.admin_role_additional_policies_arn, count.index)}"
+}
+
 # Poweruser
 resource "aws_iam_role_policy_attachment" "poweruser" {
   count = "${var.create_poweruser_role ? 1 : 0}"
 
   role       = "${aws_iam_role.poweruser.name}"
   policy_arn = "${var.poweruser_role_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "poweruser_additional_policies" {
+  count = "${var.create_poweruser_role && local.poweruser_additional_policies > 0 ? 1 * local.poweruser_additional_policies  : 0}"
+
+  role       = "${aws_iam_role.poweruser.name}"
+  policy_arn = "${element(var.poweruser_role_additional_policies_arn, count.index)}"
 }
 
 resource "aws_iam_role" "poweruser" {
@@ -63,6 +83,13 @@ resource "aws_iam_role_policy_attachment" "readonly" {
 
   role       = "${aws_iam_role.readonly.name}"
   policy_arn = "${var.readonly_role_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "readonly_additional_policies" {
+  count = "${var.create_readonly_role && local.readonly_additional_policies > 0 ? 1 * local.readonly_additional_policies  : 0}"
+
+  role       = "${aws_iam_role.readonly.name}"
+  policy_arn = "${element(var.readonly_role_additional_policies_arn, count.index)}"
 }
 
 resource "aws_iam_role" "readonly" {

--- a/modules/iam-assumable-roles-with-saml/variables.tf
+++ b/modules/iam-assumable-roles-with-saml/variables.tf
@@ -1,11 +1,9 @@
 variable "provider_name" {
   description = "Name of the SAML Provider"
-  type        = "string"
 }
 
 variable "provider_id" {
   description = "ID of the SAML Provider"
-  type        = "string"
 }
 
 variable "aws_saml_endpoint" {
@@ -35,8 +33,8 @@ variable "admin_role_policy_arn" {
   default     = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
-variable "admin_role_additional_policies_arn" {
-  description = "Additional Policies ARN to use for admin role"
+variable "admin_role_additional_policies_arns" {
+  description = "Additional Policies ARNs to use for admin role"
   default     = []
 }
 
@@ -66,8 +64,8 @@ variable "poweruser_role_policy_arn" {
   default     = "arn:aws:iam::aws:policy/PowerUserAccess"
 }
 
-variable "poweruser_role_additional_policies_arn" {
-  description = "Additional Policies ARN to use for poweruser role"
+variable "poweruser_role_additional_policies_arns" {
+  description = "Additional Policies ARNs to use for poweruser role"
   default     = []
 }
 
@@ -97,8 +95,8 @@ variable "readonly_role_policy_arn" {
   default     = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
-variable "readonly_role_additional_policies_arn" {
-  description = "Additional Policies ARN to use for poweruser role"
+variable "readonly_role_additional_policies_arns" {
+  description = "Additional Policies ARNs to use for poweruser role"
   default     = []
 }
 

--- a/modules/iam-assumable-roles-with-saml/variables.tf
+++ b/modules/iam-assumable-roles-with-saml/variables.tf
@@ -1,9 +1,11 @@
 variable "provider_name" {
   description = "Name of the SAML Provider"
+  type        = "string"
 }
 
 variable "provider_id" {
   description = "ID of the SAML Provider"
+  type        = "string"
 }
 
 variable "aws_saml_endpoint" {
@@ -33,6 +35,11 @@ variable "admin_role_policy_arn" {
   default     = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
+variable "admin_role_additional_policies_arn" {
+  description = "Additional Policies ARN to use for admin role"
+  default     = []
+}
+
 variable "admin_role_permissions_boundary_arn" {
   description = "Permissions boundary ARN to use for admin role"
   default     = ""
@@ -59,6 +66,11 @@ variable "poweruser_role_policy_arn" {
   default     = "arn:aws:iam::aws:policy/PowerUserAccess"
 }
 
+variable "poweruser_role_additional_policies_arn" {
+  description = "Additional Policies ARN to use for poweruser role"
+  default     = []
+}
+
 variable "poweruser_role_permissions_boundary_arn" {
   description = "Permissions boundary ARN to use for poweruser role"
   default     = ""
@@ -83,6 +95,11 @@ variable "readonly_role_path" {
 variable "readonly_role_policy_arn" {
   description = "Policy ARN to use for readonly role"
   default     = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+variable "readonly_role_additional_policies_arn" {
+  description = "Additional Policies ARN to use for poweruser role"
+  default     = []
 }
 
 variable "readonly_role_permissions_boundary_arn" {

--- a/modules/iam-assumable-roles/README.md
+++ b/modules/iam-assumable-roles/README.md
@@ -13,6 +13,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | admin\_role\_path | Path of admin IAM role | string | `"/"` | no |
 | admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | string | `""` | no |
 | admin\_role\_policy\_arn | Policy ARN to use for admin role | string | `"arn:aws:iam::aws:policy/AdministratorAccess"` | no |
+| admin\_role\_additional\_policies\_arn | Additional Policies ARN to use for admin role | list | `[]` | no |
 | admin\_role\_requires\_mfa | Whether admin role requires MFA | string | `"true"` | no |
 | create\_admin\_role | Whether to create admin role | string | `"false"` | no |
 | create\_poweruser\_role | Whether to create poweruser role | string | `"false"` | no |
@@ -23,11 +24,13 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | poweruser\_role\_path | Path of poweruser IAM role | string | `"/"` | no |
 | poweruser\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for poweruser role | string | `""` | no |
 | poweruser\_role\_policy\_arn | Policy ARN to use for poweruser role | string | `"arn:aws:iam::aws:policy/PowerUserAccess"` | no |
+| poweruser\_role\_additional\_policies\_arn | Additional Policies ARN to use for poweruser role | list | `[]` | no |
 | poweruser\_role\_requires\_mfa | Whether poweruser role requires MFA | string | `"true"` | no |
 | readonly\_role\_name | IAM role with readonly access | string | `"readonly"` | no |
 | readonly\_role\_path | Path of readonly IAM role | string | `"/"` | no |
 | readonly\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for readonly role | string | `""` | no |
 | readonly\_role\_policy\_arn | Policy ARN to use for readonly role | string | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
+| readonly\_role\_additional\_policies\_arn | Additional Policies ARN to use for readonly role | list | `[]` | no |
 | readonly\_role\_requires\_mfa | Whether readonly role requires MFA | string | `"true"` | no |
 | trusted\_role\_arns | ARNs of AWS entities who can assume these roles | list | `[]` | no |
 

--- a/modules/iam-assumable-roles/README.md
+++ b/modules/iam-assumable-roles/README.md
@@ -13,7 +13,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | admin\_role\_path | Path of admin IAM role | string | `"/"` | no |
 | admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | string | `""` | no |
 | admin\_role\_policy\_arn | Policy ARN to use for admin role | string | `"arn:aws:iam::aws:policy/AdministratorAccess"` | no |
-| admin\_role\_additional\_policies\_arn | Additional Policies ARN to use for admin role | list | `[]` | no |
+| admin\_role\_additional\_policies\_arns | Additional Policies ARNs to use for admin role | list | `[]` | no |
 | admin\_role\_requires\_mfa | Whether admin role requires MFA | string | `"true"` | no |
 | create\_admin\_role | Whether to create admin role | string | `"false"` | no |
 | create\_poweruser\_role | Whether to create poweruser role | string | `"false"` | no |
@@ -24,13 +24,13 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | poweruser\_role\_path | Path of poweruser IAM role | string | `"/"` | no |
 | poweruser\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for poweruser role | string | `""` | no |
 | poweruser\_role\_policy\_arn | Policy ARN to use for poweruser role | string | `"arn:aws:iam::aws:policy/PowerUserAccess"` | no |
-| poweruser\_role\_additional\_policies\_arn | Additional Policies ARN to use for poweruser role | list | `[]` | no |
+| poweruser\_role\_additional\_policies\_arns | Additional Policies ARNs to use for poweruser role | list | `[]` | no |
 | poweruser\_role\_requires\_mfa | Whether poweruser role requires MFA | string | `"true"` | no |
 | readonly\_role\_name | IAM role with readonly access | string | `"readonly"` | no |
 | readonly\_role\_path | Path of readonly IAM role | string | `"/"` | no |
-| readonly\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for readonly role | string | `""` | no |
+| readonly\_role\_permissions\_boundary\_arns | Permissions boundary ARN to use for readonly role | string | `""` | no |
 | readonly\_role\_policy\_arn | Policy ARN to use for readonly role | string | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
-| readonly\_role\_additional\_policies\_arn | Additional Policies ARN to use for readonly role | list | `[]` | no |
+| readonly\_role\_additional\_policies\_arn | Additional Policies ARNs to use for readonly role | list | `[]` | no |
 | readonly\_role\_requires\_mfa | Whether readonly role requires MFA | string | `"true"` | no |
 | trusted\_role\_arns | ARNs of AWS entities who can assume these roles | list | `[]` | no |
 

--- a/modules/iam-assumable-roles/main.tf
+++ b/modules/iam-assumable-roles/main.tf
@@ -1,3 +1,9 @@
+locals {
+  admin_additional_policies     = "${length(var.admin_role_additional_policies_arn)}"
+  poweruser_additional_policies = "${length(var.poweruser_role_additional_policies_arn)}"
+  readonly_additional_policies  = "${length(var.readonly_role_additional_policies_arn)}"
+}
+
 data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"
@@ -56,12 +62,26 @@ resource "aws_iam_role_policy_attachment" "admin" {
   policy_arn = "${var.admin_role_policy_arn}"
 }
 
+resource "aws_iam_role_policy_attachment" "admin_additional_policies" {
+  count = "${var.create_admin_role && local.admin_additional_policies > 0 ? 1 * local.admin_additional_policies  : 0}"
+
+  role       = "${aws_iam_role.admin.name}"
+  policy_arn = "${element(var.admin_role_additional_policies_arn, count.index)}"
+}
+
 # Poweruser
 resource "aws_iam_role_policy_attachment" "poweruser" {
   count = "${var.create_poweruser_role ? 1 : 0}"
 
   role       = "${aws_iam_role.poweruser.name}"
   policy_arn = "${var.poweruser_role_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "poweruser_additional_policies" {
+  count = "${var.create_poweruser_role && local.poweruser_additional_policies > 0 ? 1 * local.poweruser_additional_policies  : 0}"
+
+  role       = "${aws_iam_role.poweruser.name}"
+  policy_arn = "${element(var.poweruser_role_additional_policies_arn, count.index)}"
 }
 
 resource "aws_iam_role" "poweruser" {
@@ -82,6 +102,13 @@ resource "aws_iam_role_policy_attachment" "readonly" {
 
   role       = "${aws_iam_role.readonly.name}"
   policy_arn = "${var.readonly_role_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "readonly_additional_policies" {
+  count = "${var.create_readonly_role && local.readonly_additional_policies > 0 ? 1 * local.readonly_additional_policies  : 0}"
+
+  role       = "${aws_iam_role.readonly.name}"
+  policy_arn = "${element(var.readonly_role_additional_policies_arn, count.index)}"
 }
 
 resource "aws_iam_role" "readonly" {

--- a/modules/iam-assumable-roles/main.tf
+++ b/modules/iam-assumable-roles/main.tf
@@ -1,9 +1,3 @@
-locals {
-  admin_additional_policies     = "${length(var.admin_role_additional_policies_arn)}"
-  poweruser_additional_policies = "${length(var.poweruser_role_additional_policies_arn)}"
-  readonly_additional_policies  = "${length(var.readonly_role_additional_policies_arn)}"
-}
-
 data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"
@@ -63,10 +57,10 @@ resource "aws_iam_role_policy_attachment" "admin" {
 }
 
 resource "aws_iam_role_policy_attachment" "admin_additional_policies" {
-  count = "${var.create_admin_role && local.admin_additional_policies > 0 ? 1 * local.admin_additional_policies  : 0}"
+  count = "${var.create_admin_role  ? length(var.admin_role_additional_policies_arns)  : 0}"
 
   role       = "${aws_iam_role.admin.name}"
-  policy_arn = "${element(var.admin_role_additional_policies_arn, count.index)}"
+  policy_arn = "${element(var.admin_role_additional_policies_arns, count.index)}"
 }
 
 # Poweruser
@@ -78,10 +72,10 @@ resource "aws_iam_role_policy_attachment" "poweruser" {
 }
 
 resource "aws_iam_role_policy_attachment" "poweruser_additional_policies" {
-  count = "${var.create_poweruser_role && local.poweruser_additional_policies > 0 ? 1 * local.poweruser_additional_policies  : 0}"
+  count = "${var.create_poweruser_role ? length(var.poweruser_role_additional_policies_arns)  : 0}"
 
   role       = "${aws_iam_role.poweruser.name}"
-  policy_arn = "${element(var.poweruser_role_additional_policies_arn, count.index)}"
+  policy_arn = "${element(var.poweruser_role_additional_policies_arns, count.index)}"
 }
 
 resource "aws_iam_role" "poweruser" {
@@ -105,10 +99,10 @@ resource "aws_iam_role_policy_attachment" "readonly" {
 }
 
 resource "aws_iam_role_policy_attachment" "readonly_additional_policies" {
-  count = "${var.create_readonly_role && local.readonly_additional_policies > 0 ? 1 * local.readonly_additional_policies  : 0}"
+  count = "${var.create_readonly_role ? length(var.readonly_role_additional_policies_arns)  : 0}"
 
   role       = "${aws_iam_role.readonly.name}"
-  policy_arn = "${element(var.readonly_role_additional_policies_arn, count.index)}"
+  policy_arn = "${element(var.readonly_role_additional_policies_arns, count.index)}"
 }
 
 resource "aws_iam_role" "readonly" {

--- a/modules/iam-assumable-roles/variables.tf
+++ b/modules/iam-assumable-roles/variables.tf
@@ -34,8 +34,8 @@ variable "admin_role_policy_arn" {
   default     = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
-variable "admin_role_additional_policies_arn" {
-  description = "Additional Policies ARN to use for admin role"
+variable "admin_role_additional_policies_arns" {
+  description = "Additional Policies ARNs to use for admin role"
   default     = []
 }
 
@@ -70,8 +70,8 @@ variable "poweruser_role_policy_arn" {
   default     = "arn:aws:iam::aws:policy/PowerUserAccess"
 }
 
-variable "poweruser_role_additional_policies_arn" {
-  description = "Additional Policies ARN to use for poweruser role"
+variable "poweruser_role_additional_policies_arns" {
+  description = "Additional Policies ARNs to use for poweruser role"
   default     = []
 }
 
@@ -106,8 +106,8 @@ variable "readonly_role_policy_arn" {
   default     = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
-variable "readonly_role_additional_policies_arn" {
-  description = "Additional Policies ARN to use for poweruser role"
+variable "readonly_role_additional_policies_arns" {
+  description = "Additional Policies ARNs to use for poweruser role"
   default     = []
 }
 

--- a/modules/iam-assumable-roles/variables.tf
+++ b/modules/iam-assumable-roles/variables.tf
@@ -34,6 +34,11 @@ variable "admin_role_policy_arn" {
   default     = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
+variable "admin_role_additional_policies_arn" {
+  description = "Additional Policies ARN to use for admin role"
+  default     = []
+}
+
 variable "admin_role_permissions_boundary_arn" {
   description = "Permissions boundary ARN to use for admin role"
   default     = ""
@@ -65,6 +70,11 @@ variable "poweruser_role_policy_arn" {
   default     = "arn:aws:iam::aws:policy/PowerUserAccess"
 }
 
+variable "poweruser_role_additional_policies_arn" {
+  description = "Additional Policies ARN to use for poweruser role"
+  default     = []
+}
+
 variable "poweruser_role_permissions_boundary_arn" {
   description = "Permissions boundary ARN to use for poweruser role"
   default     = ""
@@ -94,6 +104,11 @@ variable "readonly_role_requires_mfa" {
 variable "readonly_role_policy_arn" {
   description = "Policy ARN to use for readonly role"
   default     = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+variable "readonly_role_additional_policies_arn" {
+  description = "Additional Policies ARN to use for poweruser role"
+  default     = []
 }
 
 variable "readonly_role_permissions_boundary_arn" {


### PR DESCRIPTION
I'd like to propose a new feature that allows attaching multiple policies to a role. 
We can now define roles that use multiple policies, it's useful when a user uses AWS defined policies. 