### PR TITLE
Fix IAM OIDC conditions

### DIFF
--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -21,20 +21,20 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
     }
 
     dynamic "condition" {
-      for_each = var.oidc_fully_qualified_subjects
+      for_each = length(var.oidc_fully_qualified_subjects) > 0 ? [true] : []
       content {
         test     = "StringEquals"
         variable = "${var.provider_url}:sub"
-        values   = [condition.value]
+        values   = var.oidc_fully_qualified_subjects
       }
     }
 
     dynamic "condition" {
-      for_each = var.oidc_subjects_with_wildcards
+      for_each = length(var.oidc_subjects_with_wildcards) > 0 ? [true] : []
       content {
         test     = "StringLike"
         variable = "${var.provider_url}:sub"
-        values   = [condition.value]
+        values   = var.oidc_subjects_with_wildcards
       }
     }
   }


### PR DESCRIPTION
## Description
Current implementation uses only the first value in the list as IAM condition types can be used only once, this should actually fail as its invalid policy but AWS seems to just ignore the rest.

Details at: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_multi-value-conditions.html

## Motivation and Context
Fixes IAM trust relationship for multiple OIDC subjects.

## Breaking Changes
N/A

## How Has This Been Tested?
- Empty `oidc_fully_qualified_subjects`
- Single `oidc_fully_qualified_subjects`
- Multiple `oidc_fully_qualified_subjects`