### PR TITLE
[iam-assumable-roles] Add custom trust policy per role

### DIFF
--- a/examples/iam-assumable-roles/main.tf
+++ b/examples/iam-assumable-roles/main.tf
@@ -2,9 +2,9 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-######################
-# IAM assumable roles
-######################
+#########################################################
+# IAM assumable roles with same trusted ARNs and Services
+#########################################################
 module "iam_assumable_roles" {
   source = "../../modules/iam-assumable-roles"
 
@@ -14,15 +14,52 @@ module "iam_assumable_roles" {
   ]
 
   trusted_role_services = [
-    "codedeploy.amazonaws.com"
+    "codedeploy.amazonaws.com",
   ]
 
   create_admin_role = true
 
   create_poweruser_role      = true
   poweruser_role_name        = "Billing-And-Support-Access"
-  poweruser_role_policy_arns = ["arn:aws:iam::aws:policy/job-function/Billing", "arn:aws:iam::aws:policy/AWSSupportAccess"]
+  poweruser_role_policy_arns = [
+    "arn:aws:iam::aws:policy/job-function/Billing",
+    "arn:aws:iam::aws:policy/AWSSupportAccess",
+  ]
 
   create_readonly_role       = true
   readonly_role_requires_mfa = false
+}
+
+##############################################################
+# IAM assumable roles with different trusted ARNs and Services
+##############################################################
+module "iam_assumable_roles_custom_trust" {
+  source = "../../modules/iam-assumable-roles"
+
+  trusted_role_arns = [
+    "arn:aws:iam::307990089504:root",
+    "arn:aws:iam::835367859851:user/anton",
+  ]
+
+  trusted_role_services = ["codedeploy.amazonaws.com"]
+
+  # Admin specifc trust for both ARNs and Services
+  create_admin_role           = true
+  use_custom_admin_role_trust = true
+  admin_role_name             = "admin-custom"
+  admin_trusted_role_arns     = ["arn:aws:iam::307990089504:root"]
+  admin_trusted_role_services = ["ec2fleet.amazonaws.com"]
+
+  # Poweruser specifc trust for ARNs only
+  create_poweruser_role           = true
+  use_custom_poweruser_role_trust = true
+  poweruser_role_name             = "developer"
+  poweruser_trusted_role_arns     = ["arn:aws:iam::835367859851:user/anton"]
+  poweruser_trusted_role_services = []
+
+  # Readonly inherits trust from default ARNs and Services
+  create_readonly_role           = true
+  use_custom_readonly_role_trust = false
+  readonly_role_name             = "readonly-custom"
+  readonly_role_requires_mfa     = false
 }

--- a/examples/iam-assumable-roles/outputs.tf
+++ b/examples/iam-assumable-roles/outputs.tf
@@ -19,6 +19,47 @@ output "admin_iam_role_path" {
   value       = module.iam_assumable_roles.admin_iam_role_path
 }
 
