### PR TITLE
New sub-module for IAM assumable role with OIDC

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.19.0
+  rev: v1.24.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v2.4.0
   hooks:
     - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -61,6 +61,28 @@ module "iam_assumable_role" {
 }
 ```
 
+`iam-assumable-role-with-oidc`:
+```hcl
+module "iam_assumable_role" {
+  source = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "~> 2.0"
+
+  create_role = true
+
+  role_name = "role-with-oidc"
+
+  tags = {
+    Role = "role-with-oidc"
+  }
+
+  provider_url = "oidc.eks.eu-west-1.amazonaws.com/id/BA9E170D464AF7B92084EF72A69B9DC8"
+
+  role_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+  ]
+}
+```
+
 `iam-assumable-roles`:
 ```hcl
 module "iam_assumable_roles" {
@@ -231,6 +253,7 @@ Use [iam-policy module](https://github.com/terraform-aws-modules/terraform-aws-i
 
 * [iam-account](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-account) - Set AWS account alias and password policy
 * [iam-assumable-role](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-assumable-role) - Create individual IAM role which can be assumed from specified ARNs (AWS accounts, IAM users, etc)
+* [iam-assumable-role-with-oidc](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-assumable-role-with-oidc) - Create individual IAM role which can be assumed from specified subjects federated with a OIDC Identity Provider
 * [iam-assumable-roles](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-assumable-roles) - Create several IAM roles which can be assumed from specified ARNs (AWS accounts, IAM users, etc)
 * [iam-assumable-roles-with-saml](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-assumable-roles-with-saml) - Create several IAM roles which can be assumed by users with a SAML Identity Provider
 * [iam-group-with-assumable-roles-policy](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-group-with-assumable-roles-policy) - IAM group with users who are allowed to assume IAM roles in the same or in separate AWS account

--- a/examples/iam-account/README.md
+++ b/examples/iam-account/README.md
@@ -15,11 +15,19 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | this\_caller\_identity\_account\_id | The ID of the AWS account |
-| this\_iam\_account\_password\_policy\_expire\_passwords | Indicates whether passwords in the account expire. Returns true if max_password_age contains a value greater than 0. Returns false if it is 0 or not present. |
+| this\_iam\_account\_password\_policy\_expire\_passwords | Indicates whether passwords in the account expire. Returns true if max\_password\_age contains a value greater than 0. Returns false if it is 0 or not present. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-role-with-oidc/README.md
+++ b/examples/iam-assumable-role-with-oidc/README.md
@@ -1,0 +1,29 @@
+# Individual IAM assumable roles example
+
+Configuration in this directory creates several individual IAM roles which can be assumed from a defined list of [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns).
+
+The main difference between `iam-assumable-role` and `iam-assumable-roles` examples is that the former creates just a single role.
+
+# Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| role\_requires\_mfa | Whether admin IAM role requires MFA |
+| this\_iam\_role\_arn | ARN of IAM role |
+| this\_iam\_role\_name | Name of IAM role |
+| this\_iam\_role\_path | Path of IAM role |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-role-with-oidc/README.md
+++ b/examples/iam-assumable-role-with-oidc/README.md
@@ -15,11 +15,18 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| role\_requires\_mfa | Whether admin IAM role requires MFA |
 | this\_iam\_role\_arn | ARN of IAM role |
 | this\_iam\_role\_name | Name of IAM role |
 | this\_iam\_role\_path | Path of IAM role |

--- a/examples/iam-assumable-role-with-oidc/README.md
+++ b/examples/iam-assumable-role-with-oidc/README.md
@@ -1,8 +1,6 @@
-# Individual IAM assumable roles example
+# Individual IAM assumable role example
 
-Configuration in this directory creates several individual IAM roles which can be assumed from a defined list of [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns).
-
-The main difference between `iam-assumable-role` and `iam-assumable-roles` examples is that the former creates just a single role.
+Configuration in this directory creates a single IAM role which can be assumed by trusted resources using OpenID Connect Federated Users.
 
 # Usage
 

--- a/examples/iam-assumable-role-with-oidc/main.tf
+++ b/examples/iam-assumable-role-with-oidc/main.tf
@@ -1,0 +1,24 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+###############################
+# IAM assumable role for admin
+###############################
+module "iam_assumable_role_admin" {
+  source = "../../modules/iam-assumable-role-with-iodc"
+
+  create_role = true
+
+  role_name = "role-with-oidc"
+
+  tags = {
+    Role = "role-with-oidc"
+  }
+
+  provider_url = "oidc.eks.eu-west-1.amazonaws.com/id/BA9E170D464AF7B92084EF72A69B9DC8"
+
+  role_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+  ]
+}

--- a/examples/iam-assumable-role-with-oidc/outputs.tf
+++ b/examples/iam-assumable-role-with-oidc/outputs.tf
@@ -1,0 +1,14 @@
+output "this_iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = module.iam_assumable_role_admin.this_iam_role_arn
+}
+
+output "this_iam_role_name" {
+  description = "Name of IAM role"
+  value       = module.iam_assumable_role_admin.this_iam_role_name
+}
+
+output "this_iam_role_path" {
+  description = "Path of IAM role"
+  value       = module.iam_assumable_role_admin.this_iam_role_path
+}

