### PR TITLE
fix: simplify count statements

### DIFF
--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {
-  count = var.create_role && length(var.role_policy_arns) > 0 ? length(var.role_policy_arns) : 0
+  count = var.create_role ? length(var.role_policy_arns) : 0
 
   role       = join("", aws_iam_role.this.*.name)
   policy_arn = var.role_policy_arns[count.index]

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -72,7 +72,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {
-  count = var.create_role && length(var.custom_role_policy_arns) > 0 ? length(var.custom_role_policy_arns) : 0
+  count = var.create_role ? length(var.custom_role_policy_arns) : 0
 
   role       = aws_iam_role.this[0].name
   policy_arn = element(var.custom_role_policy_arns, count.index)

--- a/modules/iam-group-with-policies/main.tf
+++ b/modules/iam-group-with-policies/main.tf
@@ -27,14 +27,14 @@ resource "aws_iam_group_policy_attachment" "iam_self_management" {
 }
 
 resource "aws_iam_group_policy_attachment" "custom_arns" {
-  count = length(var.custom_group_policy_arns) > 0 ? length(var.custom_group_policy_arns) : 0
+  count = length(var.custom_group_policy_arns)
 
   group      = local.group_name
   policy_arn = element(var.custom_group_policy_arns, count.index)
 }
 
 resource "aws_iam_group_policy_attachment" "custom" {
-  count = length(var.custom_group_policies) > 0 ? length(var.custom_group_policies) : 0
+  count = length(var.custom_group_policies)
 
   group      = local.group_name
   policy_arn = element(aws_iam_policy.custom.*.arn, count.index)
@@ -51,7 +51,7 @@ resource "aws_iam_policy" "iam_self_management" {
 }
 
 resource "aws_iam_policy" "custom" {
-  count = length(var.custom_group_policies) > 0 ? length(var.custom_group_policies) : 0
+  count = length(var.custom_group_policies)
 
   name        = var.custom_group_policies[count.index]["name"]
   policy      = var.custom_group_policies[count.index]["policy"]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Simplify Count statement in 2 cases of policy attachments as it causes failures during apply in some cases

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simplify Count statement in 2 cases of policy attachments as it causes failures during apply in some cases

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes.
