### PR TITLE
add instance profile to iam-assumable-role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
-
+- iam-assumable-role: add possibility to create an IAM instance profile
 
 <a name="v2.6.0"></a>
 ## [v2.6.0] - 2020-01-27

--- a/examples/iam-group-with-assumable-roles-policy/README.md
+++ b/examples/iam-group-with-assumable-roles-policy/README.md
@@ -30,7 +30,7 @@ No input.
 
 | Name | Description |
 |------|-------------|
-| iam\_account\_id | IAM AWS account id (this code is managing resources in this account) |
+| iam\_account\_id | IAM AWS account id \(this code is managing resources in this account\) |
 | production\_account\_id | Production AWS account id |
 | this\_assumable\_roles | List of ARNs of IAM roles which members of IAM group can assume |
 | this\_group\_users | List of IAM users in IAM group |

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -39,6 +39,9 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | Name | Description |
 |------|-------------|
 | role\_requires\_mfa | Whether IAM role requires MFA |
+| this\_iam\_instance\_profile\_arn | ARN of IAM instance profile |
+| this\_iam\_instance\_profile\_name | Name of IAM instance profile |
+| this\_iam\_instance\_profile\_path | Path of IAM instance profile |
 | this\_iam\_role\_arn | ARN of IAM role |
 | this\_iam\_role\_name | Name of IAM role |
 | this\_iam\_role\_path | Path of IAM role |

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -89,3 +89,9 @@ resource "aws_iam_role_policy_attachment" "readonly" {
   policy_arn = var.readonly_role_policy_arn
 }
 
+resource "aws_iam_instance_profile" "this" {
+  count = var.create_role && var.create_instance_profile ? 1 : 0
+  name  = var.role_name
+  path  = var.role_path
+  role  = aws_iam_role.this[0].name
+}

--- a/modules/iam-assumable-role/outputs.tf
+++ b/modules/iam-assumable-role/outputs.tf
@@ -18,3 +18,17 @@ output "role_requires_mfa" {
   value       = var.role_requires_mfa
 }
 
+output "this_iam_instance_profile_arn" {
+  description = "ARN of IAM instance profile"
+  value       = element(concat(aws_iam_instance_profile.this.*.arn, [""]), 0)
+}
+
+output "this_iam_instance_profile_name" {
+  description = "Name of IAM instance profile"
+  value       = element(concat(aws_iam_instance_profile.this.*.name, [""]), 0)
+}
+
+output "this_iam_instance_profile_path" {
+  description = "Path of IAM instance profile"
+  value       = element(concat(aws_iam_instance_profile.this.*.path, [""]), 0)
+}

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -28,6 +28,12 @@ variable "create_role" {
   default     = false
 }
 
+variable "create_instance_profile" {
+  description = "Whether to create an instance profile"
+  type        = bool
+  default     = false
+}
+
 variable "role_name" {
   description = "IAM role name"
   type        = string


### PR DESCRIPTION
# Description

I added the possibility to create an IAM instance profile to "iam-assumable-role" As it only takes 1 extra parameter, and is whitin the scope of this module (IAM)