+output "admin_iam_role_trusted_arns" {
+  description = "The ARNs trusted to assume the admin role"
+  value       = module.iam_assumable_roles.admin_iam_role_trusted_arns
+}
+
+output "admin_iam_role_trusted_services" {
+  description = "The Services trusted to assume the admin role"
+  value       = module.iam_assumable_roles.admin_iam_role_trusted_services
+}
+
+# Admin Custom
+output "admin_custom_iam_role_arn" {
+  description = "ARN of admin IAM role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.admin_iam_role_arn
+}
+
+output "admin_custom_iam_role_name" {
+  description = "Name of admin IAM role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.admin_iam_role_name
+}
+
+output "admin_custom_iam_role_requires_mfa" {
+  description = "Whether admin IAM role requires MFA with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.admin_iam_role_requires_mfa
+}
+
+output "admin_custom_iam_role_path" {
+  description = "Path of admin IAM role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.admin_iam_role_path
+}
+
+output "admin_custom_iam_role_trusted_arns" {
+  description = "The ARNs trusted to assume the admin role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.admin_iam_role_trusted_arns
+}
+
+output "admin_custom_iam_role_trusted_services" {
+  description = "The Services trusted to assume the admin role with custom trust"
+  value       = module.iam_assumable_roles.admin_iam_role_trusted_services
+}
+
 # Poweruser
 output "poweruser_iam_role_arn" {
   description = "ARN of poweruser IAM role"
@@ -40,6 +81,47 @@ output "poweruser_iam_role_path" {
   value       = module.iam_assumable_roles.poweruser_iam_role_path
 }
 
+output "poweruser_iam_role_trusted_arns" {
+  description = "The ARNs trusted to assume the poweruser role"
+  value       = module.iam_assumable_roles.poweruser_iam_role_trusted_arns
+}
+
+output "poweruser_iam_role_trusted_services" {
+  description = "The Services trusted to assume the poweruser role"
+  value       = module.iam_assumable_roles.poweruser_iam_role_trusted_services
+}
+
+# Poweruser Custom
+output "poweruser_custom_iam_role_arn" {
+  description = "ARN of poweruser IAM role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.poweruser_iam_role_arn
+}
+
+output "poweruser_custom_iam_role_name" {
+  description = "Name of poweruser IAM role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.poweruser_iam_role_name
+}
+
+output "poweruser_custom_iam_role_requires_mfa" {
+  description = "Whether poweruser IAM role requires MFA with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.poweruser_iam_role_requires_mfa
+}
+
+output "poweruser_custom_iam_role_path" {
+  description = "Path of poweruser IAM role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.poweruser_iam_role_path
+}
+
+output "poweruser_custom_iam_role_trusted_arns" {
+  description = "The ARNs trusted to assume the poweruser role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.poweruser_iam_role_trusted_arns
+}
+
+output "poweruser_custom_iam_role_trusted_services" {
+  description = "The Services trusted to assume the poweruser role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.poweruser_iam_role_trusted_services
+}
+
 # Readonly
 output "readonly_iam_role_arn" {
   description = "ARN of readonly IAM role"
@@ -59,4 +141,45 @@ output "readonly_iam_role_path" {
 output "readonly_iam_role_requires_mfa" {
   description = "Whether readonly IAM role requires MFA"
   value       = module.iam_assumable_roles.readonly_iam_role_requires_mfa
+}
+
+output "readonly_iam_role_trusted_arns" {
+  description = "The ARNs trusted to assume the readonly role"
+  value       = module.iam_assumable_roles.readonly_iam_role_trusted_arns
+}
+
+output "readonly_iam_role_trusted_services" {
+  description = "The Services trusted to assume the readonly role"
+  value       = module.iam_assumable_roles.readonly_iam_role_trusted_services
+}
+
+# Readonly Custom
+output "readonly_custom_iam_role_arn" {
+  description = "ARN of readonly IAM role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.readonly_iam_role_arn
+}
+
+output "readonly_custom_iam_role_name" {
+  description = "Name of readonly IAM role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.readonly_iam_role_name
+}
+
+output "readonly_custom_iam_role_path" {
+  description = "Path of readonly IAM role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.readonly_iam_role_path
+}
+
+output "readonly_custom_iam_role_requires_mfa" {
+  description = "Whether readonly IAM role requires MFA with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.readonly_iam_role_requires_mfa
+}
+
+output "readonly_custom_iam_role_trusted_arns" {
+  description = "The ARNs trusted to assume the readonly role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.readonly_iam_role_trusted_arns
+}
+
+output "readonly_custom_iam_role_trusted_services" {
+  description = "The Services trusted to assume the readonly role with custom trust"
+  value       = module.iam_assumable_roles_custom_trust.readonly_iam_role_trusted_services
 }

--- a/examples/iam-assumable-roles/outputs.tf
+++ b/examples/iam-assumable-roles/outputs.tf
@@ -183,3 +183,12 @@ output "readonly_custom_iam_role_trusted_services" {
   description = "The Services trusted to assume the readonly role with custom trust"
   value       = module.iam_assumable_roles_custom_trust.readonly_iam_role_trusted_services
 }
+
+# All roles
+output "role_arns" {
+  value = module.iam_assumable_roles.role_arns
+}
+
+output "custom_role_arns" {
+  value = module.iam_assumable_roles_custom_trust.role_arns
+}

--- a/modules/iam-assumable-roles/main.tf
+++ b/modules/iam-assumable-roles/main.tf
@@ -4,15 +4,15 @@ locals {
   default_assume_role_with_mfa_json = data.aws_iam_policy_document.default_assume_role_with_mfa.json
 
   # admin specific policy and default fallback
-  admin_custom_assume_role_json  = var.admin_role_requires_mfa ? data.aws_iam_policy_document.admin_assume_role_with_mfa[0].json : data.aws_iam_policy_document.admin_assume_role[0].json
+  admin_custom_assume_role_json  = var.admin_role_requires_mfa ? join("", data.aws_iam_policy_document.admin_assume_role_with_mfa.*.json) : join("", data.aws_iam_policy_document.admin_assume_role.*.json)
   admin_default_assume_role_json = var.admin_role_requires_mfa ? local.default_assume_role_with_mfa_json : local.default_assume_role_json
 
   # poweruser specific policy and default fallback
-  poweruser_custom_assume_role_json  = var.poweruser_role_requires_mfa ? data.aws_iam_policy_document.poweruser_assume_role_with_mfa[0].json : data.aws_iam_policy_document.poweruser_assume_role[0].json
+  poweruser_custom_assume_role_json  = var.poweruser_role_requires_mfa ? join("", data.aws_iam_policy_document.poweruser_assume_role_with_mfa.*.json) : join("", data.aws_iam_policy_document.poweruser_assume_role.*.json)
   poweruser_default_assume_role_json = var.poweruser_role_requires_mfa ? local.default_assume_role_with_mfa_json : local.default_assume_role_json
 
   # readonly specific policy and default fallback
-  readonly_custom_assume_role_json  = var.readonly_role_requires_mfa ? data.aws_iam_policy_document.readonly_assume_role_with_mfa[0].json : data.aws_iam_policy_document.readonly_assume_role[0].json
+  readonly_custom_assume_role_json  = var.readonly_role_requires_mfa ? join("", data.aws_iam_policy_document.readonly_assume_role_with_mfa.*.json) : join("", data.aws_iam_policy_document.readonly_assume_role.*.json)
   readonly_default_assume_role_json = var.readonly_role_requires_mfa ? local.default_assume_role_with_mfa_json : local.default_assume_role_json
 }
 

--- a/modules/iam-assumable-roles/main.tf
+++ b/modules/iam-assumable-roles/main.tf
@@ -35,7 +35,7 @@ resource "aws_iam_role_policy_attachment" "admin" {
   count = var.create_admin_role ? length(var.admin_role_policy_arns) : 0
 
   role       = aws_iam_role.admin[0].name
-  policy_arn = element(var.admin_role_policy_arns, count.index)
+  policy_arn = var.admin_role_policy_arns[count.index]
 }
 
 # Poweruser
@@ -57,7 +57,7 @@ resource "aws_iam_role_policy_attachment" "poweruser" {
   count = var.create_poweruser_role ? length(var.poweruser_role_policy_arns) : 0
 
   role       = aws_iam_role.poweruser[0].name
-  policy_arn = element(var.poweruser_role_policy_arns, count.index)
+  policy_arn = var.poweruser_role_policy_arns[count.index]
 }
 
 # Readonly
@@ -79,6 +79,6 @@ resource "aws_iam_role_policy_attachment" "readonly" {
   count = var.create_readonly_role ? length(var.readonly_role_policy_arns) : 0
 
   role       = aws_iam_role.readonly[0].name
-  policy_arn = element(var.readonly_role_policy_arns, count.index)
+  policy_arn = var.readonly_role_policy_arns[count.index]
 }
 

--- a/modules/iam-assumable-roles/outputs.tf
+++ b/modules/iam-assumable-roles/outputs.tf
@@ -19,6 +19,16 @@ output "admin_iam_role_requires_mfa" {
   value       = var.admin_role_requires_mfa
 }
 
+output "admin_iam_role_trusted_arns" {
+  description = "The ARNs trusted to assume the admin role"
+  value       = length(var.admin_trusted_role_arns) > 0 ? var.admin_trusted_role_arns : var.trusted_role_arns
+}
+
+output "admin_iam_role_trusted_services" {
+  description = "The Services trusted to assume the admin role"
+  value       = var.use_custom_admin_role_trust ? var.admin_trusted_role_services : var.trusted_role_services
+}
+
 # Poweruser
 output "poweruser_iam_role_arn" {
   description = "ARN of poweruser IAM role"
@@ -38,6 +48,16 @@ output "poweruser_iam_role_path" {
 output "poweruser_iam_role_requires_mfa" {
   description = "Whether poweruser IAM role requires MFA"
   value       = var.poweruser_role_requires_mfa
+}
+
+output "poweruser_iam_role_trusted_arns" {
+  description = "The ARNs trusted to assume the poweruser role"
+  value       = length(var.poweruser_trusted_role_arns) > 0 ? var.poweruser_trusted_role_arns : var.trusted_role_arns
+}
+
+output "poweruser_iam_role_trusted_services" {
+  description = "The Services trusted to assume the poweruser role"
+  value       = var.use_custom_poweruser_role_trust ? var.poweruser_trusted_role_services : var.trusted_role_services
 }
 
 # Readonly
@@ -61,3 +81,12 @@ output "readonly_iam_role_requires_mfa" {
   value       = var.readonly_role_requires_mfa
 }
 
+output "readonly_iam_role_trusted_arns" {
+  description = "The ARNs trusted to assume the readonly role"
+  value       = var.use_custom_readonly_role_trust ? var.readonly_trusted_role_arns : var.trusted_role_arns
+}
+
+output "readonly_iam_role_trusted_services" {
+  description = "The Services trusted to assume the readonly role"
+  value       = var.use_custom_readonly_role_trust ? var.readonly_trusted_role_services : var.trusted_role_services
+}

--- a/modules/iam-assumable-roles/outputs.tf
+++ b/modules/iam-assumable-roles/outputs.tf
@@ -90,3 +90,12 @@ output "readonly_iam_role_trusted_services" {
   description = "The Services trusted to assume the readonly role"
   value       = var.use_custom_readonly_role_trust ? var.readonly_trusted_role_services : var.trusted_role_services
 }
+
+# All roles
+output "role_arns" {
+  value = {
+    admin     = element(concat(aws_iam_role.admin.*.arn, [""]), 0)
+    poweruser = element(concat(aws_iam_role.poweruser.*.arn, [""]), 0)
+    readonly  = element(concat(aws_iam_role.readonly.*.arn, [""]), 0)
+  }
+}

--- a/modules/iam-assumable-roles/outputs.tf
+++ b/modules/iam-assumable-roles/outputs.tf
@@ -1,17 +1,17 @@
 #Admin
 output "admin_iam_role_arn" {
   description = "ARN of admin IAM role"
-  value       = element(concat(aws_iam_role.admin.*.arn, [""]), 0)
+  value       = join("", aws_iam_role.admin.*.arn)
 }
 
 output "admin_iam_role_name" {
   description = "Name of admin IAM role"
-  value       = element(concat(aws_iam_role.admin.*.name, [""]), 0)
+  value       = join("", aws_iam_role.admin.*.name)
 }
 
 output "admin_iam_role_path" {
   description = "Path of admin IAM role"
-  value       = element(concat(aws_iam_role.admin.*.path, [""]), 0)
+  value       = join("", aws_iam_role.admin.*.path)
 }
 
 output "admin_iam_role_requires_mfa" {
@@ -32,17 +32,17 @@ output "admin_iam_role_trusted_services" {
 # Poweruser
 output "poweruser_iam_role_arn" {
   description = "ARN of poweruser IAM role"
-  value       = element(concat(aws_iam_role.poweruser.*.arn, [""]), 0)
+  value       = join("", aws_iam_role.poweruser.*.arn)
 }
 
 output "poweruser_iam_role_name" {
   description = "Name of poweruser IAM role"
-  value       = element(concat(aws_iam_role.poweruser.*.name, [""]), 0)
+  value       = join("", aws_iam_role.poweruser.*.name)
 }
 
 output "poweruser_iam_role_path" {
   description = "Path of poweruser IAM role"
-  value       = element(concat(aws_iam_role.poweruser.*.path, [""]), 0)
+  value       = join("", aws_iam_role.poweruser.*.path)
 }
 
 output "poweruser_iam_role_requires_mfa" {
@@ -63,17 +63,17 @@ output "poweruser_iam_role_trusted_services" {
 # Readonly
 output "readonly_iam_role_arn" {
   description = "ARN of readonly IAM role"
-  value       = element(concat(aws_iam_role.readonly.*.arn, [""]), 0)
+  value       = join("", aws_iam_role.readonly.*.arn)
 }
 
 output "readonly_iam_role_name" {
   description = "Name of readonly IAM role"
-  value       = element(concat(aws_iam_role.readonly.*.name, [""]), 0)
+  value       = join("", aws_iam_role.readonly.*.name)
 }
 
 output "readonly_iam_role_path" {
   description = "Path of readonly IAM role"
-  value       = element(concat(aws_iam_role.readonly.*.path, [""]), 0)
+  value       = join("", aws_iam_role.readonly.*.path)
 }
 
 output "readonly_iam_role_requires_mfa" {
@@ -94,8 +94,8 @@ output "readonly_iam_role_trusted_services" {
 # All roles
 output "role_arns" {
   value = {
-    admin     = element(concat(aws_iam_role.admin.*.arn, [""]), 0)
-    poweruser = element(concat(aws_iam_role.poweruser.*.arn, [""]), 0)
-    readonly  = element(concat(aws_iam_role.readonly.*.arn, [""]), 0)
+    admin     = join("", aws_iam_role.admin.*.arn)
+    poweruser = join("", aws_iam_role.poweruser.*.arn)
+    readonly  = join("", aws_iam_role.readonly.*.arn)
   }
 }

--- a/modules/iam-assumable-roles/policy-documents.tf
+++ b/modules/iam-assumable-roles/policy-documents.tf
@@ -1,0 +1,207 @@
+# Default policy for all roles
+data "aws_iam_policy_document" "default_assume_role" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.trusted_role_arns
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = var.trusted_role_services
+    }
+  }
+}
+
+data "aws_iam_policy_document" "default_assume_role_with_mfa" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.trusted_role_arns
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = var.trusted_role_services
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+
+    condition {
+      test     = "NumericLessThan"
+      variable = "aws:MultiFactorAuthAge"
+      values   = [var.mfa_age]
+    }
+  }
+}
+
+# Policy for admin role
+data "aws_iam_policy_document" "admin_assume_role" {
+  count = var.use_custom_admin_role_trust ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.admin_trusted_role_arns
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = var.admin_trusted_role_services
+    }
+  }
+}
+
+data "aws_iam_policy_document" "admin_assume_role_with_mfa" {
+  count = var.use_custom_admin_role_trust ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.admin_trusted_role_arns
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = var.admin_trusted_role_services
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+
+    condition {
+      test     = "NumericLessThan"
+      variable = "aws:MultiFactorAuthAge"
+      values   = [var.mfa_age]
+    }
+  }
+}
+
+# Policy for poweruser role
+data "aws_iam_policy_document" "poweruser_assume_role" {
+  count = var.use_custom_poweruser_role_trust ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.poweruser_trusted_role_arns
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = var.poweruser_trusted_role_services
+    }
+  }
+}
+
+data "aws_iam_policy_document" "poweruser_assume_role_with_mfa" {
+  count = var.use_custom_poweruser_role_trust ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.poweruser_trusted_role_arns
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = var.poweruser_trusted_role_services
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+
+    condition {
+      test     = "NumericLessThan"
+      variable = "aws:MultiFactorAuthAge"
+      values   = [var.mfa_age]
+    }
+  }
+}
+
+# Policy for readonly role
+data "aws_iam_policy_document" "readonly_assume_role" {
+  count = var.use_custom_readonly_role_trust ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.readonly_trusted_role_arns
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = var.readonly_trusted_role_services
+    }
+  }
+}
+
+data "aws_iam_policy_document" "readonly_assume_role_with_mfa" {
+  count = var.use_custom_readonly_role_trust ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.readonly_trusted_role_arns
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = var.readonly_trusted_role_services
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+
+    condition {
+      test     = "NumericLessThan"
+      variable = "aws:MultiFactorAuthAge"
+      values   = [var.mfa_age]
+    }
+  }
+}

