### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
 .terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/examples/iam-account/README.md
+++ b/examples/iam-account/README.md
@@ -26,6 +26,16 @@ Run `terraform destroy` when you don't need these resources.
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam_account | ../../modules/iam-account |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -36,5 +46,4 @@ No input.
 |------|-------------|
 | this\_caller\_identity\_account\_id | The ID of the AWS account |
 | this\_iam\_account\_password\_policy\_expire\_passwords | Indicates whether passwords in the account expire. Returns true if max\_password\_age contains a value greater than 0. Returns false if it is 0 or not present. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-role-with-oidc/README.md
+++ b/examples/iam-assumable-role-with-oidc/README.md
@@ -26,6 +26,16 @@ Run `terraform destroy` when you don't need these resources.
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam_assumable_role_admin | ../../modules/iam-assumable-role-with-oidc |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -37,5 +47,4 @@ No input.
 | this\_iam\_role\_arn | ARN of IAM role |
 | this\_iam\_role\_name | Name of IAM role |
 | this\_iam\_role\_path | Path of IAM role |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-role/README.md
+++ b/examples/iam-assumable-role/README.md
@@ -28,6 +28,18 @@ Run `terraform destroy` when you don't need these resources.
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam_assumable_role_admin | ../../modules/iam-assumable-role |  |
+| iam_assumable_role_custom | ../../modules/iam-assumable-role |  |
+| iam_policy | ../../modules/iam-policy |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -40,5 +52,4 @@ No input.
 | this\_iam\_role\_arn | ARN of IAM role |
 | this\_iam\_role\_name | Name of IAM role |
 | this\_iam\_role\_path | Path of IAM role |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-roles-with-saml/README.md
+++ b/examples/iam-assumable-roles-with-saml/README.md
@@ -28,6 +28,20 @@ Run `terraform destroy` when you don't need these resources.
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam_assumable_roles_with_saml | ../../modules/iam-assumable-roles-with-saml |  |
+| iam_assumable_roles_with_saml_custom | ../../modules/iam-assumable-roles-with-saml |  |
+| iam_assumable_roles_with_saml_second_provider | ../../modules/iam-assumable-roles-with-saml |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_saml_provider](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_saml_provider) |
+
 ## Inputs
 
 No input.
@@ -45,5 +59,4 @@ No input.
 | readonly\_iam\_role\_arn | ARN of readonly IAM role |
 | readonly\_iam\_role\_name | Name of readonly IAM role |
 | readonly\_iam\_role\_path | Path of readonly IAM role |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-roles/README.md
+++ b/examples/iam-assumable-roles/README.md
@@ -26,6 +26,16 @@ Run `terraform destroy` when you don't need these resources.
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam_assumable_roles | ../../modules/iam-assumable-roles |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -46,5 +56,4 @@ No input.
 | readonly\_iam\_role\_name | Name of readonly IAM role |
 | readonly\_iam\_role\_path | Path of readonly IAM role |
 | readonly\_iam\_role\_requires\_mfa | Whether readonly IAM role requires MFA |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-group-complete/README.md
+++ b/examples/iam-group-complete/README.md
@@ -28,6 +28,19 @@ Run `terraform destroy` when you don't need these resources.
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam_group_complete | ../../modules/iam-group-with-assumable-roles-policy |  |
+| iam_group_complete_with_custom_policy | ../../modules/iam-group-with-policies |  |
+| iam_user1 | ../../modules/iam-user |  |
+| iam_user2 | ../../modules/iam-user |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -39,5 +52,4 @@ No input.
 | this\_assumable\_roles | List of ARNs of IAM roles which members of IAM group can assume |
 | this\_group\_users | List of IAM users in IAM group |
 | this\_policy\_arn | Assume role policy ARN for IAM group |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-group-with-assumable-roles-policy/README.md
+++ b/examples/iam-group-with-assumable-roles-policy/README.md
@@ -29,6 +29,24 @@ Run `terraform destroy` when you don't need these resources.
 | aws | >= 2.23 |
 | aws.production | >= 2.23 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam_assumable_role_custom | ../../modules/iam-assumable-role |  |
+| iam_assumable_roles_in_prod | ../../modules/iam-assumable-roles |  |
+| iam_group_with_assumable_roles_policy_production_admin | ../../modules/iam-group-with-assumable-roles-policy |  |
+| iam_group_with_assumable_roles_policy_production_custom | ../../modules/iam-group-with-assumable-roles-policy |  |
+| iam_group_with_assumable_roles_policy_production_readonly | ../../modules/iam-group-with-assumable-roles-policy |  |
+| iam_user1 | ../../modules/iam-user |  |
+| iam_user2 | ../../modules/iam-user |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/caller_identity) |
+
 ## Inputs
 
 No input.
