### PR TITLE
feat: iam-user - Add user_groups variable

### DIFF
--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -50,6 +50,7 @@ This module outputs commands and PGP messages which can be decrypted either usin
 | ssh\_public\_key | The SSH public key. The public key must be encoded in ssh-rsa format or PEM format | `string` | `""` | no |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | upload\_iam\_user\_ssh\_key | Whether to upload a public ssh key to the IAM user | `bool` | `false` | no |
+| user\_groups | List of IAM groups to the IAM user should be a member of | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -38,3 +38,9 @@ resource "aws_iam_user_ssh_key" "this" {
   public_key = var.ssh_public_key
 }
 
+resource "aws_iam_user_group_membership" "this" {
+  count = length(var.user_groups) > 0 ? 1 : 0
+
+  user   = aws_iam_user.this[0].name
+  groups = var.user_groups
+}

--- a/modules/iam-user/variables.tf
+++ b/modules/iam-user/variables.tf
@@ -80,3 +80,10 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "user_groups" {
+  description = "List of IAM groups a IAM user should be a memeber of."
+  type        = list(string)
+  default     = []
+}
+


### PR DESCRIPTION
## Description
Adds the ability to manage the IAM group memberships on an IAM user using the `user_groups` variable within the `iam-user` module. This uses an existing [resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) of the provider.

## Motivation and Context
This has the ability to make initial IAM group memberships easier by combining the memberships with the user. This will be especially true for few well established groups that don't change much and a large user list that could make assigning IAM groups to IAM users cumbersome.

## Breaking Changes
None

## How Has This Been Tested?
This has been tested on a AWS test account. A plan can also be used to confirm that edits to IAM users previously created create just the memberships and don't affect the established user i.e. regenerating keys