### PR TITLE
feat: Add role description variable for assumable role with oidc

### DIFF
--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -33,6 +33,7 @@ This module supports IAM Roles for kubernetes service accounts as described in t
 | provider\_url | URL of the OIDC Provider. Use provider\_urls to specify several URLs. | `string` | `""` | no |
 | provider\_urls | List of URLs of the OIDC Providers | `list(string)` | `[]` | no |
 | role\_name | IAM role name | `string` | `""` | no |
+| role\_description | IAM Role description | `string` | `""` | no |
 | role\_path | Path of IAM role | `string` | `"/"` | no |
 | role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | role\_policy\_arns | List of ARNs of IAM policies to attach to IAM role | `list(string)` | `[]` | no |

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -54,6 +54,7 @@ resource "aws_iam_role" "this" {
   count = var.create_role ? 1 : 0
 
   name                 = var.role_name
+  description          = var.role_description
   path                 = var.role_path
   max_session_duration = var.max_session_duration
 

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -34,6 +34,12 @@ variable "role_name" {
   default     = ""
 }
 
+variable "role_description" {
+  description = "IAM Role description"
+  type        = string
+  default     = ""
+}
+
 variable "role_path" {
   description = "Path of IAM role"
   type        = string


### PR DESCRIPTION
## Description
Add "role_description" variable for the "assumable-role-with-oidc" module

## Motivation and Context
During a personal project using this excellent module I noticed that the feature to add a description for an oidc role was missing.

## Breaking Changes
Nothing breaks, the change is minor. The parts that were added were copy-pasted from the "assumable-role" module.

## How Has This Been Tested?
The change in the module was tested against a role that had no description before and one was added via this branch, and then the description was changed through the same method. No issues detected. 
