### PR TITLE
Feature: custom inline policy

### DIFF
--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -51,6 +51,17 @@ variable "role_policy_arns" {
   default     = []
 }
 
+variable "role_policy_statements" {
+  description = "List of inline policy statements to attach to IAM role"
+  type = list(object({
+    sid       = string
+    actions   = list(string)
+    effect    = string
+    resources = list(string)
+  }))
+  default = []
+}
+
 variable "oidc_fully_qualified_subjects" {
   description = "The fully qualified OIDC subjects to be added to the role policy"
   type        = set(string)

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -46,6 +46,20 @@ data "aws_iam_policy_document" "assume_role_with_mfa" {
   }
 }
 
+data "aws_iam_policy_document" "custom" {
+  count = var.create_role && length(var.custom_role_policy_statements) > 0 ? 1 : 0
+
+  dynamic "statement" {
+    for_each = var.custom_role_policy_statements
+    content {
+      sid       = statement.value.sid
+      actions   = statement.value.actions
+      effect    = statement.value.effect
+      resources = statement.value.resources
+    }
+  }
+}
+
 resource "aws_iam_role" "this" {
   count = var.create_role ? 1 : 0
 
@@ -60,6 +74,14 @@ resource "aws_iam_role" "this" {
   assume_role_policy = var.role_requires_mfa ? data.aws_iam_policy_document.assume_role_with_mfa.json : data.aws_iam_policy_document.assume_role.json
 
   tags = var.tags
+}
+
+resource "aws_iam_role_policy" "custom" {
+  count = var.create_role && length(var.custom_role_policy_statements) > 0 ? 1 : 0
+
+  role        = aws_iam_role.this[0].name
+  name_prefix = "custom_"
+  policy      = data.aws_iam_policy_document.custom[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -76,6 +76,17 @@ variable "custom_role_policy_arns" {
   default     = []
 }
 
+variable "custom_role_policy_statements" {
+  description = "List of inline policy statements to attach to IAM role"
+  type = list(object({
+    sid       = string
+    actions   = list(string)
+    effect    = string
+    resources = list(string)
+  }))
+  default = []
+}
+
 # Pre-defined policies
 variable "admin_role_policy_arn" {
   description = "Policy ARN to use for admin role"


### PR DESCRIPTION
## Description
Add support for inline policies in addition to custom policy arns.

## Motivation and Context
We would like to migrate from our self maintained IAM modules to this one. The only missing feature is to support custom inline policy definitions. We don't want to maintain IAM policies, as long as they are not shared with multiple roles. Instead we would like to be able to add inline policies to a role with this module.

## How Has This Been Tested?
This is in a state of a proposal. If you would like to add this feature, we would start to use this implementation in our workspaces and then describe the context on how this has been tested.