### PR TITLE
fix: Delete DEPRECATED ses_smtp_password in iam-user.

### DIFF
--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -64,7 +64,6 @@ This module outputs commands and PGP messages which can be decrypted either usin
 | this\_iam\_access\_key\_id | The access key ID |
 | this\_iam\_access\_key\_key\_fingerprint | The fingerprint of the PGP key used to encrypt the secret |
 | this\_iam\_access\_key\_secret | The access key secret |
-| this\_iam\_access\_key\_ses\_smtp\_password | DEPRECATED: The secret access key converted into an SES SMTP password by applying AWS's SigV2 conversion algorithm |
 | this\_iam\_access\_key\_ses\_smtp\_password\_v4 | The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm |
 | this\_iam\_access\_key\_status | Active or Inactive. Keys are initially active, but can be made inactive by other means. |
 | this\_iam\_user\_arn | The ARN assigned by AWS for this user |

--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -56,18 +56,6 @@ output "this_iam_access_key_encrypted_secret" {
   value       = element(concat(aws_iam_access_key.this.*.encrypted_secret, [""]), 0)
 }
 
-output "this_iam_access_key_ses_smtp_password" {
-  description = "DEPRECATED: The secret access key converted into an SES SMTP password by applying AWS's SigV2 conversion algorithm"
-  value = element(
-    concat(
-      aws_iam_access_key.this.*.ses_smtp_password,
-      aws_iam_access_key.this_no_pgp.*.ses_smtp_password,
-      [""],
-    ),
-    0,
-  )
-}
-
 output "this_iam_access_key_ses_smtp_password_v4" {
   description = "The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm"
   value = element(


### PR DESCRIPTION
## Description

`iam-user`'s output ses_smtp_password is cannot access error.

```zsh
Error: Unsupported attribute

  on .terraform/modules/iam_user_test/modules/iam-user/outputs.tf line 63, in output "this_iam_access_key_ses_smtp_password":
  63:       aws_iam_access_key.this.*.ses_smtp_password,

This object does not have an attribute named "ses_smtp_password".
```

## Motivation and Context
Cannot create iam-user.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
