### PR TITLE
feat: Add arn of created group(s) to outputs

### DIFF
--- a/modules/iam-group-with-assumable-roles-policy/README.md
+++ b/modules/iam-group-with-assumable-roles-policy/README.md
@@ -28,6 +28,7 @@ Creates IAM group with users who are allowed to assume IAM roles. This is typica
 
 | Name | Description |
 |------|-------------|
+| group\_arn | IAM group arn |
 | group\_name | IAM group name |
 | this\_assumable\_roles | List of ARNs of IAM roles which members of IAM group can assume |
 | this\_group\_users | List of IAM users in IAM group |

--- a/modules/iam-group-with-assumable-roles-policy/outputs.tf
+++ b/modules/iam-group-with-assumable-roles-policy/outputs.tf
@@ -18,3 +18,8 @@ output "group_name" {
   value       = aws_iam_group.this.name
 }
 
+output "group_arn" {
+  description = "IAM group arn"
+  value       = aws_iam_group.this.arn
+}
+


### PR DESCRIPTION
## Description
Export arn of created groups

## Motivation and Context
We have multiple AWS accounts across our org. IAM user are kept centrally in one account, are put into groups and the groups get permission to `assumeRole` in other accounts. We need the group arn for the trustee relationship between the accounts.

## How Has This Been Tested?
I run Terraform from my branch and compared the result.

Before:
```
Unsupported attribute

  on outputs.tf line 5, in output "groups":
   5:       arn   = module.iam-groups[name]. group_arn
    |----------------
    | module.iam-groups is object with 3 attributes

This object does not have an attribute named "group_arn".
```

After:
```
Changes to Outputs:
  + groups = [
      + {
          + arn  = (known after apply)
          + name = "data-services-admin"
        },
      + {
          + arn  = (known after apply)
          + name = "data-services-developer"
        },
      + {
          + arn  = (known after apply)
          + name = "zeppelin-admin"
        },
    ]
```