### PR TITLE
Added description for roles when using iam-group-with-policies

### DIFF
--- a/modules/iam-group-with-policies/main.tf
+++ b/modules/iam-group-with-policies/main.tf
@@ -53,7 +53,8 @@ resource "aws_iam_policy" "iam_self_management" {
 resource "aws_iam_policy" "custom" {
   count = length(var.custom_group_policies) > 0 ? length(var.custom_group_policies) : 0
 
-  name   = var.custom_group_policies[count.index]["name"]
-  policy = var.custom_group_policies[count.index]["policy"]
+  name        = var.custom_group_policies[count.index]["name"]
+  policy      = var.custom_group_policies[count.index]["policy"]
+  description = lookup(var.custom_group_policies[count.index], "description", null)
 }
 


### PR DESCRIPTION
# Description

I got into a limitation regarding set descriptions for roles used inside `iam-group-with-policies` module. 

I added the possibility of set descriptions for roles using a terraform `lookup` function, which doesn't affect the behaviour because it sets to `null` description (basically not set) in case user doesn't specify description field inside the lits(maps)