### PR TITLE
ci: Update pre-commit-terraform

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.39.0
+    rev: v1.43.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs


### PR DESCRIPTION
Needed with new terraform-docs

## Description

Update to latest `pre-commit-terraform` release

## Motivation and Context

The old pre-commit-terraform was failing to update README.md with a new install and new terraform-docs (`0.10.1`). This was stopping me from making a functional PR

## Breaking Changes

No known breaking changes

## How Has This Been Tested?

Run locally
