### PR TITLE
docs: Add note about pgp_key when create_iam_login_profile is set

### DIFF
--- a/examples/iam-account/README.md
+++ b/examples/iam-account/README.md
@@ -15,6 +15,10 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.

--- a/examples/iam-assumable-role-with-oidc/README.md
+++ b/examples/iam-assumable-role-with-oidc/README.md
@@ -15,6 +15,10 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.

--- a/examples/iam-assumable-role/README.md
+++ b/examples/iam-assumable-role/README.md
@@ -17,6 +17,10 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.

--- a/examples/iam-assumable-roles-with-saml/README.md
+++ b/examples/iam-assumable-roles-with-saml/README.md
@@ -15,6 +15,10 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |

--- a/examples/iam-assumable-roles/README.md
+++ b/examples/iam-assumable-roles/README.md
@@ -15,6 +15,10 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.

--- a/examples/iam-group-complete/README.md
+++ b/examples/iam-group-complete/README.md
@@ -17,6 +17,10 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.

--- a/examples/iam-group-with-assumable-roles-policy/README.md
+++ b/examples/iam-group-with-assumable-roles-policy/README.md
@@ -15,6 +15,10 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |

--- a/examples/iam-group-with-policies/README.md
+++ b/examples/iam-group-with-policies/README.md
@@ -15,6 +15,10 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |

--- a/examples/iam-policy/README.md
+++ b/examples/iam-policy/README.md
@@ -15,6 +15,10 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |

--- a/examples/iam-user/README.md
+++ b/examples/iam-user/README.md
@@ -16,6 +16,10 @@ $ terraform apply
 Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.

