### PR TITLE
feat: Support External ID with MFA in iam-assumable-role

### DIFF
--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -52,6 +52,15 @@ data "aws_iam_policy_document" "assume_role_with_mfa" {
       variable = "aws:MultiFactorAuthAge"
       values   = [var.mfa_age]
     }
+
+    dynamic "condition" {
+      for_each = var.role_sts_externalid != null ? [true] : []
+      content {
+        test     = "StringEquals"
+        variable = "sts:ExternalId"
+        values   = [var.role_sts_externalid]
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
External ID was supported without MFA, this support to work with MFA  as well.
This is merely a copy/paste of the condition block from the IAM policy document above it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We delegate the management of a subset of our services to a third-party company, we want to ensure that their users have MFA enable in their AWS account and assume the IAM role for the right customer (avoid confused deputy problem)

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Yes, used `role_requires_mfa = true` and `sts_externalid = var.sts_externalid` together.