### PR TITLE
fix: Allow customisation of trusted_role_actions in iam-assumable-role module

### DIFF
--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -39,6 +39,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | role\_requires\_mfa | Whether role requires MFA | `bool` | `true` | no |
 | tags | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
+| trusted\_role\_actions | Actions of STS that can be used | `list(string)` | `["sts:AssumeRole"]` | no |
 | trusted\_role\_arns | ARNs of AWS entities who can assume these roles | `list(string)` | `[]` | no |
 | trusted\_role\_services | AWS Services that can assume these roles | `list(string)` | `[]` | no |
 

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -39,7 +39,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | role\_requires\_mfa | Whether role requires MFA | `bool` | `true` | no |
 | tags | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
-| trusted\_role\_actions | Actions of STS that can be used | `list(string)` | `["sts:AssumeRole"]` | no |
+| trusted\_role\_actions | Actions of STS | `list(string)` | <pre>[<br>  "sts:AssumeRole"<br>]</pre> | no |
 | trusted\_role\_arns | ARNs of AWS entities who can assume these roles | `list(string)` | `[]` | no |
 | trusted\_role\_services | AWS Services that can assume these roles | `list(string)` | `[]` | no |
 

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -2,7 +2,7 @@ data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"
 
-    actions = ["sts:AssumeRole"]
+    actions = var.trusted_role_actions
 
     principals {
       type        = "AWS"

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -1,3 +1,9 @@
+variable "trusted_role_actions" {
+  description = "Actions of STS"
+  type        = list(string)
+  default     = ["sts:AssumeRole"]
+}
+
 variable "trusted_role_arns" {
   description = "ARNs of AWS entities who can assume these roles"
   type        = list(string)


### PR DESCRIPTION
## Description
Add var to action to can fill out in module iam-assumable-role

## Motivation and Context
We use github actions and the AWS action to get credentials need the sts:TagSession permission as you can read on:
https://github.com/aws-actions/configure-aws-credentials/

## Breaking Changes
Doesn't apply

## How Has This Been Tested?
I tested this changes on my AWS account to ensure that works as I spected
