### PR TITLE
Fix policy counter

### DIFF
--- a/modules/iam-assumable-role-with-oidc/locals.tf
+++ b/modules/iam-assumable-role-with-oidc/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  number_of_role_policy_arns = length(var.role_policy_arns)
+}

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -68,7 +68,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {
-  count = var.create_role ? length(var.role_policy_arns) : 0
+  count = var.create_role ? local.number_of_role_policy_arns : 0
 
   role       = join("", aws_iam_role.this.*.name)
   policy_arn = var.role_policy_arns[count.index]

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -68,7 +68,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {
-  count = var.create_role ? var.number_of_role_policy_arns : 0
+  count = var.create_role ? length(var.role_policy_arns) : 0
 
   role       = join("", aws_iam_role.this.*.name)
   policy_arn = var.role_policy_arns[count.index]

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -70,13 +70,6 @@ variable "role_policy_arns" {
   default     = []
 }
 
-variable "number_of_role_policy_arns" {
-  description = "Number of IAM policies to attach to IAM role"
-  type        = number
-  default     = 0
-}
-
-
 variable "oidc_fully_qualified_subjects" {
   description = "The fully qualified OIDC subjects to be added to the role policy"
   type        = set(string)

--- a/modules/iam-assumable-role/locals.tf
+++ b/modules/iam-assumable-role/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  number_of_custom_role_policy_arns = length(var.custom_role_policy_arns)
+}

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -72,7 +72,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {
-  count = var.create_role ? var.number_of_custom_role_policy_arns : 0
+  count = var.create_role ? length(var.custom_role_policy_arns) : 0
 
   role       = aws_iam_role.this[0].name
   policy_arn = element(var.custom_role_policy_arns, count.index)

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -72,7 +72,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {
-  count = var.create_role ? length(var.custom_role_policy_arns) : 0
+  count = var.create_role ? local.number_of_custom_role_policy_arns : 0
 
   role       = aws_iam_role.this[0].name
   policy_arn = element(var.custom_role_policy_arns, count.index)

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -76,12 +76,6 @@ variable "custom_role_policy_arns" {
   default     = []
 }
 
-variable "number_of_custom_role_policy_arns" {
-  description = "Number of IAM policies to attach to IAM role"
-  type        = number
-  default     = 0
-}
-
 # Pre-defined policies
 variable "admin_role_policy_arn" {
   description = "Policy ARN to use for admin role"


### PR DESCRIPTION
## Description
changes the `number_of_policy_arns` from a var to a local to remove the need to set this value manually

This is for your consideration, feel free to toss.

## Motivation and Context
having to declare a count of policies is error prone for the end user as well as a breaking change in version from previous versions. By moving this value into a local, we can calculate the number with length() before the resource is created avoiding the potential race condition that caused the previous error to occur while maintaining legacy compatibility.

## Breaking Changes
This reverts the latest change by allowing it to behave predicatbly and thus the extra variables unnessisary. We could leave the old var in place as a "do nothing", but I figured that would confuse things worse.

## How Has This Been Tested?
This has been tested in a local fork, albiet at a small scale (only 6 resources across 3 clusters use this module currently).
