### PR TITLE
Variable duplication

### DIFF
--- a/modules/iam-user/variables.tf
+++ b/modules/iam-user/variables.tf
@@ -69,12 +69,6 @@ variable "ssh_public_key" {
   default     = ""
 }
 
-variable "tags" {
-  description = "A map of tags to add to all resources."
-  type        = "map"
-  default     = {}
-}
-
 variable "permissions_boundary" {
   description = "The ARN of the policy that is used to set the permissions boundary for the user."
   type        = string


### PR DESCRIPTION
The variable tags is duplicated and Terragrunt is failing

# Description

```
Error: Duplicate variable declaration

  on .terraform/modules/iam_user/terraform-aws-modules-terraform-aws-iam-c736c90/modules/iam-user/variables.tf line 84:
  84: variable "tags" {
```
