### PR TITLE
fix(Federated-OIDC-ARN): work with regions such as Govcloud

### DIFF
--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       type = "Federated"
 
       identifiers = [
-        "arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${var.provider_url}" 
+        "arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${var.provider_url}"
       ]
     }
 

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -4,6 +4,8 @@ locals {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "assume_role_with_oidc" {
   count = var.create_role ? 1 : 0
 

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       type = "Federated"
 
       identifiers = [
-        "arn:aws:iam::${local.aws_account_id}:oidc-provider/${var.provider_url}"
+        "arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${var.provider_url}"
       ]
     }
 

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       type = "Federated"
 
       identifiers = [
-        "arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${var.provider_url}"
+        "arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${var.provider_url}" 
       ]
     }
 


### PR DESCRIPTION
## Description
Override hard-coding of aws partition and use computed partition instead

## Motivation and Context
For example this is an invalid ARN in govcloud:
   arn:aws:iam::431345505690:oidc-provider/oidc.eks.us-gov-east-1.amazonaws.com/id/xyz
This is valid:
  arn:aws-us-gov:iam::431345505690:oidc-provider/oidc.eks.us-gov-east-1.amazonaws.com/id/xyz

Note that this computed partition is used elsewhere within this module, but has been overlooked here.

## Breaking Changes
no

## How Has This Been Tested?
have tested the equivalent logic locally by using terraform's replace() function around the results of this module
