### PR TITLE
fix: handle unencrypted secrets

### DIFF
--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -1,3 +1,8 @@
+locals {
+  has_encrypted_password = length(compact(aws_iam_user_login_profile.this.*.encrypted_password)) > 0
+  has_encrypted_secret   = length(compact(aws_iam_access_key.this.*.encrypted_secret)) > 0
+}
+
 output "this_iam_user_name" {
   description = "The user's name"
   value       = element(concat(aws_iam_user.this.*.name, [""]), 0)
@@ -15,18 +20,12 @@ output "this_iam_user_unique_id" {
 
 output "this_iam_user_login_profile_key_fingerprint" {
   description = "The fingerprint of the PGP key used to encrypt the password"
-  value = element(
-    concat(aws_iam_user_login_profile.this.*.key_fingerprint, [""]),
-    0,
-  )
+  value       = element(concat(aws_iam_user_login_profile.this.*.key_fingerprint, [""]), 0)
 }
 
 output "this_iam_user_login_profile_encrypted_password" {
   description = "The encrypted password, base64 encoded"
-  value = element(
-    concat(aws_iam_user_login_profile.this.*.encrypted_password, [""]),
-    0,
-  )
+  value       = element(concat(aws_iam_user_login_profile.this.*.encrypted_password, [""]), 0)
 }
 
 output "this_iam_access_key_id" {
@@ -37,7 +36,7 @@ output "this_iam_access_key_id" {
       aws_iam_access_key.this_no_pgp.*.id,
       [""],
     ),
-    0,
+    0
   )
 }
 
@@ -64,7 +63,7 @@ output "this_iam_access_key_ses_smtp_password_v4" {
       aws_iam_access_key.this_no_pgp.*.ses_smtp_password_v4,
       [""],
     ),
-    0,
+    0
   )
 }
 
@@ -76,7 +75,7 @@ output "this_iam_access_key_status" {
       aws_iam_access_key.this_no_pgp.*.status,
       [""],
     ),
-    0,
+    0
   )
 }
 
@@ -87,26 +86,20 @@ output "pgp_key" {
 
 output "keybase_password_decrypt_command" {
   description = "Decrypt user password command"
-  value = <<EOF
-echo "${element(
-  concat(aws_iam_user_login_profile.this.*.encrypted_password, [""]),
-  0,
-)}" | base64 --decode | keybase pgp decrypt
+  value = !has_encrypted_password ? null : <<EOF
+echo "${element(concat(aws_iam_user_login_profile.this.*.encrypted_password, [""]), 0)}" | base64 --decode | keybase pgp decrypt
 EOF
 
 }
 
 output "keybase_password_pgp_message" {
   description = "Encrypted password"
-  value = <<EOF
+  value = !has_encrypted_password ? null : <<EOF
 -----BEGIN PGP MESSAGE-----
 Version: Keybase OpenPGP v2.0.76
 Comment: https://keybase.io/crypto
 
-${element(
-  concat(aws_iam_user_login_profile.this.*.encrypted_password, [""]),
-  0,
-)}
+${element(concat(aws_iam_user_login_profile.this.*.encrypted_password, [""]), 0)}
 -----END PGP MESSAGE-----
 EOF
 
@@ -114,7 +107,7 @@ EOF
 
 output "keybase_secret_key_decrypt_command" {
   description = "Decrypt access secret key command"
-  value       = <<EOF
+  value       = !has_encrypted_secret ? null : <<EOF
 echo "${element(concat(aws_iam_access_key.this.*.encrypted_secret, [""]), 0)}" | base64 --decode | keybase pgp decrypt
 EOF
 
@@ -122,7 +115,7 @@ EOF
 
 output "keybase_secret_key_pgp_message" {
   description = "Encrypted access secret key"
-  value       = <<EOF
+  value       = !has_encrypted_secret ? null : <<EOF
 -----BEGIN PGP MESSAGE-----
 Version: Keybase OpenPGP v2.0.76
 Comment: https://keybase.io/crypto
@@ -135,14 +128,10 @@ EOF
 
 output "this_iam_user_ssh_key_ssh_public_key_id" {
   description = "The unique identifier for the SSH public key"
-  value = element(
-    concat(aws_iam_user_ssh_key.this.*.ssh_public_key_id, [""]),
-    0,
-  )
+  value       = element(concat(aws_iam_user_ssh_key.this.*.ssh_public_key_id, [""]), 0)
 }
 
 output "this_iam_user_ssh_key_fingerprint" {
   description = "The MD5 message digest of the SSH public key"
   value       = element(concat(aws_iam_user_ssh_key.this.*.fingerprint, [""]), 0)
 }
-

--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -86,7 +86,7 @@ output "pgp_key" {
 
 output "keybase_password_decrypt_command" {
   description = "Decrypt user password command"
-  value = !has_encrypted_password ? null : <<EOF
+  value = !local.has_encrypted_password ? null : <<EOF
 echo "${element(concat(aws_iam_user_login_profile.this.*.encrypted_password, [""]), 0)}" | base64 --decode | keybase pgp decrypt
 EOF
 
@@ -94,7 +94,7 @@ EOF
 
 output "keybase_password_pgp_message" {
   description = "Encrypted password"
-  value = !has_encrypted_password ? null : <<EOF
+  value = !local.has_encrypted_password ? null : <<EOF
 -----BEGIN PGP MESSAGE-----
 Version: Keybase OpenPGP v2.0.76
 Comment: https://keybase.io/crypto
@@ -107,7 +107,7 @@ EOF
 
 output "keybase_secret_key_decrypt_command" {
   description = "Decrypt access secret key command"
-  value       = !has_encrypted_secret ? null : <<EOF
+  value       = !local.has_encrypted_secret ? null : <<EOF
 echo "${element(concat(aws_iam_access_key.this.*.encrypted_secret, [""]), 0)}" | base64 --decode | keybase pgp decrypt
 EOF
 
@@ -115,7 +115,7 @@ EOF
 
 output "keybase_secret_key_pgp_message" {
   description = "Encrypted access secret key"
-  value       = !has_encrypted_secret ? null : <<EOF
+  value       = !local.has_encrypted_secret ? null : <<EOF
 -----BEGIN PGP MESSAGE-----
 Version: Keybase OpenPGP v2.0.76
 Comment: https://keybase.io/crypto

--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -86,7 +86,7 @@ output "pgp_key" {
 
 output "keybase_password_decrypt_command" {
   description = "Decrypt user password command"
-  value = !local.has_encrypted_password ? null : <<EOF
+  value       = !local.has_encrypted_password ? null : <<EOF
 echo "${element(concat(aws_iam_user_login_profile.this.*.encrypted_password, [""]), 0)}" | base64 --decode | keybase pgp decrypt
 EOF
 
@@ -94,7 +94,7 @@ EOF
 
 output "keybase_password_pgp_message" {
   description = "Encrypted password"
-  value = !local.has_encrypted_password ? null : <<EOF
+  value       = !local.has_encrypted_password ? null : <<EOF
 -----BEGIN PGP MESSAGE-----
 Version: Keybase OpenPGP v2.0.76
 Comment: https://keybase.io/crypto


### PR DESCRIPTION
## Description
There are use cases when encryption is not possible and these are not handled properly right now.

## Motivation and Context
Sometimes internal accounts are created and they never leave Terraform and encryption is not possible due to the lack of decryption functionality within Terraform.

## Breaking Changes
When not appropriate, Keybase commands will just be null, which could be extended further to check if a regular PGP key is used and not a Keybase one.