### PR TITLE
fix: Allow modules/iam-assumable-role-with-oidc to work in govcloud

### DIFF
--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -4,6 +4,8 @@ locals {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "assume_role_with_oidc" {
   count = var.create_role ? 1 : 0
 
@@ -16,7 +18,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       type = "Federated"
 
       identifiers = [
-        "arn:aws:iam::${local.aws_account_id}:oidc-provider/${var.provider_url}"
+        "arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${var.provider_url}"
       ]
     }
 


### PR DESCRIPTION
by using the current partition instead of hardcoding "aws"

## Description
Currently this module does not work in govcloud because it hardcodes "arn:aws:...", while govcloud uses ARNs of the form "arn:aws-gov". This changes to use the documented technique for getting the current partition.

## Breaking Changes
None.

## How Has This Been Tested?

I have verified in a local Xometry environment that this produces correct and working IAM role definitions for both govcloud and non-govcloud environments.
