### PR TITLE
feat: Support for Terraform v0.13 and AWS provider v3

### DIFF
--- a/modules/iam-account/versions.tf
+++ b/modules/iam-account/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23, < 4.0"
   }
 }

--- a/modules/iam-assumable-role-with-oidc/versions.tf
+++ b/modules/iam-assumable-role-with-oidc/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23, < 4.0"
   }
 }

--- a/modules/iam-assumable-role/versions.tf
+++ b/modules/iam-assumable-role/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23, < 4.0"
   }
 }

--- a/modules/iam-assumable-roles-with-saml/versions.tf
+++ b/modules/iam-assumable-roles-with-saml/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23, < 4.0"
   }
 }

--- a/modules/iam-assumable-roles/versions.tf
+++ b/modules/iam-assumable-roles/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23, < 4.0"
   }
 }

--- a/modules/iam-group-with-assumable-roles-policy/versions.tf
+++ b/modules/iam-group-with-assumable-roles-policy/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23, < 4.0"
   }
 }

--- a/modules/iam-group-with-policies/versions.tf
+++ b/modules/iam-group-with-policies/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23, < 4.0"
   }
 }

--- a/modules/iam-policy/versions.tf
+++ b/modules/iam-policy/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = ">= 2.23, < 4.0"
   }
 }

--- a/modules/iam-user/versions.tf
+++ b/modules/iam-user/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.50"
+    aws = ">= 2.50, < 4.0"
   }
 }


### PR DESCRIPTION
## Description
Terraform v0.13 feature count on modules.
Additionally, AWS provider v3.0 is released and should be supported.

## Motivation and Context
Many of us have already upgraded to Terraform 0.13 and this module is incompatible.

## Breaking Changes
[Terraform](https://github.com/hashicorp/terraform/releases/tag/v0.13.0)
[AWS provider](https://github.com/terraform-providers/terraform-provider-aws/releases/tag/v3.0.0)

## How Has This Been Tested?
Anecdotally tested with our Terraform Cloud setup.

## Issues
https://github.com/terraform-aws-modules/terraform-aws-iam/issues/84
https://github.com/terraform-aws-modules/terraform-aws-iam/issues/85