### PR TITLE
fix: Adhere to Checkov security recommendations

### DIFF
--- a/modules/iam-account/variables.tf
+++ b/modules/iam-account/variables.tf
@@ -18,7 +18,7 @@ variable "create_account_password_policy" {
 variable "max_password_age" {
   description = "The number of days that an user password is valid."
   type        = number
-  default     = 0
+  default     = 90
 }
 
 variable "minimum_password_length" {

--- a/modules/iam-account/variables.tf
+++ b/modules/iam-account/variables.tf
@@ -24,7 +24,7 @@ variable "max_password_age" {
 variable "minimum_password_length" {
   description = "Minimum length to require for user passwords"
   type        = number
-  default     = 8
+  default     = 14
 }
 
 variable "allow_users_to_change_password" {


### PR DESCRIPTION
## Description
I ran [Checkov](https://github.com/bridgecrewio/checkov) against this repository and got two errors shown below:

```
Check: CKV_AWS_9: "Ensure IAM password policy expires passwords within 90 days or less"
        FAILED for resource: aws_iam_account_password_policy.this
        File: /iam-account/main.tf:9-21
        Guide: https://docs.bridgecrew.io/docs/iam_11

                9  | resource "aws_iam_account_password_policy" "this" {
                10 |   count = var.create_account_password_policy ? 1 : 0
                11 | 
                12 |   max_password_age               = var.max_password_age
                13 |   minimum_password_length        = var.minimum_password_length
                14 |   allow_users_to_change_password = var.allow_users_to_change_password
                15 |   hard_expiry                    = var.hard_expiry
                16 |   password_reuse_prevention      = var.password_reuse_prevention
                17 |   require_lowercase_characters   = var.require_lowercase_characters
                18 |   require_uppercase_characters   = var.require_uppercase_characters
                19 |   require_numbers                = var.require_numbers
                20 |   require_symbols                = var.require_symbols
                21 | }

        Variable create_account_password_policy (of /iam-account/variables.tf) evaluated to value "True" in expression: count = ${var.create_account_password_policy ? 1 : 0}
        Variable max_password_age (of /iam-account/variables.tf) evaluated to value "0" in expression: max_password_age = ${var.max_password_age}
        Variable minimum_password_length (of /iam-account/variables.tf) evaluated to value "8" in expression: minimum_password_length = ${var.minimum_password_length}
        Variable allow_users_to_change_password (of /iam-account/variables.tf) evaluated to value "True" in expression: allow_users_to_change_password = ${var.allow_users_to_change_password}
        Variable hard_expiry (of /iam-account/variables.tf) evaluated to value "False" in expression: hard_expiry = ${var.hard_expiry}
        Variable require_lowercase_characters (of /iam-account/variables.tf) evaluated to value "True" in expression: require_lowercase_characters = ${var.require_lowercase_characters}
        Variable require_uppercase_characters (of /iam-account/variables.tf) evaluated to value "True" in expression: require_uppercase_characters = ${var.require_uppercase_characters}
        Variable require_numbers (of /iam-account/variables.tf) evaluated to value "True" in expression: require_numbers = ${var.require_numbers}
        Variable require_symbols (of /iam-account/variables.tf) evaluated to value "True" in expression: require_symbols = ${var.require_symbols}

Check: CKV_AWS_10: "Ensure IAM password policy requires minimum length of 14 or greater"
        FAILED for resource: aws_iam_account_password_policy.this
        File: /iam-account/main.tf:9-21
        Guide: https://docs.bridgecrew.io/docs/iam_9-1

                9  | resource "aws_iam_account_password_policy" "this" {
                10 |   count = var.create_account_password_policy ? 1 : 0
                11 | 
                12 |   max_password_age               = var.max_password_age
                13 |   minimum_password_length        = var.minimum_password_length
                14 |   allow_users_to_change_password = var.allow_users_to_change_password
                15 |   hard_expiry                    = var.hard_expiry
                16 |   password_reuse_prevention      = var.password_reuse_prevention
                17 |   require_lowercase_characters   = var.require_lowercase_characters
                18 |   require_uppercase_characters   = var.require_uppercase_characters
                19 |   require_numbers                = var.require_numbers
                20 |   require_symbols                = var.require_symbols
                21 | }

        Variable create_account_password_policy (of /iam-account/variables.tf) evaluated to value "True" in expression: count = ${var.create_account_password_policy ? 1 : 0}
        Variable max_password_age (of /iam-account/variables.tf) evaluated to value "0" in expression: max_password_age = ${var.max_password_age}
        Variable minimum_password_length (of /iam-account/variables.tf) evaluated to value "8" in expression: minimum_password_length = ${var.minimum_password_length}
        Variable allow_users_to_change_password (of /iam-account/variables.tf) evaluated to value "True" in expression: allow_users_to_change_password = ${var.allow_users_to_change_password}
        Variable hard_expiry (of /iam-account/variables.tf) evaluated to value "False" in expression: hard_expiry = ${var.hard_expiry}
        Variable require_lowercase_characters (of /iam-account/variables.tf) evaluated to value "True" in expression: require_lowercase_characters = ${var.require_lowercase_characters}
        Variable require_uppercase_characters (of /iam-account/variables.tf) evaluated to value "True" in expression: require_uppercase_characters = ${var.require_uppercase_characters}
        Variable require_numbers (of /iam-account/variables.tf) evaluated to value "True" in expression: require_numbers = ${var.require_numbers}
        Variable require_symbols (of /iam-account/variables.tf) evaluated to value "True" in expression: require_symbols = ${var.require_symbols}
```

## Motivation and Context
I'm creating this PR to align with Checkov recommendations from a security perspective.

References:

`max_password_age` = 90 | https://docs.bridgecrew.io/docs/iam_11
`minimum_password_length` = 14 | https://docs.bridgecrew.io/docs/iam_9-1

## Breaking Changes
It can affect users using the current module as their policies will change after applying this.

## How Has This Been Tested?
I have tested in our environments.