--- a/modules/iam-account/README.md
+++ b/modules/iam-account/README.md
@@ -22,6 +22,13 @@ Import successful!
 ``` 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.23 |
+
 ## Providers
 
 | Name | Version |
@@ -31,7 +38,7 @@ Import successful!
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | account\_alias | AWS IAM account alias for this account | `string` | n/a | yes |
 | allow\_users\_to\_change\_password | Whether to allow users to change their own password | `bool` | `true` | no |
 | create\_account\_password\_policy | Whether to create AWS IAM account password policy | `bool` | `true` | no |
@@ -39,7 +46,7 @@ Import successful!
 | hard\_expiry | Whether users are prevented from setting a new password after their password has expired (i.e. require administrator reset) | `bool` | `false` | no |
 | max\_password\_age | The number of days that an user password is valid. | `number` | `0` | no |
 | minimum\_password\_length | Minimum length to require for user passwords | `number` | `8` | no |
-| password\_reuse\_prevention | The number of previous passwords that users are prevented from reusing | `number` | n/a | yes |
+| password\_reuse\_prevention | The number of previous passwords that users are prevented from reusing | `number` | `null` | no |
 | require\_lowercase\_characters | Whether to require lowercase characters for user passwords | `bool` | `true` | no |
 | require\_numbers | Whether to require numbers for user passwords | `bool` | `true` | no |
 | require\_symbols | Whether to require symbols for user passwords | `bool` | `true` | no |

--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -7,6 +7,13 @@ Creates single IAM role which can be assumed by trusted resources using OpenID C
 This module supports IAM Roles for kubernetes service accounts as described in the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.23 |
+
 ## Providers
 
 | Name | Version |
@@ -16,7 +23,7 @@ This module supports IAM Roles for kubernetes service accounts as described in t
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | aws\_account\_id | The AWS account ID where the OIDC provider lives, leave empty to use the account fo the AWS provider | `string` | `""` | no |
 | create\_role | Whether to create a role | `bool` | `false` | no |
 | max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -5,6 +5,13 @@ Creates single IAM role which can be assumed by trusted resources.
 Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns) - typically, AWS accounts and users.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.23 |
+
 ## Providers
 
 | Name | Version |
@@ -14,7 +21,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | admin\_role\_policy\_arn | Policy ARN to use for admin role | `string` | `"arn:aws:iam::aws:policy/AdministratorAccess"` | no |
 | attach\_admin\_policy | Whether to attach an admin policy to a role | `bool` | `false` | no |
 | attach\_poweruser\_policy | Whether to attach a poweruser policy to a role | `bool` | `false` | no |

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -7,6 +7,13 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 [Enabling SAML 2.0 Federated Users to Access the AWS Management Console](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-saml.html) 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.23 |
+
 ## Providers
 
 | Name | Version |
@@ -16,7 +23,7 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | admin\_role\_name | IAM role with admin access | `string` | `"admin"` | no |
 | admin\_role\_path | Path of admin IAM role | `string` | `"/"` | no |
 | admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | `string` | `""` | no |

--- a/modules/iam-assumable-roles/README.md
+++ b/modules/iam-assumable-roles/README.md
@@ -5,6 +5,13 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns) - typically, AWS accounts and users.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.23 |
+
 ## Providers
 
 | Name | Version |
@@ -14,7 +21,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | admin\_role\_name | IAM role with admin access | `string` | `"admin"` | no |
 | admin\_role\_path | Path of admin IAM role | `string` | `"/"` | no |
 | admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | `string` | `""` | no |

--- a/modules/iam-group-with-assumable-roles-policy/README.md
+++ b/modules/iam-group-with-assumable-roles-policy/README.md
@@ -3,6 +3,13 @@
 Creates IAM group with users who are allowed to assume IAM roles. This is typically done in resource AWS account where IAM users can jump into from IAM AWS account.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.23 |
+
 ## Providers
 
 | Name | Version |
@@ -12,7 +19,7 @@ Creates IAM group with users who are allowed to assume IAM roles. This is typica
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | assumable\_roles | List of IAM roles ARNs which can be assumed by the group | `list(string)` | `[]` | no |
 | group\_users | List of IAM users to have in an IAM group which can assume the role | `list(string)` | `[]` | no |
 | name | Name of IAM policy and IAM group | `string` | n/a | yes |

--- a/modules/iam-group-with-policies/README.md
+++ b/modules/iam-group-with-policies/README.md
@@ -3,6 +3,13 @@
 Creates IAM group with specified IAM policies, and add users into a group.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.23 |
+
 ## Providers
 
 | Name | Version |
@@ -12,7 +19,7 @@ Creates IAM group with specified IAM policies, and add users into a group.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | attach\_iam\_self\_management\_policy | Whether to attach IAM policy which allows IAM users to manage their credentials and MFA | `bool` | `true` | no |
 | aws\_account\_id | AWS account id to use inside IAM policies. If empty, current AWS account ID will be used. | `string` | `""` | no |
 | create\_group | Whether to create IAM group | `bool` | `true` | no |

--- a/modules/iam-policy/README.md
+++ b/modules/iam-policy/README.md
@@ -3,6 +3,13 @@
 Creates IAM policy.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.23 |
+
 ## Providers
 
 | Name | Version |
@@ -12,7 +19,7 @@ Creates IAM policy.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | description | The description of the policy | `string` | `"IAM Policy"` | no |
 | name | The name of the policy | `string` | `""` | no |
 | path | The path of the policy in IAM | `string` | `"/"` | no |

--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -19,6 +19,13 @@ This module outputs commands and PGP messages which can be decrypted either usin
 - `keybase_secret_key_pgp_message`
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.23 |
+
 ## Providers
 
 | Name | Version |
@@ -28,7 +35,7 @@ This module outputs commands and PGP messages which can be decrypted either usin
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | create\_iam\_access\_key | Whether to create IAM access key | `bool` | `true` | no |
 | create\_iam\_user\_login\_profile | Whether to create IAM user login profile | `bool` | `true` | no |
 | create\_user | Whether to create the IAM user | `bool` | `true` | no |
@@ -38,7 +45,7 @@ This module outputs commands and PGP messages which can be decrypted either usin
 | password\_reset\_required | Whether the user should be forced to reset the generated password on first login. | `bool` | `true` | no |
 | path | Desired path for the IAM user | `string` | `"/"` | no |
 | permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the user. | `string` | `""` | no |
-| pgp\_key | Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Used to encrypt password and access key. `pgp_key` is required when `create_iam_user_login_profile` is set to `True` | `string` | `""` | no |
+| pgp\_key | Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Used to encrypt password and access key. `pgp_key` is required when `create_iam_user_login_profile` is set to `true` | `string` | `""` | no |
 | ssh\_key\_encoding | Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH. To retrieve the public key in PEM format, use PEM | `string` | `"SSH"` | no |
 | ssh\_public\_key | The SSH public key. The public key must be encoded in ssh-rsa format or PEM format | `string` | `""` | no |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |

--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -38,7 +38,7 @@ This module outputs commands and PGP messages which can be decrypted either usin
 | password\_reset\_required | Whether the user should be forced to reset the generated password on first login. | `bool` | `true` | no |
 | path | Desired path for the IAM user | `string` | `"/"` | no |
 | permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the user. | `string` | `""` | no |
-| pgp\_key | Either a base-64 encoded PGP public key, or a keybase username in the form keybase:username. Used to encrypt password and access key. | `string` | `""` | no |
+| pgp\_key | Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Used to encrypt password and access key. `pgp_key` is required when `create_iam_user_login_profile` is set to `True` | `string` | `""` | no |
 | ssh\_key\_encoding | Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH. To retrieve the public key in PEM format, use PEM | `string` | `"SSH"` | no |
 | ssh\_public\_key | The SSH public key. The public key must be encoded in ssh-rsa format or PEM format | `string` | `""` | no |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |

--- a/modules/iam-user/variables.tf
+++ b/modules/iam-user/variables.tf
@@ -34,7 +34,7 @@ variable "force_destroy" {
 }
 
 variable "pgp_key" {
-  description = "Either a base-64 encoded PGP public key, or a keybase username in the form keybase:username. Used to encrypt password and access key."
+  description = "Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Used to encrypt password and access key. `pgp_key` is required when `create_iam_user_login_profile` is set to `true`"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The pgp_key is only required if `create_iam_login_profile` is set. This should be reflected in README. It addresses the issue #39.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> Documentation is somehow misleading
<!--- If it fixes an open issue, please link to the isse here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