--- a/examples/iam-assumable-role/README.md
+++ b/examples/iam-assumable-role/README.md
@@ -17,6 +17,14 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/examples/iam-assumable-roles-with-saml/README.md
+++ b/examples/iam-assumable-roles-with-saml/README.md
@@ -15,6 +15,16 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/examples/iam-assumable-roles/README.md
+++ b/examples/iam-assumable-roles/README.md
@@ -15,6 +15,14 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/examples/iam-group-complete/README.md
+++ b/examples/iam-group-complete/README.md
@@ -17,6 +17,14 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/examples/iam-group-with-assumable-roles-policy/README.md
+++ b/examples/iam-group-with-assumable-roles-policy/README.md
@@ -15,6 +15,17 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| aws.production | n/a |
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/examples/iam-group-with-policies/README.md
+++ b/examples/iam-group-with-policies/README.md
@@ -15,6 +15,16 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/examples/iam-policy/README.md
+++ b/examples/iam-policy/README.md
@@ -15,6 +15,16 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/examples/iam-user/README.md
+++ b/examples/iam-user/README.md
@@ -16,14 +16,22 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| keybase\_password\_decrypt\_command |  |
-| keybase\_password\_pgp\_message |  |
-| keybase\_secret\_key\_decrypt\_command |  |
-| keybase\_secret\_key\_pgp\_message |  |
+| keybase\_password\_decrypt\_command | n/a |
+| keybase\_password\_pgp\_message | n/a |
+| keybase\_secret\_key\_decrypt\_command | n/a |
+| keybase\_secret\_key\_pgp\_message | n/a |
 | pgp\_key | PGP key used to encrypt sensitive data for this user (if empty - secrets are not encrypted) |
 | this\_iam\_access\_key\_encrypted\_secret | The encrypted secret, base64 encoded |
 | this\_iam\_access\_key\_id | The access key ID |

