### PR TITLE
feat: modules/iam-user - Output SMTP password generated with SigV4 algorithm

### DIFF
--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -64,7 +64,8 @@ This module outputs commands and PGP messages which can be decrypted either usin
 | this\_iam\_access\_key\_id | The access key ID |
 | this\_iam\_access\_key\_key\_fingerprint | The fingerprint of the PGP key used to encrypt the secret |
 | this\_iam\_access\_key\_secret | The access key secret |
-| this\_iam\_access\_key\_ses\_smtp\_password | The secret access key converted into an SES SMTP password |
+| this\_iam\_access\_key\_ses\_smtp\_password | DEPRECATED: The secret access key converted into an SES SMTP password by applying AWS's SigV2 conversion algorithm |
+| this\_iam\_access\_key\_ses\_smtp\_password_v4 | The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorith |
 | this\_iam\_access\_key\_status | Active or Inactive. Keys are initially active, but can be made inactive by other means. |
 | this\_iam\_user\_arn | The ARN assigned by AWS for this user |
 | this\_iam\_user\_login\_profile\_encrypted\_password | The encrypted password, base64 encoded |

--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -24,13 +24,13 @@ This module outputs commands and PGP messages which can be decrypted either usin
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.6 |
-| aws | ~> 2.23 |
+| aws | ~> 2.50 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.23 |
+| aws | ~> 2.50 |
 
 ## Inputs
 
@@ -65,7 +65,7 @@ This module outputs commands and PGP messages which can be decrypted either usin
 | this\_iam\_access\_key\_key\_fingerprint | The fingerprint of the PGP key used to encrypt the secret |
 | this\_iam\_access\_key\_secret | The access key secret |
 | this\_iam\_access\_key\_ses\_smtp\_password | DEPRECATED: The secret access key converted into an SES SMTP password by applying AWS's SigV2 conversion algorithm |
-| this\_iam\_access\_key\_ses\_smtp\_password_v4 | The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorith |
+| this\_iam\_access\_key\_ses\_smtp\_password\_v4 | The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm |
 | this\_iam\_access\_key\_status | Active or Inactive. Keys are initially active, but can be made inactive by other means. |
 | this\_iam\_user\_arn | The ARN assigned by AWS for this user |
 | this\_iam\_user\_login\_profile\_encrypted\_password | The encrypted password, base64 encoded |

--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -57,11 +57,23 @@ output "this_iam_access_key_encrypted_secret" {
 }
 
 output "this_iam_access_key_ses_smtp_password" {
-  description = "The secret access key converted into an SES SMTP password"
+  description = "DEPRECATED: The secret access key converted into an SES SMTP password by applying AWS's SigV2 conversion algorithm"
   value = element(
     concat(
       aws_iam_access_key.this.*.ses_smtp_password,
       aws_iam_access_key.this_no_pgp.*.ses_smtp_password,
+      [""],
+    ),
+    0,
+  )
+}
+
+output "this_iam_access_key_ses_smtp_password_v4" {
+  description = "The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm"
+  value = element(
+    concat(
+      aws_iam_access_key.this.*.ses_smtp_password_v4,
+      aws_iam_access_key.this_no_pgp.*.ses_smtp_password_v4,
       [""],
     ),
     0,

--- a/modules/iam-user/versions.tf
+++ b/modules/iam-user/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = "~> 2.50"
   }
 }


### PR DESCRIPTION
## Description
This PR changes output value of `this_iam_access_key_ses_smtp_password` in `iam-user` submodule from deprecated attribute ` ses_smtp_password` to new one `ses_smtp_password_v4`, referencing secret access key converted into an SES SMTP password by applying AWS's documented Sigv4 conversion algorithm.

## Motivation and Context
The SES SMTP interface no longer supports legacy AWS's SigV2 conversion algorithm and only works with Sigv4:
https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html
The change was introduced in AWS provider version `2.50`.
https://www.terraform.io/docs/providers/aws/r/iam_access_key.html#ses_smtp_password_v4
terraform-providers/terraform-provider-aws#11143
terraform-providers/terraform-provider-aws#11144

## Breaking Changes
Since the old SigV2 signed passwords no longer work for AWS SES SMTP authentication, there is really no breaking changes. The module will output the SMTP password by converting existing secret access key with the new algorithm. 

## How Has This Been Tested?
This could be tested by applying the following Terraform file and sending email via regional AWS SES SMTP interface with outputted login and password.

```tf
variable "region" {
  type = string
}

provider "aws" {
  region = var.region
}

module "send_email_iam_policy" {
  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
  version = "2.8.0"

  name        = "AWSSESSendEmail"
  path        = "/"
  description = "Allow to send email via AWS SES SMTP interface"

  policy = <<EOF
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": "ses:SendRawEmail",
            "Resource": "*"
        }
    ]
}
EOF
}

module "smtp_user" {
  # Patched module with secret access key converted into an SES SMTP password
  # by applying AWS's documented Sigv4 conversion algorithm.
  source = "github.com/vutny/terraform-aws-iam//modules/iam-user?ref=ses-smtp-password-sigv4"

  name                          = "smtp-user"
  force_destroy                 = true
  create_iam_user_login_profile = false
  password_reset_required       = false
}

module "iam_group_with_policies" {
  source  = "terraform-aws-modules/iam/aws//modules/iam-group-with-policies"
  version = "2.8.0"

  name = "smtp"

  group_users = [
    "smtp-user",
  ]

  attach_iam_self_management_policy = false

  custom_group_policy_arns = [
    module.send_email_iam_policy.arn,
  ]
}

output "smtp_user" {
  value       = module.smtp_user.this_iam_access_key_id
  description = "SMTP user"
}

output "smtp_password" {
  value       = module.smtp_user.this_iam_access_key_ses_smtp_password_v4
  description = "SMTP password"
}
```