### PR TITLE
fix: Multiple provider_urls not working with iam-assumable-role-with-oidc

### DIFF
--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -17,6 +17,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
 
   dynamic "statement" {
     for_each = local.urls
+
     content {
       effect = "Allow"
 
@@ -30,6 +31,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
 
       dynamic "condition" {
         for_each = length(var.oidc_fully_qualified_subjects) > 0 ? local.urls : []
+
         content {
           test     = "StringEquals"
           variable = "${statement.value}:sub"
@@ -39,6 +41,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
 
       dynamic "condition" {
         for_each = length(var.oidc_subjects_with_wildcards) > 0 ? local.urls : []
+
         content {
           test     = "StringLike"
           variable = "${statement.value}:sub"

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -5,10 +5,6 @@ locals {
     for url in compact(distinct(concat(var.provider_urls, [var.provider_url]))) :
     replace(url, "https://", "")
   ]
-  identifiers = [
-    for url in local.urls :
-    "arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${url}"
-  ]
 }
 
 data "aws_caller_identity" "current" {}
@@ -18,33 +14,35 @@ data "aws_partition" "current" {}
 data "aws_iam_policy_document" "assume_role_with_oidc" {
   count = var.create_role ? 1 : 0
 
-  statement {
-    effect = "Allow"
+  dynamic "statement" {
+    for_each = local.urls
+    content {
+      effect = "Allow"
 
-    actions = ["sts:AssumeRoleWithWebIdentity"]
+      actions = ["sts:AssumeRoleWithWebIdentity"]
 
-    principals {
-      type = "Federated"
+      principals {
+        type = "Federated"
 
-      identifiers = local.identifiers
-    }
-
-    dynamic "condition" {
-      for_each = length(var.oidc_fully_qualified_subjects) > 0 ? local.urls : []
-      content {
-        test     = "StringEquals"
-        variable = "${condition.value}:sub"
-        values   = var.oidc_fully_qualified_subjects
+        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${statement.value}"]
       }
-    }
 
+      dynamic "condition" {
+        for_each = length(var.oidc_fully_qualified_subjects) > 0 ? local.urls : []
+        content {
+          test     = "StringEquals"
+          variable = "${statement.value}:sub"
+          values   = var.oidc_fully_qualified_subjects
+        }
+      }
 
-    dynamic "condition" {
-      for_each = length(var.oidc_subjects_with_wildcards) > 0 ? local.urls : []
-      content {
-        test     = "StringLike"
-        variable = "${condition.value}:sub"
-        values   = var.oidc_subjects_with_wildcards
+      dynamic "condition" {
+        for_each = length(var.oidc_subjects_with_wildcards) > 0 ? local.urls : []
+        content {
+          test     = "StringLike"
+          variable = "${statement.value}:sub"
+          values   = var.oidc_subjects_with_wildcards
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fix #114 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #114 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR was tested by extending the example provided with the module (examples/iam-assumable-role-with-oidc).
Also see **expected output** in #114

#### Terraform plan output

```
  # module.iam_assumable_role_admin.aws_iam_role.this[0] will be created
  + resource "aws_iam_role" "this" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRoleWithWebIdentity"
                      + Condition = {
                          + StringEquals = {
                              + oidc.eks.eu-west-1.amazonaws.com/id/AA9E170D464AF7B92084EF72A69B9DC8:sub = [
                                  + "system:serviceaccount:default:sa2",
                                  + "system:serviceaccount:default:sa1",
                                ]
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::530488130478:oidc-provider/oidc.eks.eu-west-1.amazonaws.com/id/AA9E170D464AF7B92084EF72A69B9DC8"
                        }
                      + Sid       = ""
                    },
                  + {
                      + Action    = "sts:AssumeRoleWithWebIdentity"
                      + Condition = {
                          + StringEquals = {
                              + oidc.eks.eu-west-1.amazonaws.com/id/BA9E170D464AF7B92084EF72A69B9DC8:sub = [
                                  + "system:serviceaccount:default:sa2",
                                  + "system:serviceaccount:default:sa1",
                                ]
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::530488130478:oidc-provider/oidc.eks.eu-west-1.amazonaws.com/id/BA9E170D464AF7B92084EF72A69B9DC8"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + max_session_duration  = 3600
      + name                  = "role-with-oidc"
      + path                  = "/"
      + tags                  = {
          + "Role" = "role-with-oidc"
        }
      + unique_id             = (known after apply)
    }
```