### PR TITLE
Adds create flag to iam-policy module

### DIFF
--- a/modules/iam-policy/README.md
+++ b/modules/iam-policy/README.md
@@ -20,6 +20,7 @@ Creates IAM policy.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| create | Whether to create a policy | `bool` | `true` | no |
 | description | The description of the policy | `string` | `"IAM Policy"` | no |
 | name | The name of the policy | `string` | `""` | no |
 | path | The path of the policy in IAM | `string` | `"/"` | no |

--- a/modules/iam-policy/main.tf
+++ b/modules/iam-policy/main.tf
@@ -1,4 +1,6 @@
 resource "aws_iam_policy" "policy" {
+  count = var.create ? 1 : 0
+
   name        = var.name
   path        = var.path
   description = var.description

--- a/modules/iam-policy/outputs.tf
+++ b/modules/iam-policy/outputs.tf
@@ -1,30 +1,30 @@
 output "id" {
   description = "The policy's ID"
-  value       = aws_iam_policy.policy.id
+  value       = element(concat(aws_iam_policy.policy.*.id, [""]), 0)
 }
 
 output "arn" {
   description = "The ARN assigned by AWS to this policy"
-  value       = aws_iam_policy.policy.arn
+  value       = element(concat(aws_iam_policy.policy.*.arn, [""]), 0)
 }
 
 output "description" {
   description = "The description of the policy"
-  value       = aws_iam_policy.policy.description
+  value       = element(concat(aws_iam_policy.policy.*.description, [""]), 0)
 }
 
 output "name" {
   description = "The name of the policy"
-  value       = aws_iam_policy.policy.name
+  value       = element(concat(aws_iam_policy.policy.*.name, [""]), 0)
 }
 
 output "path" {
   description = "The path of the policy in IAM"
-  value       = aws_iam_policy.policy.path
+  value       = element(concat(aws_iam_policy.policy.*.path, [""]), 0)
 }
 
 output "policy" {
   description = "The policy document"
-  value       = aws_iam_policy.policy.policy
+  value       = element(concat(aws_iam_policy.policy.*.policy, [""]), 0)
 }
 

--- a/modules/iam-policy/variables.tf
+++ b/modules/iam-policy/variables.tf
@@ -1,3 +1,9 @@
+variable "create" {
+  description = "Whether to create a policy"
+  type        = bool
+  default     = true
+}
+
 variable "name" {
   description = "The name of the policy"
   type        = string


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adds a `create` flag to the iam-policy module allowing calling modules to exclude a policy's creation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some of our modules use "feature flags" to determine whether items are created or not.  The other iam modules have create flags we can make use of; however, the policy module does not.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

This will not necessarily break compatibility; however, it will cause a new change to appear on the next plan.  The `aws_iam_policy.policy` has now moved to `aws_iam_policy.policy[0]`.  As such, one can avoid a change in the plan by using the terraform state mv functionality.  That is, assuming the target path to the iam_policy is on the root and the module is called `my_iam_policy`:

```bash
terraform state mv module.my_iam_policy.aws_iam_policy.policy 'module.my_iam_policy.aws_iam_policy.policy[0]'
```

It might be better to consider this a breaking change as it will cause a change to the plan.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Hoping over to the iam-policy examples, setting `create = false` on both examples, and running a terraform plan results in a blank plan.

```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.aws_iam_policy_document.bucket_policy: Refreshing state...

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```
