### PR TITLE
feat: Allows multiple STS External IDs to be provided to an assumable role

### DIFF
--- a/examples/iam-assumable-role/README.md
+++ b/examples/iam-assumable-role/README.md
@@ -52,4 +52,5 @@ No input.
 | this\_iam\_role\_arn | ARN of IAM role |
 | this\_iam\_role\_name | Name of IAM role |
 | this\_iam\_role\_path | Path of IAM role |
+
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-role/README.md
+++ b/examples/iam-assumable-role/README.md
@@ -34,6 +34,7 @@ No provider.
 |------|--------|---------|
 | iam_assumable_role_admin | ../../modules/iam-assumable-role |  |
 | iam_assumable_role_custom | ../../modules/iam-assumable-role |  |
+| iam_assumable_role_sts | ../../modules/iam-assumable-role |  |
 | iam_policy | ../../modules/iam-policy |  |
 
 ## Resources

--- a/examples/iam-assumable-role/README.md
+++ b/examples/iam-assumable-role/README.md
@@ -52,5 +52,4 @@ No input.
 | this\_iam\_role\_arn | ARN of IAM role |
 | this\_iam\_role\_name | Name of IAM role |
 | this\_iam\_role\_path | Path of IAM role |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-role/main.tf
+++ b/examples/iam-assumable-role/main.tf
@@ -49,8 +49,8 @@ module "iam_assumable_role_custom" {
   role_requires_mfa = false
 
   role_sts_external_ids = [
+    "some-id-goes-here",
     "another-id-goes-here",
-    "yet-another-id-goes-here",
   ]
 
   custom_role_policy_arns = [

--- a/examples/iam-assumable-role/main.tf
+++ b/examples/iam-assumable-role/main.tf
@@ -48,7 +48,6 @@ module "iam_assumable_role_custom" {
   role_name         = "custom"
   role_requires_mfa = false
 
-  role_sts_externalid = "some-id-goes-here" # This will be added to the role_sts_external_ids list
   role_sts_external_ids = [
     "another-id-goes-here",
     "yet-another-id-goes-here",

--- a/examples/iam-assumable-role/main.tf
+++ b/examples/iam-assumable-role/main.tf
@@ -48,7 +48,36 @@ module "iam_assumable_role_custom" {
   role_name         = "custom"
   role_requires_mfa = false
 
-  role_sts_external_ids = [
+  role_sts_externalid = "some-id-goes-here"
+
+  custom_role_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonCognitoReadOnly",
+    "arn:aws:iam::aws:policy/AlexaForBusinessFullAccess",
+    module.iam_policy.arn
+  ]
+  #  number_of_custom_role_policy_arns = 3
+}
+
+####################################################
+# IAM assumable role with multiple sts external ids
+####################################################
+module "iam_assumable_role_sts" {
+  source = "../../modules/iam-assumable-role"
+
+  trusted_role_arns = [
+    "arn:aws:iam::307990089504:root",
+  ]
+
+  trusted_role_services = [
+    "codedeploy.amazonaws.com"
+  ]
+
+  create_role = true
+
+  role_name         = "custom_sts"
+  role_requires_mfa = false
+
+  role_sts_externalid = [
     "some-id-goes-here",
     "another-id-goes-here",
   ]

--- a/examples/iam-assumable-role/main.tf
+++ b/examples/iam-assumable-role/main.tf
@@ -48,7 +48,11 @@ module "iam_assumable_role_custom" {
   role_name         = "custom"
   role_requires_mfa = false
 
-  role_sts_externalid = "some-id-goes-here"
+  role_sts_externalid = "some-id-goes-here" # This will be added to the role_sts_external_ids list
+  role_sts_external_ids = [
+    "another-id-goes-here",
+    "yet-another-id-goes-here",
+  ]
 
   custom_role_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonCognitoReadOnly",

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -53,7 +53,7 @@ No Modules.
 | role\_path | Path of IAM role | `string` | `"/"` | no |
 | role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | role\_requires\_mfa | Whether role requires MFA | `bool` | `true` | no |
-| role\_sts\_external\_ids | STS ExternalId condition value to use with a role (when MFA is not required) | `list(string)` | `[]` | no |
+| role\_sts\_external\_ids | STS External ID condition values to use with a role (when MFA is not required) | `list(string)` | `[]` | no |
 | role\_sts\_externalid | STS ExternalId condition value to use with a role (when MFA is not required) | `string` | `null` | no |
 | tags | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
 | trusted\_role\_actions | Actions of STS | `list(string)` | <pre>[<br>  "sts:AssumeRole"<br>]</pre> | no |

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -53,7 +53,7 @@ No Modules.
 | role\_path | Path of IAM role | `string` | `"/"` | no |
 | role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | role\_requires\_mfa | Whether role requires MFA | `bool` | `true` | no |
-| role\_sts\_external\_ids | STS External ID condition values to use with a role (when MFA is not required) | `list(string)` | `[]` | no |
+| role\_sts\_externalid | STS ExternalId condition values to use with a role (when MFA is not required) | `any` | `[]` | no |
 | tags | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
 | trusted\_role\_actions | Actions of STS | `list(string)` | <pre>[<br>  "sts:AssumeRole"<br>]</pre> | no |
 | trusted\_role\_arns | ARNs of AWS entities who can assume these roles | `list(string)` | `[]` | no |
@@ -64,6 +64,7 @@ No Modules.
 | Name | Description |
 |------|-------------|
 | role\_requires\_mfa | Whether IAM role requires MFA |
+| role\_sts\_externalid | STS ExternalId condition value to use with a role |
 | this\_iam\_instance\_profile\_arn | ARN of IAM instance profile |
 | this\_iam\_instance\_profile\_name | Name of IAM instance profile |
 | this\_iam\_instance\_profile\_path | Path of IAM instance profile |

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -53,6 +53,7 @@ No Modules.
 | role\_path | Path of IAM role | `string` | `"/"` | no |
 | role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | role\_requires\_mfa | Whether role requires MFA | `bool` | `true` | no |
+| role\_sts\_external\_ids | STS ExternalId condition value to use with a role (when MFA is not required) | `list(string)` | `[]` | no |
 | role\_sts\_externalid | STS ExternalId condition value to use with a role (when MFA is not required) | `string` | `null` | no |
 | tags | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
 | trusted\_role\_actions | Actions of STS | `list(string)` | <pre>[<br>  "sts:AssumeRole"<br>]</pre> | no |
@@ -71,4 +72,5 @@ No Modules.
 | this\_iam\_role\_arn | ARN of IAM role |
 | this\_iam\_role\_name | Name of IAM role |
 | this\_iam\_role\_path | Path of IAM role |
+
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -54,7 +54,6 @@ No Modules.
 | role\_permissions\_boundary\_arn | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | role\_requires\_mfa | Whether role requires MFA | `bool` | `true` | no |
 | role\_sts\_external\_ids | STS External ID condition values to use with a role (when MFA is not required) | `list(string)` | `[]` | no |
-| role\_sts\_externalid | STS ExternalId condition value to use with a role (when MFA is not required) | `string` | `null` | no |
 | tags | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
 | trusted\_role\_actions | Actions of STS | `list(string)` | <pre>[<br>  "sts:AssumeRole"<br>]</pre> | no |
 | trusted\_role\_arns | ARNs of AWS entities who can assume these roles | `list(string)` | `[]` | no |
@@ -65,12 +64,10 @@ No Modules.
 | Name | Description |
 |------|-------------|
 | role\_requires\_mfa | Whether IAM role requires MFA |
-| role\_sts\_externalid | STS ExternalId condition value to use with a role |
 | this\_iam\_instance\_profile\_arn | ARN of IAM instance profile |
 | this\_iam\_instance\_profile\_name | Name of IAM instance profile |
 | this\_iam\_instance\_profile\_path | Path of IAM instance profile |
 | this\_iam\_role\_arn | ARN of IAM role |
 | this\_iam\_role\_name | Name of IAM role |
 | this\_iam\_role\_path | Path of IAM role |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -1,3 +1,7 @@
+locals {
+  role_sts_externalid = flatten(list(var.role_sts_externalid))
+}
+
 data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"
@@ -15,11 +19,11 @@ data "aws_iam_policy_document" "assume_role" {
     }
 
     dynamic "condition" {
-      for_each = length(var.role_sts_external_ids) != 0 ? [true] : []
+      for_each = length(local.role_sts_externalid) != 0 ? [true] : []
       content {
         test     = "StringEquals"
         variable = "sts:ExternalId"
-        values   = var.role_sts_external_ids
+        values   = local.role_sts_externalid
       }
     }
   }

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -1,7 +1,3 @@
-locals {
-  role_sts_external_ids = compact(concat(var.role_sts_external_ids, [var.role_sts_externalid]))
-}
-
 data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"
@@ -19,11 +15,11 @@ data "aws_iam_policy_document" "assume_role" {
     }
 
     dynamic "condition" {
-      for_each = length(local.role_sts_external_ids) != 0 ? [true] : []
+      for_each = length(var.role_sts_external_ids) != 0 ? [true] : []
       content {
         test     = "StringEquals"
         variable = "sts:ExternalId"
-        values   = local.role_sts_external_ids
+        values   = var.role_sts_external_ids
       }
     }
   }

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -1,3 +1,7 @@
+locals {
+  role_sts_external_ids = compact(concat(var.role_sts_external_ids, [var.role_sts_externalid]))
+}
+
 data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"
@@ -15,11 +19,11 @@ data "aws_iam_policy_document" "assume_role" {
     }
 
     dynamic "condition" {
-      for_each = var.role_sts_externalid != null ? [true] : []
+      for_each = length(local.role_sts_external_ids) != 0 ? [true] : []
       content {
         test     = "StringEquals"
         variable = "sts:ExternalId"
-        values   = [var.role_sts_externalid]
+        values   = local.role_sts_external_ids
       }
     }
   }

--- a/modules/iam-assumable-role/outputs.tf
+++ b/modules/iam-assumable-role/outputs.tf
@@ -32,9 +32,3 @@ output "this_iam_instance_profile_path" {
   description = "Path of IAM instance profile"
   value       = element(concat(aws_iam_instance_profile.this.*.path, [""]), 0)
 }
-
-output "role_sts_externalid" {
-  description = "STS ExternalId condition value to use with a role"
-  value       = var.role_sts_externalid
-}
-

--- a/modules/iam-assumable-role/outputs.tf
+++ b/modules/iam-assumable-role/outputs.tf
@@ -32,3 +32,8 @@ output "this_iam_instance_profile_path" {
   description = "Path of IAM instance profile"
   value       = element(concat(aws_iam_instance_profile.this.*.path, [""]), 0)
 }
+
+output "role_sts_externalid" {
+  description = "STS ExternalId condition value to use with a role"
+  value       = var.role_sts_externalid
+}

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -137,3 +137,8 @@ variable "role_sts_externalid" {
   default     = null
 }
 
+variable "role_sts_external_ids" {
+  description = "STS External ID condition values to use with a role (when MFA is not required)"
+  type        = list(string)
+  default     = []
+}

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -131,12 +131,6 @@ variable "role_description" {
   default     = ""
 }
 
-variable "role_sts_externalid" {
-  description = "STS ExternalId condition value to use with a role (when MFA is not required)"
-  type        = string
-  default     = null
-}
-
 variable "role_sts_external_ids" {
   description = "STS External ID condition values to use with a role (when MFA is not required)"
   type        = list(string)

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -131,8 +131,8 @@ variable "role_description" {
   default     = ""
 }
 
-variable "role_sts_external_ids" {
-  description = "STS External ID condition values to use with a role (when MFA is not required)"
-  type        = list(string)
+variable "role_sts_externalid" {
+  description = "STS ExternalId condition values to use with a role (when MFA is not required)"
+  type        = any
   default     = []
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Allows more than one STS External ID to be provided to an assumable role.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We need to pass multiple External IDs allowing one role for multiple external ids.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have added the `role_sts_external_ids` field to the `iam-assumable-role` example.

### Using a string
```
  # module.iam_assumable_role_custom.aws_iam_role.this[0] will be created
  + resource "aws_iam_role" "this" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Condition = {
                          + StringEquals = {
                              + sts:ExternalId = [
                                  + "some-id-goes-here",
                                ]
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS     = "arn:aws:iam::307990089504:root"
                          + Service = "codedeploy.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "custom"
      + path                  = "/"
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }
```

### Using a list(string)
```
  # module.iam_assumable_role_sts.aws_iam_role.this[0] will be created
  + resource "aws_iam_role" "this" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Condition = {
                          + StringEquals = {
                              + sts:ExternalId = [
                                  + "some-id-goes-here",
                                  + "another-id-goes-here",
                                ]
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS     = "arn:aws:iam::307990089504:root"
                          + Service = "codedeploy.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "custom_sts"
      + path                  = "/"
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }
```