### PR TITLE
iam-assumable-role: add description support

### DIFF
--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -52,6 +52,7 @@ resource "aws_iam_role" "this" {
   name                 = var.role_name
   path                 = var.role_path
   max_session_duration = var.max_session_duration
+  description          = var.role_description
 
   permissions_boundary = var.role_permissions_boundary_arn
 

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -101,3 +101,9 @@ variable "attach_readonly_policy" {
   default     = false
 }
 
+variable "role_description" {
+  description = "IAM Role description"
+  type        = string
+  default     = ""
+}
+


### PR DESCRIPTION


# Description
This PR adds support for custom description in iam-assumable-role. It can be useful in cases where services depend on role description (like keymaker for example).

This is based on https://github.com/terraform-aws-modules/terraform-aws-iam/issues/40

