### PR TITLE
feat: Strip https:// from OIDC provider URL if present

### DIFF
--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -1,5 +1,6 @@
 locals {
   aws_account_id = var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.current.account_id
+  provider_url   = replace(var.provider_url, "https://", "")
 }
 
 data "aws_caller_identity" "current" {}
@@ -16,7 +17,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       type = "Federated"
 
       identifiers = [
-        "arn:aws:iam::${local.aws_account_id}:oidc-provider/${var.provider_url}"
+        "arn:aws:iam::${local.aws_account_id}:oidc-provider/${local.provider_url}"
       ]
     }
 
@@ -24,7 +25,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       for_each = length(var.oidc_fully_qualified_subjects) > 0 ? [1] : []
       content {
         test     = "StringEquals"
-        variable = "${var.provider_url}:sub"
+        variable = "${local.provider_url}:sub"
         values   = var.oidc_fully_qualified_subjects
       }
     }
@@ -34,7 +35,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       for_each = length(var.oidc_subjects_with_wildcards) > 0 ? [1] : []
       content {
         test     = "StringLike"
-        variable = "${var.provider_url}:sub"
+        variable = "${local.provider_url}:sub"
         values   = var.oidc_subjects_with_wildcards
       }
     }


### PR DESCRIPTION
The OIDC URL returned from the AWS API and https://github.com/terraform-aws-modules/terraform-aws-eks
contains the https:// scheme in the URL, this handles removing it
automatically, as required for correctly creating IAM policies.