### PR TITLE
Update variables.tf

### DIFF
--- a/modules/iam-user/variables.tf
+++ b/modules/iam-user/variables.tf
@@ -46,9 +46,9 @@ variable "password_reset_required" {
 }
 
 variable "password_length" {
-  description = "The length of the generated password"
+  description = "The length of the generated password. You can type any number from 6 to 128."
   type        = number
-  default     = 20
+  default     = 6
 }
 
 variable "upload_iam_user_ssh_key" {


### PR DESCRIPTION
## Description
Minimum password length.
You can specify the minimum number of characters allowed in an IAM user password. You can type any number from 6 to 128.

## Motivation and Context
This is supported by official document.