--- a/modules/iam-assumable-roles/variables.tf
+++ b/modules/iam-assumable-roles/variables.tf
@@ -10,6 +10,60 @@ variable "trusted_role_services" {
   default     = []
 }
 
+variable "use_custom_admin_role_trust" {
+  description = "Whether to create a trust policy for the admin role with custom trusted ARNs and services"
+  type        = bool
+  default     = false
+}
+
+variable "admin_trusted_role_arns" {
+  description = "ARNs of AWS entities who can assume the admin role"
+  type        = list(string)
+  default     = []
+}
+
+variable "admin_trusted_role_services" {
+  description = "AWS Services that can assume the admin roles"
+  type        = list(string)
+  default     = []
+}
+
+variable "use_custom_poweruser_role_trust" {
+  description = "Whether to create a trust policy for the poweruser role with custom trusted ARNs and services"
+  type        = bool
+  default     = false
+}
+
+variable "poweruser_trusted_role_arns" {
+  description = "ARNs of AWS entities who can assume the poweruser role"
+  type        = list(string)
+  default     = []
+}
+
+variable "poweruser_trusted_role_services" {
+  description = "AWS Services that can assume the admin roles"
+  type        = list(string)
+  default     = []
+}
+
+variable "use_custom_readonly_role_trust" {
+  description = "Whether to create a trust policy for the readonly role with custom trusted ARNs and services"
+  type        = bool
+  default     = false
+}
+
+variable "readonly_trusted_role_arns" {
+  description = "ARNs of AWS entities who can readonly the admin role"
+  type        = list(string)
+  default     = []
+}
+
+variable "readonly_trusted_role_services" {
+  description = "AWS Services that can assume the admin roles"
+  type        = list(string)
+  default     = []
+}
+
 variable "mfa_age" {
   description = "Max age of valid MFA (in seconds) for roles which require MFA"
   type        = number


### PR DESCRIPTION
# Description

This PR adds the possibility of defining custom trust policies per role (ie, who can assume a role) to the iam-assumable-roles module.

The customisation of the policies can be controller on a per-role basis via 3 new boolean variables: `use_custom_admin_role_trust`, `use_custom_poweuser_role_trust` and `use_custom_readonly_role_trust`. Those variables default to `false` in order to not change the default behaviour of the module. 

The PR also extends the example for iam-assumable-roles:
```hcl
module "iam_assumable_roles_custom_trust" {
  source = "../../modules/iam-assumable-roles"

  trusted_role_arns = [
    "arn:aws:iam::307990089504:root",
    "arn:aws:iam::835367859851:user/anton",
  ]

  trusted_role_services = ["codedeploy.amazonaws.com"]

  # Admin specifc trust for both ARNs and Services
  create_admin_role           = true
  use_custom_admin_role_trust = true
  admin_role_name             = "admin-custom"
  admin_trusted_role_arns     = ["arn:aws:iam::307990089504:root"]
  admin_trusted_role_services = ["ec2fleet.amazonaws.com"]

  # Poweruser specifc trust for ARNs only
  create_poweruser_role           = true
  use_custom_poweruser_role_trust = true
  poweruser_role_name             = "developer"
  poweruser_trusted_role_arns     = ["arn:aws:iam::835367859851:user/anton"]
  poweruser_trusted_role_services = []

  # Readonly inherits trust from default ARNs and Services
  create_readonly_role           = true
  use_custom_readonly_role_trust = false
  readonly_role_name             = "readonly-custom"
  readonly_role_requires_mfa     = false
}
```