### PR TITLE
iam-assumable-roles-with-saml: Allow for multiple provider ids

### DIFF
--- a/examples/iam-assumable-roles-with-saml/main.tf
+++ b/examples/iam-assumable-roles-with-saml/main.tf
@@ -7,6 +7,11 @@ resource "aws_iam_saml_provider" "idp_saml" {
   saml_metadata_document = file("saml-metadata.xml")
 }
 
+resource "aws_iam_saml_provider" "second_idp_saml" {
+  name                   = "second_idp_saml"
+  saml_metadata_document = file("saml-metadata.xml")
+}
+
 ###############################
 # IAM assumable roles with SAML
 ###############################
@@ -22,6 +27,23 @@ module "iam_assumable_roles_with_saml" {
   create_readonly_role = true
 
   provider_id = aws_iam_saml_provider.idp_saml.id
+}
+
+###############################
+# IAM assumable roles with SAML
+###############################
+
+module "iam_assumable_roles_with_saml_second_provider" {
+  source = "../../modules/iam-assumable-roles-with-saml"
+
+  create_admin_role = true
+
+  create_poweruser_role = true
+  poweruser_role_name   = "developer"
+
+  create_readonly_role = true
+
+  provider_ids = [aws_iam_saml_provider.idp_saml.id, aws_iam_saml_provider.second_idp_saml.id]
 }
 
 #################################################################

--- a/examples/iam-assumable-roles-with-saml/main.tf
+++ b/examples/iam-assumable-roles-with-saml/main.tf
@@ -21,7 +21,7 @@ module "iam_assumable_roles_with_saml" {
 
   create_readonly_role = true
 
-  provider_id = aws_iam_saml_provider.idp_saml.id
+  provider_ids = [aws_iam_saml_provider.idp_saml.id]
 }
 
 #################################################################
@@ -34,5 +34,5 @@ module "iam_assumable_roles_with_saml_custom" {
   poweruser_role_name        = "Billing-And-Support-Access"
   poweruser_role_policy_arns = ["arn:aws:iam::aws:policy/job-function/Billing", "arn:aws:iam::aws:policy/AWSSupportAccess"]
 
-  provider_id = aws_iam_saml_provider.idp_saml.id
+  provider_ids = [aws_iam_saml_provider.idp_saml.id]
 }

--- a/examples/iam-assumable-roles-with-saml/main.tf
+++ b/examples/iam-assumable-roles-with-saml/main.tf
@@ -21,7 +21,7 @@ module "iam_assumable_roles_with_saml" {
 
   create_readonly_role = true
 
-  provider_ids = [aws_iam_saml_provider.idp_saml.id]
+  provider_id = aws_iam_saml_provider.idp_saml.id
 }
 
 #################################################################
@@ -34,5 +34,5 @@ module "iam_assumable_roles_with_saml_custom" {
   poweruser_role_name        = "Billing-And-Support-Access"
   poweruser_role_policy_arns = ["arn:aws:iam::aws:policy/job-function/Billing", "arn:aws:iam::aws:policy/AWSSupportAccess"]
 
-  provider_ids = [aws_iam_saml_provider.idp_saml.id]
+  provider_id = aws_iam_saml_provider.idp_saml.id
 }

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -29,6 +29,7 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 | admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | `string` | `""` | no |
 | admin\_role\_policy\_arns | List of policy ARNs to use for admin role | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/AdministratorAccess"<br>]</pre> | no |
 | admin\_role\_tags | A map of tags to add to admin role resource. | `map(string)` | `{}` | no |
+| aws\_account\_id | The AWS account ID where the SAML provider lives, leave empty to use the current account for the AWS provider | `string` | `""` | no |
 | aws\_saml\_endpoint | AWS SAML Endpoint | `string` | `"https://signin.aws.amazon.com/saml"` | no |
 | create\_admin\_role | Whether to create admin role | `bool` | `false` | no |
 | create\_poweruser\_role | Whether to create poweruser role | `bool` | `false` | no |
@@ -40,7 +41,8 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 | poweruser\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for poweruser role | `string` | `""` | no |
 | poweruser\_role\_policy\_arns | List of policy ARNs to use for poweruser role | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/PowerUserAccess"<br>]</pre> | no |
 | poweruser\_role\_tags | A map of tags to add to poweruser role resource. | `map(string)` | `{}` | no |
