### PR TITLE
Add Trusted Services to iam-assumable-role

### DIFF
--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -25,6 +25,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | role\_requires\_mfa | Whether role requires MFA | string | `"true"` | no |
 | tags | A map of tags to add to all resources. | map | `{}` | no |
 | trusted\_role\_arns | ARNs of AWS entities who can assume these roles | list | `[]` | no |
+| trusted\_role\_services | AWS Services that can assume these roles | list | `[]` | no |
 
 ## Outputs
 

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -8,6 +8,11 @@ data "aws_iam_policy_document" "assume_role" {
       type        = "AWS"
       identifiers = var.trusted_role_arns
     }
+
+    principals {
+      type        = "Service"
+      identifiers = var.trusted_role_services
+    }
   }
 }
 

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -4,6 +4,12 @@ variable "trusted_role_arns" {
   default     = []
 }
 
+variable "trusted_role_services" {
+  description = "AWS Services that can assume these roles"
+  type        = list(string)
+  default     = []
+}
+
 variable "mfa_age" {
   description = "Max age of valid MFA (in seconds) for roles which require MFA"
   type        = number


### PR DESCRIPTION
Adds a new feature that allows for the addition of AWS Service Principals. Specifics on AWS Role Principals can be found here: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html