### PR TITLE
Fix conditions with multiple subjects in assume role with oidc policy

### DIFF
--- a/examples/iam-assumable-role-with-oidc/main.tf
+++ b/examples/iam-assumable-role-with-oidc/main.tf
@@ -21,4 +21,6 @@ module "iam_assumable_role_admin" {
   role_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
   ]
+
+  oidc_fully_qualified_subjects = ["system:serviceaccount:default:sa1","system:serviceaccount:default:sa2"]
 }

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -21,20 +21,21 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
     }
 
     dynamic "condition" {
-      for_each = var.oidc_fully_qualified_subjects
+      for_each = length(var.oidc_fully_qualified_subjects) > 0 ? [1] : []
       content {
         test     = "StringEquals"
         variable = "${var.provider_url}:sub"
-        values   = [condition.value]
+        values   = var.oidc_fully_qualified_subjects
       }
     }
 
+
     dynamic "condition" {
-      for_each = var.oidc_subjects_with_wildcards
+      for_each = length(var.oidc_subjects_with_wildcards) > 0 ? [1] : []
       content {
         test     = "StringLike"
         variable = "${var.provider_url}:sub"
-        values   = [condition.value]
+        values   = var.oidc_subjects_with_wildcards
       }
     }
   }

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -53,13 +53,13 @@ variable "role_policy_arns" {
 
 variable "oidc_fully_qualified_subjects" {
   description = "The fully qualified OIDC subjects to be added to the role policy"
-  type        = list(string)
+  type        = set(string)
   default     = []
 }
 
 variable "oidc_subjects_with_wildcards" {
   description = "The OIDC subject using wildcards to be added to the role policy"
-  type        = list(string)
+  type        = set(string)
   default     = []
 }
 


### PR DESCRIPTION
Fixes #73

## Description
This PR fixes the logic that creates the assume role policy with OIDC to allow users to specify multiple subjects for the policy. 

## Motivation and Context
See #73 

## Breaking Changes
No breaking changes

## How Has This Been Tested?
This PR was tested by extending the example provided with the module (`examples/iam-assumable-role-with-oidc`) with the failing use case reported in #73. Then asking for a plan of that example shows that the policy is now created with two subjects.

```hcl-terraform
  # module.iam_assumable_role_admin.aws_iam_role.this[0] will be created
  + resource "aws_iam_role" "this" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRoleWithWebIdentity"
                      + Condition = {
                          + StringEquals = {
                              + oidc.eks.eu-west-1.amazonaws.com/id/BA9E170D464AF7B92084EF72A69B9DC8:sub = [
                                  + "system:serviceaccount:default:sa2",
                                  + "system:serviceaccount:default:sa1",
                                ]
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::119393867667:oidc-provider/oidc.eks.eu-west-1.amazonaws.com/id/BA9E170D464AF7B92084EF72A69B9DC8"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + max_session_duration  = 3600
      + name                  = "role-with-oidc"
      + path                  = "/"
      + tags                  = {
          + "Role" = "role-with-oidc"
        }
      + unique_id             = (known after apply)
    }
```