@@ -42,5 +60,4 @@ No input.
 | this\_assumable\_roles | List of ARNs of IAM roles which members of IAM group can assume |
 | this\_group\_users | List of IAM users in IAM group |
 | this\_policy\_arn | Assume role policy ARN for IAM group |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-group-with-policies/README.md
+++ b/examples/iam-group-with-policies/README.md
@@ -28,6 +28,21 @@ Run `terraform destroy` when you don't need these resources.
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam_group_superadmins | ../../modules/iam-group-with-policies |  |
+| iam_group_with_custom_policies | ../../modules/iam-group-with-policies |  |
+| iam_user1 | ../../modules/iam-user |  |
+| iam_user2 | ../../modules/iam-user |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
+
 ## Inputs
 
 No input.
@@ -39,5 +54,4 @@ No input.
 | iam\_account\_id | IAM AWS account id |
 | this\_group\_name | IAM group name |
 | this\_group\_users | List of IAM users in IAM group |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-policy/README.md
+++ b/examples/iam-policy/README.md
@@ -28,6 +28,19 @@ Run `terraform destroy` when you don't need these resources.
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam_policy | ../../modules/iam-policy |  |
+| iam_policy_from_data_source | ../../modules/iam-policy |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
+
 ## Inputs
 
 No input.
@@ -42,5 +55,4 @@ No input.
 | name | The name of the policy |
 | path | The path of the policy in IAM |
 | policy | The policy document |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-user/README.md
+++ b/examples/iam-user/README.md
@@ -27,6 +27,17 @@ Run `terraform destroy` when you don't need these resources.
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam_user | ../../modules/iam-user |  |
+| iam_user2 | ../../modules/iam-user |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -51,5 +62,4 @@ No input.
 | this\_iam\_user\_login\_profile\_key\_fingerprint | The fingerprint of the PGP key used to encrypt the password |
 | this\_iam\_user\_name | The user's name |
 | this\_iam\_user\_unique\_id | The unique ID assigned by AWS |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-account/README.md
+++ b/modules/iam-account/README.md
@@ -35,6 +35,18 @@ Import successful!
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/caller_identity) |
+| [aws_iam_account_alias](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_account_alias) |
+| [aws_iam_account_password_policy](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_account_password_policy) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -60,5 +72,4 @@ Import successful!
 | this\_caller\_identity\_arn | The AWS ARN associated with the calling entity |
 | this\_caller\_identity\_user\_id | The unique identifier of the calling entity |
 | this\_iam\_account\_password\_policy\_expire\_passwords | Indicates whether passwords in the account expire. Returns true if max\_password\_age contains a value greater than 0. Returns false if it is 0 or not present. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -30,8 +30,8 @@ No Modules.
 |------|
 | [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/caller_identity) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role_policy_attachment) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
 | [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/partition) |
 
 ## Inputs

--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -20,6 +20,20 @@ This module supports IAM Roles for kubernetes service accounts as described in t
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/caller_identity) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role_policy_attachment) |
+| [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/partition) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -48,5 +62,4 @@ This module supports IAM Roles for kubernetes service accounts as described in t
 | this\_iam\_role\_arn | ARN of IAM role |
 | this\_iam\_role\_name | Name of IAM role |
 | this\_iam\_role\_path | Path of IAM role |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -28,8 +28,8 @@ No Modules.
 |------|
 | [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_instance_profile) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role_policy_attachment) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
 
 ## Inputs
 

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -18,6 +18,19 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_instance_profile) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role_policy_attachment) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -58,5 +71,4 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | this\_iam\_role\_arn | ARN of IAM role |
 | this\_iam\_role\_name | Name of IAM role |
 | this\_iam\_role\_path | Path of IAM role |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -29,8 +29,8 @@ No Modules.
 | Name |
 |------|
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role_policy_attachment) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
 
 ## Inputs
 

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -20,6 +20,18 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role_policy_attachment) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -61,5 +73,4 @@ Creates predefined IAM roles (admin, poweruser and readonly) which can be assume
 | readonly\_iam\_role\_arn | ARN of readonly IAM role |
 | readonly\_iam\_role\_name | Name of readonly IAM role |
 | readonly\_iam\_role\_path | Path of readonly IAM role |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-roles/README.md
+++ b/modules/iam-assumable-roles/README.md
@@ -27,8 +27,8 @@ No Modules.
 | Name |
 |------|
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role_policy_attachment) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
 
 ## Inputs
 

--- a/modules/iam-assumable-roles/README.md
+++ b/modules/iam-assumable-roles/README.md
@@ -18,6 +18,18 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_role_policy_attachment) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -65,5 +77,4 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | readonly\_iam\_role\_name | Name of readonly IAM role |
 | readonly\_iam\_role\_path | Path of readonly IAM role |
 | readonly\_iam\_role\_requires\_mfa | Whether readonly IAM role requires MFA |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-group-with-assumable-roles-policy/README.md