--- a/modules/iam-account/README.md
+++ b/modules/iam-account/README.md
@@ -22,22 +22,28 @@ Import successful!
 ``` 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| account\_alias | AWS IAM account alias for this account | string | n/a | yes |
-| allow\_users\_to\_change\_password | Whether to allow users to change their own password | bool | `"true"` | no |
-| create\_account\_password\_policy | Whether to create AWS IAM account password policy | bool | `"true"` | no |
-| get\_caller\_identity | Whether to get AWS account ID, User ID, and ARN in which Terraform is authorized | bool | `"true"` | no |
-| hard\_expiry | Whether users are prevented from setting a new password after their password has expired (i.e. require administrator reset) | bool | `"false"` | no |
-| max\_password\_age | The number of days that an user password is valid. | number | `"0"` | no |
-| minimum\_password\_length | Minimum length to require for user passwords | number | `"8"` | no |
-| password\_reuse\_prevention | The number of previous passwords that users are prevented from reusing | number | `"null"` | no |
-| require\_lowercase\_characters | Whether to require lowercase characters for user passwords | bool | `"true"` | no |
-| require\_numbers | Whether to require numbers for user passwords | bool | `"true"` | no |
-| require\_symbols | Whether to require symbols for user passwords | bool | `"true"` | no |
-| require\_uppercase\_characters | Whether to require uppercase characters for user passwords | bool | `"true"` | no |
+|------|-------------|------|---------|:-----:|
+| account\_alias | AWS IAM account alias for this account | `string` | n/a | yes |
+| allow\_users\_to\_change\_password | Whether to allow users to change their own password | `bool` | `true` | no |
+| create\_account\_password\_policy | Whether to create AWS IAM account password policy | `bool` | `true` | no |
+| get\_caller\_identity | Whether to get AWS account ID, User ID, and ARN in which Terraform is authorized | `bool` | `true` | no |
+| hard\_expiry | Whether users are prevented from setting a new password after their password has expired (i.e. require administrator reset) | `bool` | `false` | no |
+| max\_password\_age | The number of days that an user password is valid. | `number` | `0` | no |
+| minimum\_password\_length | Minimum length to require for user passwords | `number` | `8` | no |
+| password\_reuse\_prevention | The number of previous passwords that users are prevented from reusing | `number` | n/a | yes |
+| require\_lowercase\_characters | Whether to require lowercase characters for user passwords | `bool` | `true` | no |
+| require\_numbers | Whether to require numbers for user passwords | `bool` | `true` | no |
+| require\_symbols | Whether to require symbols for user passwords | `bool` | `true` | no |
+| require\_uppercase\_characters | Whether to require uppercase characters for user passwords | `bool` | `true` | no |
 
 ## Outputs
 
@@ -46,6 +52,6 @@ Import successful!
 | this\_caller\_identity\_account\_id | The AWS Account ID number of the account that owns or contains the calling entity |
 | this\_caller\_identity\_arn | The AWS ARN associated with the calling entity |
 | this\_caller\_identity\_user\_id | The unique identifier of the calling entity |
-| this\_iam\_account\_password\_policy\_expire\_passwords | Indicates whether passwords in the account expire. Returns true if max_password_age contains a value greater than 0. Returns false if it is 0 or not present. |
+| this\_iam\_account\_password\_policy\_expire\_passwords | Indicates whether passwords in the account expire. Returns true if max\_password\_age contains a value greater than 0. Returns false if it is 0 or not present. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-account/README.md
+++ b/modules/iam-account/README.md
@@ -26,7 +26,7 @@ Import successful!
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.23 |
 
 ## Inputs
 

--- a/modules/iam-account/versions.tf
+++ b/modules/iam-account/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.23"
+  }
+}

--- a/modules/iam-assumable-role-with-iodc/README.md
+++ b/modules/iam-assumable-role-with-iodc/README.md
@@ -7,34 +7,34 @@ Creates single IAM role which can be assumed by trusted resources using OpenID C
 This module supports IAM Roles for kubernetes service accounts as described in the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| aws\_account\_id | The AWS account ID where the OIDC provider lives, leave empty to use the account fo the AWS provider | string | `""` | no |
-| create\_role | Whether to create a role | bool | `"false"` | no |
-| max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | number | `"3600"` | no |
-| oidc\_fully\_qualified\_subjects | The fully qualified OIDC subjects to be added to the role policy | list(string) | `[]` | no |
-| oidc\_subjects\_with\_wildcards | The OIDC subject using wildcards to be added to the role policy | list(string) | `[]` | no |
-| provider\_url | URL of the OIDC Provider | string | n/a | yes |
-| role\_name | IAM role name | string | `""` | no |
-| role\_path | Path of IAM role | string | `"/"` | no |
-| role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | string | `""` | no |
-| role\_policy\_arns | List of ARNs of IAM policies to attach to IAM role | list(string) | `[]` | no |
-| tags | A map of tags to add to IAM role resources | map(string) | `{}` | no |
+|------|-------------|------|---------|:-----:|
+| aws\_account\_id | The AWS account ID where the OIDC provider lives, leave empty to use the account fo the AWS provider | `string` | `""` | no |
+| create\_role | Whether to create a role | `bool` | `false` | no |
+| max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
+| oidc\_fully\_qualified\_subjects | The fully qualified OIDC subjects to be added to the role policy | `list(string)` | `[]` | no |
+| oidc\_subjects\_with\_wildcards | The OIDC subject using wildcards to be added to the role policy | `list(string)` | `[]` | no |
+| provider\_url | URL of the OIDC Provider | `string` | n/a | yes |
+| role\_name | IAM role name | `string` | `""` | no |
+| role\_path | Path of IAM role | `string` | `"/"` | no |
+| role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
+| role\_policy\_arns | List of ARNs of IAM policies to attach to IAM role | `list(string)` | `[]` | no |
+| tags | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| admin\_iam\_role\_arn | ARN of admin IAM role |
-| admin\_iam\_role\_name | Name of admin IAM role |
-| admin\_iam\_role\_path | Path of admin IAM role |
-| poweruser\_iam\_role\_arn | ARN of poweruser IAM role |
-| poweruser\_iam\_role\_name | Name of poweruser IAM role |
-| poweruser\_iam\_role\_path | Path of poweruser IAM role |
-| readonly\_iam\_role\_arn | ARN of readonly IAM role |
-| readonly\_iam\_role\_name | Name of readonly IAM role |
-| readonly\_iam\_role\_path | Path of readonly IAM role |
+| this\_iam\_role\_arn | ARN of IAM role |
+| this\_iam\_role\_name | Name of IAM role |
+| this\_iam\_role\_path | Path of IAM role |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-role-with-iodc/README.md
+++ b/modules/iam-assumable-role-with-iodc/README.md
@@ -4,7 +4,7 @@ Creates single IAM role which can be assumed by trusted resources using OpenID C
 
 [Creating IAM OIDC Identity Providers](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html)
 
-This module supports IAM Roles for kubernetes service accounts as described in the [EKS documentation](https://docs.aws.amazon.com/en_pv/eks/latest/userguide/iam-roles-for-service-accounts.html). 
+This module supports IAM Roles for kubernetes service accounts as described in the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/modules/iam-assumable-role-with-iodc/README.md
+++ b/modules/iam-assumable-role-with-iodc/README.md
@@ -1,0 +1,40 @@
+# iam-assumable-role-with-oidc
+
+Creates single IAM role which can be assumed by trusted resources using OpenID Connect Federated Users.
+
+[Creating IAM OIDC Identity Providers](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html)
+
+This module supports IAM Roles for kubernetes service accounts as described in the [EKS documentation](https://docs.aws.amazon.com/en_pv/eks/latest/userguide/iam-roles-for-service-accounts.html). 
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws\_account\_id | The AWS account ID where the OIDC provider lives, leave empty to use the account fo the AWS provider | string | `""` | no |
+| create\_role | Whether to create a role | bool | `"false"` | no |
+| max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | number | `"3600"` | no |
+| oidc\_fully\_qualified\_subjects | The fully qualified OIDC subjects to be added to the role policy | list(string) | `[]` | no |
+| oidc\_subjects\_with\_wildcards | The OIDC subject using wildcards to be added to the role policy | list(string) | `[]` | no |
+| provider\_url | URL of the OIDC Provider | string | n/a | yes |
+| role\_name | IAM role name | string | `""` | no |
+| role\_path | Path of IAM role | string | `"/"` | no |
+| role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | string | `""` | no |
+| role\_policy\_arns | List of ARNs of IAM policies to attach to IAM role | list(string) | `[]` | no |
+| tags | A map of tags to add to IAM role resources | map(string) | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| admin\_iam\_role\_arn | ARN of admin IAM role |
+| admin\_iam\_role\_name | Name of admin IAM role |
+| admin\_iam\_role\_path | Path of admin IAM role |
+| poweruser\_iam\_role\_arn | ARN of poweruser IAM role |
+| poweruser\_iam\_role\_name | Name of poweruser IAM role |
+| poweruser\_iam\_role\_path | Path of poweruser IAM role |
+| readonly\_iam\_role\_arn | ARN of readonly IAM role |
+| readonly\_iam\_role\_name | Name of readonly IAM role |
+| readonly\_iam\_role\_path | Path of readonly IAM role |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-role-with-iodc/README.md
+++ b/modules/iam-assumable-role-with-iodc/README.md
@@ -11,7 +11,7 @@ This module supports IAM Roles for kubernetes service accounts as described in t
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.23 |
 
 ## Inputs
 

--- a/modules/iam-assumable-role-with-iodc/main.tf
+++ b/modules/iam-assumable-role-with-iodc/main.tf
@@ -1,0 +1,62 @@
+locals {
+  aws_account_id = var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.current.account_id
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "assume_role_with_oidc" {
+  count = var.create_role ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type = "Federated"
+
+      identifiers = [
+        "arn:aws:iam::${local.aws_account_id}:oidc-provider/${var.provider_url}"
+      ]
+    }
+
+    dynamic "condition" {
+      for_each = var.oidc_fully_qualified_subjects
+      content {
+        test     = "StringEquals"
+        variable = "${var.provider_url}:sub"
+        values   = [condition.value]
+      }
+    }
+
+    dynamic "condition" {
+      for_each = var.oidc_subjects_with_wildcards
+      content {
+        test     = "StringLike"
+        variable = "${var.provider_url}:sub"
+        values   = [condition.value]
+      }
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  count = var.create_role ? 1 : 0
+
+  name                 = var.role_name
+  path                 = var.role_path
+  max_session_duration = var.max_session_duration
+
+  permissions_boundary = var.role_permissions_boundary_arn
+
+  assume_role_policy = join("", data.aws_iam_policy_document.assume_role_with_oidc.*.json)
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "custom" {
+  count = var.create_role && length(var.role_policy_arns) > 0 ? length(var.role_policy_arns) : 0
+
+  role       = join("", aws_iam_role.this.*.name)
+  policy_arn = var.role_policy_arns[count.index]
+}

--- a/modules/iam-assumable-role-with-iodc/outputs.tf
+++ b/modules/iam-assumable-role-with-iodc/outputs.tf
@@ -1,0 +1,14 @@
+output "this_iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = element(concat(aws_iam_role.this.*.arn, [""]), 0)
+}
+
+output "this_iam_role_name" {
+  description = "Name of IAM role"
+  value       = element(concat(aws_iam_role.this.*.name, [""]), 0)
+}
+
+output "this_iam_role_path" {
+  description = "Path of IAM role"
+  value       = element(concat(aws_iam_role.this.*.path, [""]), 0)
+}

--- a/modules/iam-assumable-role-with-iodc/variables.tf
+++ b/modules/iam-assumable-role-with-iodc/variables.tf
@@ -1,0 +1,65 @@
+variable "create_role" {
+  description = "Whether to create a role"
+  type        = bool
+  default     = false
+}
+
+variable "provider_url" {
+  description = "URL of the OIDC Provider"
+  type        = string
+}
+
+variable "aws_account_id" {
+  description = "The AWS account ID where the OIDC provider lives, leave empty to use the account fo the AWS provider"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "A map of tags to add to IAM role resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "role_name" {
+  description = "IAM role name"
+  type        = string
+  default     = ""
+}
+
+variable "role_path" {
+  description = "Path of IAM role"
+  type        = string
+  default     = "/"
+}
+
+variable "role_permissions_boundary_arn" {
+  description = "Permissions boundary ARN to use for IAM role"
+  type        = string
+  default     = ""
+}
+
+variable "max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200"
+  type        = number
+  default     = 3600
+}
+
+variable "role_policy_arns" {
+  description = "List of ARNs of IAM policies to attach to IAM role"
+  type        = list(string)
+  default     = []
+}
+
+variable "oidc_fully_qualified_subjects" {
+  description = "The fully qualified OIDC subjects to be added to the role policy"
+  type        = list(string)
+  default     = []
+}
+
+variable "oidc_subjects_with_wildcards" {
+  description = "The OIDC subject using wildcards to be added to the role policy"
+  type        = list(string)
+  default     = []
+}
+

--- a/modules/iam-assumable-role-with-iodc/versions.tf
+++ b/modules/iam-assumable-role-with-iodc/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.23"
+  }
+}

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -9,7 +9,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.23 |
 
 ## Inputs
 

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -5,27 +5,33 @@ Creates single IAM role which can be assumed by trusted resources.
 Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns) - typically, AWS accounts and users.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| admin\_role\_policy\_arn | Policy ARN to use for admin role | string | `"arn:aws:iam::aws:policy/AdministratorAccess"` | no |
-| attach\_admin\_policy | Whether to attach an admin policy to a role | bool | `"false"` | no |
-| attach\_poweruser\_policy | Whether to attach a poweruser policy to a role | bool | `"false"` | no |
-| attach\_readonly\_policy | Whether to attach a readonly policy to a role | bool | `"false"` | no |
-| create\_role | Whether to create a role | bool | `"false"` | no |
-| custom\_role\_policy\_arns | List of ARNs of IAM policies to attach to IAM role | list(string) | `[]` | no |
-| max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | number | `"3600"` | no |
-| mfa\_age | Max age of valid MFA (in seconds) for roles which require MFA | number | `"86400"` | no |
-| poweruser\_role\_policy\_arn | Policy ARN to use for poweruser role | string | `"arn:aws:iam::aws:policy/PowerUserAccess"` | no |
-| readonly\_role\_policy\_arn | Policy ARN to use for readonly role | string | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
-| role\_name | IAM role name | string | `""` | no |
-| role\_path | Path of IAM role | string | `"/"` | no |
-| role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | string | `""` | no |
-| role\_requires\_mfa | Whether role requires MFA | bool | `"true"` | no |
-| tags | A map of tags to add to IAM role resources | map(string) | `{}` | no |
-| trusted\_role\_arns | ARNs of AWS entities who can assume these roles | list(string) | `[]` | no |
-| trusted\_role\_services | AWS Services that can assume these roles | list(string) | `[]` | no |
+|------|-------------|------|---------|:-----:|
+| admin\_role\_policy\_arn | Policy ARN to use for admin role | `string` | `"arn:aws:iam::aws:policy/AdministratorAccess"` | no |
+| attach\_admin\_policy | Whether to attach an admin policy to a role | `bool` | `false` | no |
+| attach\_poweruser\_policy | Whether to attach a poweruser policy to a role | `bool` | `false` | no |
+| attach\_readonly\_policy | Whether to attach a readonly policy to a role | `bool` | `false` | no |
+| create\_role | Whether to create a role | `bool` | `false` | no |
+| custom\_role\_policy\_arns | List of ARNs of IAM policies to attach to IAM role | `list(string)` | `[]` | no |
+| max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
+| mfa\_age | Max age of valid MFA (in seconds) for roles which require MFA | `number` | `86400` | no |
+| poweruser\_role\_policy\_arn | Policy ARN to use for poweruser role | `string` | `"arn:aws:iam::aws:policy/PowerUserAccess"` | no |
+| readonly\_role\_policy\_arn | Policy ARN to use for readonly role | `string` | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
+| role\_name | IAM role name | `string` | `""` | no |
+| role\_path | Path of IAM role | `string` | `"/"` | no |
+| role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
+| role\_requires\_mfa | Whether role requires MFA | `bool` | `true` | no |
+| tags | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
+| trusted\_role\_arns | ARNs of AWS entities who can assume these roles | `list(string)` | `[]` | no |
+| trusted\_role\_services | AWS Services that can assume these roles | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -25,6 +25,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | mfa\_age | Max age of valid MFA (in seconds) for roles which require MFA | `number` | `86400` | no |
 | poweruser\_role\_policy\_arn | Policy ARN to use for poweruser role | `string` | `"arn:aws:iam::aws:policy/PowerUserAccess"` | no |
 | readonly\_role\_policy\_arn | Policy ARN to use for readonly role | `string` | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
+| role\_description | IAM Role description | `string` | `""` | no |
 | role\_name | IAM role name | `string` | `""` | no |
 | role\_path | Path of IAM role | `string` | `"/"` | no |
 | role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |

--- a/modules/iam-assumable-role/versions.tf
+++ b/modules/iam-assumable-role/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.23"
+  }
+}

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -11,7 +11,7 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.23 |
 
 ## Inputs
 

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -7,32 +7,38 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 [Enabling SAML 2.0 Federated Users to Access the AWS Management Console](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-saml.html) 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| admin\_role\_name | IAM role with admin access | string | `"admin"` | no |
-| admin\_role\_path | Path of admin IAM role | string | `"/"` | no |
-| admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | string | `""` | no |
-| admin\_role\_policy\_arns | List of policy ARNs to use for admin role | list(string) | `[ "arn:aws:iam::aws:policy/AdministratorAccess" ]` | no |
-| admin\_role\_tags | A map of tags to add to admin role resource. | map(string) | `{}` | no |
-| aws\_saml\_endpoint | AWS SAML Endpoint | string | `"https://signin.aws.amazon.com/saml"` | no |
-| create\_admin\_role | Whether to create admin role | bool | `"false"` | no |
-| create\_poweruser\_role | Whether to create poweruser role | bool | `"false"` | no |
-| create\_readonly\_role | Whether to create readonly role | bool | `"false"` | no |
-| max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | number | `"3600"` | no |
-| poweruser\_role\_name | IAM role with poweruser access | string | `"poweruser"` | no |
-| poweruser\_role\_path | Path of poweruser IAM role | string | `"/"` | no |
-| poweruser\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for poweruser role | string | `""` | no |
-| poweruser\_role\_policy\_arns | List of policy ARNs to use for poweruser role | list(string) | `[ "arn:aws:iam::aws:policy/PowerUserAccess" ]` | no |
-| poweruser\_role\_tags | A map of tags to add to poweruser role resource. | map(string) | `{}` | no |
-| provider\_id | ID of the SAML Provider | string | n/a | yes |
-| provider\_name | Name of the SAML Provider | string | n/a | yes |
-| readonly\_role\_name | IAM role with readonly access | string | `"readonly"` | no |
-| readonly\_role\_path | Path of readonly IAM role | string | `"/"` | no |
-| readonly\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for readonly role | string | `""` | no |
-| readonly\_role\_policy\_arns | List of policy ARNs to use for readonly role | list(string) | `[ "arn:aws:iam::aws:policy/ReadOnlyAccess" ]` | no |
-| readonly\_role\_tags | A map of tags to add to readonly role resource. | map(string) | `{}` | no |
+|------|-------------|------|---------|:-----:|
+| admin\_role\_name | IAM role with admin access | `string` | `"admin"` | no |
+| admin\_role\_path | Path of admin IAM role | `string` | `"/"` | no |
+| admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | `string` | `""` | no |
+| admin\_role\_policy\_arns | List of policy ARNs to use for admin role | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/AdministratorAccess"<br>]<br></pre> | no |
+| admin\_role\_tags | A map of tags to add to admin role resource. | `map(string)` | `{}` | no |
+| aws\_saml\_endpoint | AWS SAML Endpoint | `string` | `"https://signin.aws.amazon.com/saml"` | no |
+| create\_admin\_role | Whether to create admin role | `bool` | `false` | no |
+| create\_poweruser\_role | Whether to create poweruser role | `bool` | `false` | no |
+| create\_readonly\_role | Whether to create readonly role | `bool` | `false` | no |
+| max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
+| poweruser\_role\_name | IAM role with poweruser access | `string` | `"poweruser"` | no |
+| poweruser\_role\_path | Path of poweruser IAM role | `string` | `"/"` | no |
+| poweruser\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for poweruser role | `string` | `""` | no |
+| poweruser\_role\_policy\_arns | List of policy ARNs to use for poweruser role | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/PowerUserAccess"<br>]<br></pre> | no |
+| poweruser\_role\_tags | A map of tags to add to poweruser role resource. | `map(string)` | `{}` | no |
+| provider\_id | ID of the SAML Provider | `string` | n/a | yes |
+| provider\_name | Name of the SAML Provider | `string` | n/a | yes |
+| readonly\_role\_name | IAM role with readonly access | `string` | `"readonly"` | no |
+| readonly\_role\_path | Path of readonly IAM role | `string` | `"/"` | no |
+| readonly\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for readonly role | `string` | `""` | no |
+| readonly\_role\_policy\_arns | List of policy ARNs to use for readonly role | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/ReadOnlyAccess"<br>]<br></pre> | no |
+| readonly\_role\_tags | A map of tags to add to readonly role resource. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -1,6 +1,6 @@
 # iam-assumable-roles-with-saml
 
-Creates single IAM role which can be assumed by trusted resources using SAML Federated Users.
+Creates predefined IAM roles (admin, poweruser and readonly) which can be assumed by trusted resources using SAML Federated Users.
 
 
 [Creating IAM SAML Identity Providers](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml.html) 

--- a/modules/iam-assumable-roles-with-saml/versions.tf
+++ b/modules/iam-assumable-roles-with-saml/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.23"
+  }
+}

--- a/modules/iam-assumable-roles/README.md
+++ b/modules/iam-assumable-roles/README.md
@@ -9,7 +9,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.23 |
 
 ## Inputs
 

--- a/modules/iam-assumable-roles/README.md
+++ b/modules/iam-assumable-roles/README.md
@@ -5,35 +5,41 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns) - typically, AWS accounts and users.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| admin\_role\_name | IAM role with admin access | string | `"admin"` | no |
-| admin\_role\_path | Path of admin IAM role | string | `"/"` | no |
-| admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | string | `""` | no |
-| admin\_role\_policy\_arns | List of policy ARNs to use for admin role | list(string) | `[ "arn:aws:iam::aws:policy/AdministratorAccess" ]` | no |
-| admin\_role\_requires\_mfa | Whether admin role requires MFA | bool | `"true"` | no |
-| admin\_role\_tags | A map of tags to add to admin role resource. | map(string) | `{}` | no |
-| create\_admin\_role | Whether to create admin role | bool | `"false"` | no |
-| create\_poweruser\_role | Whether to create poweruser role | bool | `"false"` | no |
-| create\_readonly\_role | Whether to create readonly role | bool | `"false"` | no |
-| max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | number | `"3600"` | no |
-| mfa\_age | Max age of valid MFA (in seconds) for roles which require MFA | number | `"86400"` | no |
-| poweruser\_role\_name | IAM role with poweruser access | string | `"poweruser"` | no |
-| poweruser\_role\_path | Path of poweruser IAM role | string | `"/"` | no |
-| poweruser\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for poweruser role | string | `""` | no |
-| poweruser\_role\_policy\_arns | List of policy ARNs to use for poweruser role | list(string) | `[ "arn:aws:iam::aws:policy/PowerUserAccess" ]` | no |
-| poweruser\_role\_requires\_mfa | Whether poweruser role requires MFA | bool | `"true"` | no |
-| poweruser\_role\_tags | A map of tags to add to poweruser role resource. | map(string) | `{}` | no |
-| readonly\_role\_name | IAM role with readonly access | string | `"readonly"` | no |
-| readonly\_role\_path | Path of readonly IAM role | string | `"/"` | no |
-| readonly\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for readonly role | string | `""` | no |
-| readonly\_role\_policy\_arns | List of policy ARNs to use for readonly role | list(string) | `[ "arn:aws:iam::aws:policy/ReadOnlyAccess" ]` | no |
-| readonly\_role\_requires\_mfa | Whether readonly role requires MFA | bool | `"true"` | no |
-| readonly\_role\_tags | A map of tags to add to readonly role resource. | map(string) | `{}` | no |
-| trusted\_role\_arns | ARNs of AWS entities who can assume these roles | list(string) | `[]` | no |
-| trusted\_role\_services | AWS Services that can assume these roles | list(string) | `[]` | no |
+|------|-------------|------|---------|:-----:|
+| admin\_role\_name | IAM role with admin access | `string` | `"admin"` | no |
+| admin\_role\_path | Path of admin IAM role | `string` | `"/"` | no |
+| admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | `string` | `""` | no |
+| admin\_role\_policy\_arns | List of policy ARNs to use for admin role | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/AdministratorAccess"<br>]<br></pre> | no |
+| admin\_role\_requires\_mfa | Whether admin role requires MFA | `bool` | `true` | no |
+| admin\_role\_tags | A map of tags to add to admin role resource. | `map(string)` | `{}` | no |
+| create\_admin\_role | Whether to create admin role | `bool` | `false` | no |
+| create\_poweruser\_role | Whether to create poweruser role | `bool` | `false` | no |
+| create\_readonly\_role | Whether to create readonly role | `bool` | `false` | no |
+| max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
+| mfa\_age | Max age of valid MFA (in seconds) for roles which require MFA | `number` | `86400` | no |
+| poweruser\_role\_name | IAM role with poweruser access | `string` | `"poweruser"` | no |
+| poweruser\_role\_path | Path of poweruser IAM role | `string` | `"/"` | no |
+| poweruser\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for poweruser role | `string` | `""` | no |
+| poweruser\_role\_policy\_arns | List of policy ARNs to use for poweruser role | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/PowerUserAccess"<br>]<br></pre> | no |
+| poweruser\_role\_requires\_mfa | Whether poweruser role requires MFA | `bool` | `true` | no |
+| poweruser\_role\_tags | A map of tags to add to poweruser role resource. | `map(string)` | `{}` | no |
+| readonly\_role\_name | IAM role with readonly access | `string` | `"readonly"` | no |
+| readonly\_role\_path | Path of readonly IAM role | `string` | `"/"` | no |
+| readonly\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for readonly role | `string` | `""` | no |
+| readonly\_role\_policy\_arns | List of policy ARNs to use for readonly role | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/ReadOnlyAccess"<br>]<br></pre> | no |
+| readonly\_role\_requires\_mfa | Whether readonly role requires MFA | `bool` | `true` | no |
+| readonly\_role\_tags | A map of tags to add to readonly role resource. | `map(string)` | `{}` | no |
+| trusted\_role\_arns | ARNs of AWS entities who can assume these roles | `list(string)` | `[]` | no |
+| trusted\_role\_services | AWS Services that can assume these roles | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/iam-assumable-roles/versions.tf
+++ b/modules/iam-assumable-roles/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.23"
+  }
+}

--- a/modules/iam-group-with-assumable-roles-policy/README.md
+++ b/modules/iam-group-with-assumable-roles-policy/README.md
@@ -3,13 +3,19 @@
 Creates IAM group with users who are allowed to assume IAM roles. This is typically done in resource AWS account where IAM users can jump into from IAM AWS account.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| assumable\_roles | List of IAM roles ARNs which can be assumed by the group | list(string) | `[]` | no |
-| group\_users | List of IAM users to have in an IAM group which can assume the role | list(string) | `[]` | no |
-| name | Name of IAM policy and IAM group | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| assumable\_roles | List of IAM roles ARNs which can be assumed by the group | `list(string)` | `[]` | no |
+| group\_users | List of IAM users to have in an IAM group which can assume the role | `list(string)` | `[]` | no |
+| name | Name of IAM policy and IAM group | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/iam-group-with-assumable-roles-policy/README.md
+++ b/modules/iam-group-with-assumable-roles-policy/README.md
@@ -7,7 +7,7 @@ Creates IAM group with users who are allowed to assume IAM roles. This is typica
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.23 |
 
 ## Inputs
 

--- a/modules/iam-group-with-assumable-roles-policy/versions.tf
+++ b/modules/iam-group-with-assumable-roles-policy/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.23"
+  }
+}

--- a/modules/iam-group-with-policies/README.md
+++ b/modules/iam-group-with-policies/README.md
@@ -3,18 +3,24 @@
 Creates IAM group with specified IAM policies, and add users into a group.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| attach\_iam\_self\_management\_policy | Whether to attach IAM policy which allows IAM users to manage their credentials and MFA | bool | `"true"` | no |
-| aws\_account\_id | AWS account id to use inside IAM policies. If empty, current AWS account ID will be used. | string | `""` | no |
-| create\_group | Whether to create IAM group | bool | `"true"` | no |
-| custom\_group\_policies | List of maps of inline IAM policies to attach to IAM group. Should have `name` and `policy` keys in each element. | list(map(string)) | `[]` | no |
-| custom\_group\_policy\_arns | List of IAM policies ARNs to attach to IAM group | list(string) | `[]` | no |
-| group\_users | List of IAM users to have in an IAM group which can assume the role | list(string) | `[]` | no |
-| iam\_self\_management\_policy\_name\_prefix | Name prefix for IAM policy to create with IAM self-management permissions | string | `"IAMSelfManagement-"` | no |
-| name | Name of IAM group | string | `""` | no |
+|------|-------------|------|---------|:-----:|
+| attach\_iam\_self\_management\_policy | Whether to attach IAM policy which allows IAM users to manage their credentials and MFA | `bool` | `true` | no |
+| aws\_account\_id | AWS account id to use inside IAM policies. If empty, current AWS account ID will be used. | `string` | `""` | no |
+| create\_group | Whether to create IAM group | `bool` | `true` | no |
+| custom\_group\_policies | List of maps of inline IAM policies to attach to IAM group. Should have `name` and `policy` keys in each element. | `list(map(string))` | `[]` | no |
+| custom\_group\_policy\_arns | List of IAM policies ARNs to attach to IAM group | `list(string)` | `[]` | no |
+| group\_users | List of IAM users to have in an IAM group which can assume the role | `list(string)` | `[]` | no |
+| iam\_self\_management\_policy\_name\_prefix | Name prefix for IAM policy to create with IAM self-management permissions | `string` | `"IAMSelfManagement-"` | no |
+| name | Name of IAM group | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/iam-group-with-policies/README.md
+++ b/modules/iam-group-with-policies/README.md
@@ -7,7 +7,7 @@ Creates IAM group with specified IAM policies, and add users into a group.
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.23 |
 
 ## Inputs
 

--- a/modules/iam-group-with-policies/versions.tf
+++ b/modules/iam-group-with-policies/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.23"
+  }
+}

--- a/modules/iam-policy/README.md
+++ b/modules/iam-policy/README.md
@@ -7,7 +7,7 @@ Creates IAM policy.
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.23 |
 
 ## Inputs
 

--- a/modules/iam-policy/README.md
+++ b/modules/iam-policy/README.md
@@ -3,14 +3,20 @@
 Creates IAM policy.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| description | The description of the policy | string | `"IAM Policy"` | no |
-| name | The name of the policy | string | `""` | no |
-| path | The path of the policy in IAM | string | `"/"` | no |
-| policy | The path of the policy in IAM (tpl file) | string | `""` | no |
+|------|-------------|------|---------|:-----:|
+| description | The description of the policy | `string` | `"IAM Policy"` | no |
+| name | The name of the policy | `string` | `""` | no |
+| path | The path of the policy in IAM | `string` | `"/"` | no |
+| policy | The path of the policy in IAM (tpl file) | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/iam-policy/versions.tf
+++ b/modules/iam-policy/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.23"
+  }
+}

--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -23,7 +23,7 @@ This module outputs commands and PGP messages which can be decrypted either usin
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.23 |
 
 ## Inputs
 

--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -19,33 +19,39 @@ This module outputs commands and PGP messages which can be decrypted either usin
 - `keybase_secret_key_pgp_message`
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| create\_iam\_access\_key | Whether to create IAM access key | bool | `"true"` | no |
-| create\_iam\_user\_login\_profile | Whether to create IAM user login profile | bool | `"true"` | no |
-| create\_user | Whether to create the IAM user | bool | `"true"` | no |
-| force\_destroy | When destroying this user, destroy even if it has non-Terraform-managed IAM access keys, login profile or MFA devices. Without force_destroy a user with non-Terraform-managed access keys and login profile will fail to be destroyed. | bool | `"false"` | no |
-| name | Desired name for the IAM user | string | n/a | yes |
-| password\_length | The length of the generated password | number | `"20"` | no |
-| password\_reset\_required | Whether the user should be forced to reset the generated password on first login. | bool | `"true"` | no |
-| path | Desired path for the IAM user | string | `"/"` | no |
-| permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the user. | string | `""` | no |
-| pgp\_key | Either a base-64 encoded PGP public key, or a keybase username in the form keybase:username. Used to encrypt password and access key. | string | `""` | no |
-| ssh\_key\_encoding | Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH. To retrieve the public key in PEM format, use PEM | string | `"SSH"` | no |
-| ssh\_public\_key | The SSH public key. The public key must be encoded in ssh-rsa format or PEM format | string | `""` | no |
-| tags | A map of tags to add to all resources. | map(string) | `{}` | no |
-| upload\_iam\_user\_ssh\_key | Whether to upload a public ssh key to the IAM user | bool | `"false"` | no |
+|------|-------------|------|---------|:-----:|
+| create\_iam\_access\_key | Whether to create IAM access key | `bool` | `true` | no |
+| create\_iam\_user\_login\_profile | Whether to create IAM user login profile | `bool` | `true` | no |
+| create\_user | Whether to create the IAM user | `bool` | `true` | no |
+| force\_destroy | When destroying this user, destroy even if it has non-Terraform-managed IAM access keys, login profile or MFA devices. Without force\_destroy a user with non-Terraform-managed access keys and login profile will fail to be destroyed. | `bool` | `false` | no |
+| name | Desired name for the IAM user | `string` | n/a | yes |
+| password\_length | The length of the generated password | `number` | `20` | no |
+| password\_reset\_required | Whether the user should be forced to reset the generated password on first login. | `bool` | `true` | no |
+| path | Desired path for the IAM user | `string` | `"/"` | no |
+| permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the user. | `string` | `""` | no |
+| pgp\_key | Either a base-64 encoded PGP public key, or a keybase username in the form keybase:username. Used to encrypt password and access key. | `string` | `""` | no |
+| ssh\_key\_encoding | Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH. To retrieve the public key in PEM format, use PEM | `string` | `"SSH"` | no |
+| ssh\_public\_key | The SSH public key. The public key must be encoded in ssh-rsa format or PEM format | `string` | `""` | no |
+| tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| upload\_iam\_user\_ssh\_key | Whether to upload a public ssh key to the IAM user | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| keybase\_password\_decrypt\_command |  |
-| keybase\_password\_pgp\_message |  |
-| keybase\_secret\_key\_decrypt\_command |  |
-| keybase\_secret\_key\_pgp\_message |  |
+| keybase\_password\_decrypt\_command | n/a |
+| keybase\_password\_pgp\_message | n/a |
+| keybase\_secret\_key\_decrypt\_command | n/a |
+| keybase\_secret\_key\_pgp\_message | n/a |
 | pgp\_key | PGP key used to encrypt sensitive data for this user (if empty - secrets are not encrypted) |
 | this\_iam\_access\_key\_encrypted\_secret | The encrypted secret, base64 encoded |
 | this\_iam\_access\_key\_id | The access key ID |

--- a/modules/iam-user/versions.tf
+++ b/modules/iam-user/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.23"
+  }
+}


### PR DESCRIPTION
# Description

This PR adds a new submodule that creates a single role that can be assumed by OIDC subjects. The motivation for the change is to setup IAM Roles for EKS Service Accounts. 