-| provider\_id | ID of the SAML Provider | `string` | n/a | yes |
+| provider\_id | ID of the SAML Provider. Use provider\_ids to specify several IDs. | `string` | `""` | no |
+| provider\_ids | List of SAML Provider IDs | `list(string)` | `[]` | no |
 | readonly\_role\_name | IAM role with readonly access | `string` | `"readonly"` | no |
 | readonly\_role\_path | Path of readonly IAM role | `string` | `"/"` | no |
 | readonly\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for readonly role | `string` | `""` | no |

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -29,7 +29,6 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 | admin\_role\_permissions\_boundary\_arn | Permissions boundary ARN to use for admin role | `string` | `""` | no |
 | admin\_role\_policy\_arns | List of policy ARNs to use for admin role | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/AdministratorAccess"<br>]</pre> | no |
 | admin\_role\_tags | A map of tags to add to admin role resource. | `map(string)` | `{}` | no |
-| aws\_account\_id | The AWS account ID where the SAML provider lives, leave empty to use the current account for the AWS provider | `string` | `""` | no |
 | aws\_saml\_endpoint | AWS SAML Endpoint | `string` | `"https://signin.aws.amazon.com/saml"` | no |
 | create\_admin\_role | Whether to create admin role | `bool` | `false` | no |
 | create\_poweruser\_role | Whether to create poweruser role | `bool` | `false` | no |

--- a/modules/iam-assumable-roles-with-saml/main.tf
+++ b/modules/iam-assumable-roles-with-saml/main.tf
@@ -1,15 +1,6 @@
 locals {
-  aws_account_id = var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.current.account_id
-  ids            = compact(distinct(concat(var.provider_ids, [var.provider_id])))
-  identifiers = [
-    for id in local.ids :
-    "arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:saml-provider/${id}"
-  ]
+  identifiers = compact(distinct(concat(var.provider_ids, [var.provider_id])))
 }
-
-data "aws_caller_identity" "current" {}
-
-data "aws_partition" "current" {}
 
 data "aws_iam_policy_document" "assume_role_with_saml" {
   statement {

--- a/modules/iam-assumable-roles-with-saml/main.tf
+++ b/modules/iam-assumable-roles-with-saml/main.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "assume_role_with_saml" {
 
     principals {
       type        = "Federated"
-      identifiers = [var.provider_id]
+      identifiers = var.provider_ids
     }
 
     condition {

--- a/modules/iam-assumable-roles-with-saml/variables.tf
+++ b/modules/iam-assumable-roles-with-saml/variables.tf
@@ -1,6 +1,19 @@
+variable "provider_id" {
+  description = "ID of the SAML Provider. Use provider_ids to specify several IDs."
+  type        = string
+  default     = ""
+}
+
 variable "provider_ids" {
   description = "List of SAML Provider IDs"
   type        = list(string)
+  default     = []
+}
+
+variable "aws_account_id" {
+  description = "The AWS account ID where the SAML provider lives, leave empty to use the current account for the AWS provider"
+  type        = string
+  default     = ""
 }
 
 variable "aws_saml_endpoint" {

--- a/modules/iam-assumable-roles-with-saml/variables.tf
+++ b/modules/iam-assumable-roles-with-saml/variables.tf
@@ -1,6 +1,6 @@
-variable "provider_id" {
-  description = "ID of the SAML Provider"
-  type        = string
+variable "provider_ids" {
+  description = "List of SAML Provider IDs"
+  type        = list(string)
 }
 
 variable "aws_saml_endpoint" {

--- a/modules/iam-assumable-roles-with-saml/variables.tf
+++ b/modules/iam-assumable-roles-with-saml/variables.tf
@@ -10,12 +10,6 @@ variable "provider_ids" {
   default     = []
 }
 
-variable "aws_account_id" {
-  description = "The AWS account ID where the SAML provider lives, leave empty to use the current account for the AWS provider"
-  type        = string
-  default     = ""
-}
-
 variable "aws_saml_endpoint" {
   description = "AWS SAML Endpoint"
   default     = "https://signin.aws.amazon.com/saml"


### PR DESCRIPTION
## Description
The aws_iam_policy_document has support for specifying multiple principle federated identifiers like this:
```
"Principal": {
  "Federated": [
    "arn:aws:iam::012345678912:saml-provider/first",
    "arn:aws:iam::012345678912:saml-provider/second"
  ]
},
```

Currently, this module only supports specifying one provider_id:
```
principals {
  type        = "Federated"
  identifiers = [var.provider_id]
}
```

## Motivation and Context
Solves issue #109 

## Breaking Changes
-

## How Has This Been Tested?
Not yet tested
