### PR TITLE
fix: automatically determine the number of role policy arns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 terraform.tfstate
 *.tfstate*
 terraform.tfvars
+.terraform.lock.hcl

--- a/examples/iam-assumable-role-with-oidc/main.tf
+++ b/examples/iam-assumable-role-with-oidc/main.tf
@@ -22,7 +22,6 @@ module "iam_assumable_role_admin" {
   role_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
   ]
-  number_of_role_policy_arns = 1
 
   oidc_fully_qualified_subjects = ["system:serviceaccount:default:sa1", "system:serviceaccount:default:sa2"]
 }

--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -28,7 +28,7 @@ This module supports IAM Roles for kubernetes service accounts as described in t
 | create\_role | Whether to create a role | `bool` | `false` | no |
 | force\_detach\_policies | Whether policies should be detached from this role when destroying | `bool` | `false` | no |
 | max\_session\_duration | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
-| number\_of\_role\_policy\_arns | Number of IAM policies to attach to IAM role | `number` | `0` | no |
+| number\_of\_role\_policy\_arns | Number of IAM policies to attach to IAM role | `number` | `null` | no |
 | oidc\_fully\_qualified\_subjects | The fully qualified OIDC subjects to be added to the role policy | `set(string)` | `[]` | no |
 | oidc\_subjects\_with\_wildcards | The OIDC subject using wildcards to be added to the role policy | `set(string)` | `[]` | no |
 | provider\_url | URL of the OIDC Provider. Use provider\_urls to specify several URLs. | `string` | `""` | no |

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -9,6 +9,7 @@ locals {
     for url in local.urls :
     "arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${url}"
   ]
+  number_of_role_policy_arns = var.number_of_role_policy_arns == null ? length(var.role_policy_arns) : var.number_of_role_policy_arns
 }
 
 data "aws_caller_identity" "current" {}
@@ -68,7 +69,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {
-  count = var.create_role ? var.number_of_role_policy_arns : 0
+  count = var.create_role ? local.number_of_role_policy_arns : 0
 
   role       = join("", aws_iam_role.this.*.name)
   policy_arn = var.role_policy_arns[count.index]

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -9,7 +9,7 @@ locals {
     for url in local.urls :
     "arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${url}"
   ]
-  number_of_role_policy_arns = var.number_of_role_policy_arns == null ? length(var.role_policy_arns) : var.number_of_role_policy_arns
+  number_of_role_policy_arns = coalesce(var.number_of_role_policy_arns, length(var.role_policy_arns))
 }
 
 data "aws_caller_identity" "current" {}

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -73,7 +73,7 @@ variable "role_policy_arns" {
 variable "number_of_role_policy_arns" {
   description = "Number of IAM policies to attach to IAM role"
   type        = number
-  default     = 0
+  default     = null
 }
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changed to automatically calculate `number_of_role_policy_arns` even if you omit this.

Added backward compatibility to #116

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
By default the `number_of_role_policy_arns` should be calculated automatically, but it can be also specified explicitly as variable.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Probably not

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Use new example.