### PR TITLE
feat: modules/iam-assumable-role-with-oidc - Adding role_name_prefix …

### DIFF
--- a/examples/iam-assumable-role-with-oidc/main.tf
+++ b/examples/iam-assumable-role-with-oidc/main.tf
@@ -10,7 +10,7 @@ module "iam_assumable_role_admin" {
 
   create_role = true
 
-  role_name = "role-with-oidc"
+  role_name_prefix = "role-with-oidc"
 
   tags = {
     Role = "role-with-oidc"

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -44,6 +44,7 @@ resource "aws_iam_role" "this" {
   count = var.create_role ? 1 : 0
 
   name                 = var.role_name
+  name_prefix          = var.role_name_prefix
   path                 = var.role_path
   max_session_duration = var.max_session_duration
 

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -24,7 +24,13 @@ variable "tags" {
 variable "role_name" {
   description = "IAM role name"
   type        = string
-  default     = ""
+  default     = null
+}
+
+variable "role_name_prefix" {
+  description = "IAM role name prefix"
+  type        = string
+  default     = null
 }
 
 variable "role_path" {


### PR DESCRIPTION
…variable

Signed-off-by: Alex Snast <alexsn@fb.com>

## Description
Adding the option to pass role_name_prefix variable that will be propagated to underlying aws_iam_role resource.

## Motivation and Context
I'd like to pass a name_prefix instead of name to underlying aws_iam_role resource.

## How Has This Been Tested?
ran terraform plan from `examples/iam-assumable-role-with-oidc` after updating it to use role_naname_prefix instead of role_name.