+++ b/modules/iam-group-with-assumable-roles-policy/README.md
@@ -24,11 +24,11 @@ No Modules.
 
 | Name |
 |------|
-| [aws_iam_group](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group) |
 | [aws_iam_group_membership](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group_membership) |
 | [aws_iam_group_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group_policy_attachment) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_policy) |
+| [aws_iam_group](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_policy) |
 
 ## Inputs
 

--- a/modules/iam-group-with-assumable-roles-policy/README.md
+++ b/modules/iam-group-with-assumable-roles-policy/README.md
@@ -16,6 +16,20 @@ Creates IAM group with users who are allowed to assume IAM roles. This is typica
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_group](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group) |
+| [aws_iam_group_membership](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group_membership) |
+| [aws_iam_group_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group_policy_attachment) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -32,5 +46,4 @@ Creates IAM group with users who are allowed to assume IAM roles. This is typica
 | this\_assumable\_roles | List of ARNs of IAM roles which members of IAM group can assume |
 | this\_group\_users | List of IAM users in IAM group |
 | this\_policy\_arn | Assume role policy ARN of IAM group |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-group-with-policies/README.md
+++ b/modules/iam-group-with-policies/README.md
@@ -25,11 +25,11 @@ No Modules.
 | Name |
 |------|
 | [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/caller_identity) |
-| [aws_iam_group](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group) |
 | [aws_iam_group_membership](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group_membership) |
 | [aws_iam_group_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group_policy_attachment) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_policy) |
+| [aws_iam_group](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_policy) |
 | [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/partition) |
 
 ## Inputs

--- a/modules/iam-group-with-policies/README.md
+++ b/modules/iam-group-with-policies/README.md
@@ -16,6 +16,22 @@ Creates IAM group with specified IAM policies, and add users into a group.
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/caller_identity) |
+| [aws_iam_group](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group) |
+| [aws_iam_group_membership](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group_membership) |
+| [aws_iam_group_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_group_policy_attachment) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/iam_policy_document) |
+| [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/data-sources/partition) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -36,5 +52,4 @@ Creates IAM group with specified IAM policies, and add users into a group.
 | aws\_account\_id | IAM AWS account id |
 | this\_group\_name | IAM group name |
 | this\_group\_users | List of IAM users in IAM group |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-policy/README.md
+++ b/modules/iam-policy/README.md
@@ -16,6 +16,16 @@ Creates IAM policy.
 |------|---------|
 | aws | >= 2.23 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.23/docs/resources/iam_policy) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -35,5 +45,4 @@ Creates IAM policy.
 | name | The name of the policy |
 | path | The path of the policy in IAM |
 | policy | The policy document |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -32,6 +32,19 @@ This module outputs commands and PGP messages which can be decrypted either usin
 |------|---------|
 | aws | >= 2.50 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_access_key](https://registry.terraform.io/providers/hashicorp/aws/2.50/docs/resources/iam_access_key) |
+| [aws_iam_user](https://registry.terraform.io/providers/hashicorp/aws/2.50/docs/resources/iam_user) |
+| [aws_iam_user_login_profile](https://registry.terraform.io/providers/hashicorp/aws/2.50/docs/resources/iam_user_login_profile) |
+| [aws_iam_user_ssh_key](https://registry.terraform.io/providers/hashicorp/aws/2.50/docs/resources/iam_user_ssh_key) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -73,5 +86,4 @@ This module outputs commands and PGP messages which can be decrypted either usin
 | this\_iam\_user\_ssh\_key\_fingerprint | The MD5 message digest of the SSH public key |
 | this\_iam\_user\_ssh\_key\_ssh\_public\_key\_id | The unique identifier for the SSH public key |
 | this\_iam\_user\_unique\_id | The unique ID assigned by AWS |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -41,9 +41,9 @@ No Modules.
 | Name |
 |------|
 | [aws_iam_access_key](https://registry.terraform.io/providers/hashicorp/aws/2.50/docs/resources/iam_access_key) |
-| [aws_iam_user](https://registry.terraform.io/providers/hashicorp/aws/2.50/docs/resources/iam_user) |
 | [aws_iam_user_login_profile](https://registry.terraform.io/providers/hashicorp/aws/2.50/docs/resources/iam_user_login_profile) |
 | [aws_iam_user_ssh_key](https://registry.terraform.io/providers/hashicorp/aws/2.50/docs/resources/iam_user_ssh_key) |
+| [aws_iam_user](https://registry.terraform.io/providers/hashicorp/aws/2.50/docs/resources/iam_user) |
 
 ## Inputs
 


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
