### PR TITLE
feature: add sts:ExternalId

### DIFF
--- a/examples/iam-assumable-role/main.tf
+++ b/examples/iam-assumable-role/main.tf
@@ -48,6 +48,8 @@ module "iam_assumable_role_custom" {
   role_name         = "custom"
   role_requires_mfa = false
 
+  role_sts_externalid = "some-id-goes-here"
+
   custom_role_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonCognitoReadOnly",
     "arn:aws:iam::aws:policy/AlexaForBusinessFullAccess",

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -39,6 +39,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | role\_path | Path of IAM role | `string` | `"/"` | no |
 | role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | role\_requires\_mfa | Whether role requires MFA | `bool` | `true` | no |
+| sts\_externalid | STS ExternalId condition value | `string` | `""` | no |
 | tags | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
 | trusted\_role\_actions | Actions of STS | `list(string)` | <pre>[<br>  "sts:AssumeRole"<br>]</pre> | no |
 | trusted\_role\_arns | ARNs of AWS entities who can assume these roles | `list(string)` | `[]` | no |
@@ -49,6 +50,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | Name | Description |
 |------|-------------|
 | role\_requires\_mfa | Whether IAM role requires MFA |
+| role\_sts\_externalid | STS ExternalId condition value |
 | this\_iam\_instance\_profile\_arn | ARN of IAM instance profile |
 | this\_iam\_instance\_profile\_name | Name of IAM instance profile |
 | this\_iam\_instance\_profile\_path | Path of IAM instance profile |

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -39,7 +39,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | role\_path | Path of IAM role | `string` | `"/"` | no |
 | role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | role\_requires\_mfa | Whether role requires MFA | `bool` | `true` | no |
-| sts\_externalid | STS ExternalId condition value | `string` | `""` | no |
+| role\_sts\_externalid | STS ExternalId condition value to use with a role (when MFA is not required) | `string` | `null` | no |
 | tags | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
 | trusted\_role\_actions | Actions of STS | `list(string)` | <pre>[<br>  "sts:AssumeRole"<br>]</pre> | no |
 | trusted\_role\_arns | ARNs of AWS entities who can assume these roles | `list(string)` | `[]` | no |
@@ -50,7 +50,7 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | Name | Description |
 |------|-------------|
 | role\_requires\_mfa | Whether IAM role requires MFA |
-| role\_sts\_externalid | STS ExternalId condition value |
+| role\_sts\_externalid | STS ExternalId condition value to use with a role |
 | this\_iam\_instance\_profile\_arn | ARN of IAM instance profile |
 | this\_iam\_instance\_profile\_name | Name of IAM instance profile |
 | this\_iam\_instance\_profile\_path | Path of IAM instance profile |

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -13,6 +13,15 @@ data "aws_iam_policy_document" "assume_role" {
       type        = "Service"
       identifiers = var.trusted_role_services
     }
+
+    dynamic "condition" {
+      for_each = length(var.sts_externalid) > 0 ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "sts:ExternalId"
+        values   = [var.sts_externalid]
+      }
+    }
   }
 }
 

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -15,11 +15,11 @@ data "aws_iam_policy_document" "assume_role" {
     }
 
     dynamic "condition" {
-      for_each = length(var.sts_externalid) > 0 ? [1] : []
+      for_each = var.role_sts_externalid != null ? [true] : []
       content {
         test     = "StringEquals"
         variable = "sts:ExternalId"
-        values   = [var.sts_externalid]
+        values   = [var.role_sts_externalid]
       }
     }
   }

--- a/modules/iam-assumable-role/outputs.tf
+++ b/modules/iam-assumable-role/outputs.tf
@@ -34,7 +34,7 @@ output "this_iam_instance_profile_path" {
 }
 
 output "role_sts_externalid" {
-  description = "STS ExternalId condition value"
-  value       = var.sts_externalid
+  description = "STS ExternalId condition value to use with a role"
+  value       = var.role_sts_externalid
 }
 

--- a/modules/iam-assumable-role/outputs.tf
+++ b/modules/iam-assumable-role/outputs.tf
@@ -32,3 +32,9 @@ output "this_iam_instance_profile_path" {
   description = "Path of IAM instance profile"
   value       = element(concat(aws_iam_instance_profile.this.*.path, [""]), 0)
 }
+
+output "role_sts_externalid" {
+  description = "STS ExternalId condition value"
+  value       = var.sts_externalid
+}
+

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -125,9 +125,9 @@ variable "role_description" {
   default     = ""
 }
 
-variable "sts_externalid" {
-  description = "STS ExternalId condition value"
+variable "role_sts_externalid" {
+  description = "STS ExternalId condition value to use with a role (when MFA is not required)"
   type        = string
-  default     = ""
+  default     = null
 }
 

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -125,3 +125,9 @@ variable "role_description" {
   default     = ""
 }
 
+variable "sts_externalid" {
+  description = "STS ExternalId condition value"
+  type        = string
+  default     = ""
+}
+


### PR DESCRIPTION
## Description
- Add support of sts:ExternalId

## Motivation and Context
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html - sometimes service integration require ExternalId instead of MFA.
 
## Breaking Changes
None

## How Has This Been Tested?
I've tested in my environment having this kind of setup:

```
module "iam_assume_role_in_prod_testrole" {
  source = "git::https://github.com/LAKostis/terraform-aws-iam.git//modules/iam-assumable-role?ref=feature/add-sts-externalid-support"

  trusted_role_arns = [
    "arn:aws:iam::${var.some_account_id}:root",
  ]

  create_role = true

  role_name         = "DatadogAWSIntegrationRole"
  role_requires_mfa = false

  sts_externalid = var.datadog_sts_id

  custom_role_policy_arns = [
    "arn:aws:iam::${data.aws_caller_identity.test.account_id}:policy/DatadogAWSIntegrationPolicy",
  ]

  providers = {
    aws = aws.test
  }
}
```
