### PR TITLE
feat: Add support tags to additional IAM modules

### DIFF
--- a/examples/iam-policy/main.tf
+++ b/examples/iam-policy/main.tf
@@ -34,6 +34,10 @@ module "iam_policy" {
   ]
 }
 EOF
+
+  tags = {
+    PolicyDescription = "Policy created using heredoc policy"
+  }
 }
 
 module "iam_policy_from_data_source" {
@@ -44,4 +48,8 @@ module "iam_policy_from_data_source" {
   description = "My example policy"
 
   policy = data.aws_iam_policy_document.bucket_policy.json
+
+  tags = {
+    PolicyDescription = "Policy created using example from data source"
+  }
 }

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -10,13 +10,13 @@ Trusted resources can be any [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/U
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.23 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.34 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.23 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.34 |
 
 ## Modules
 

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -108,4 +108,6 @@ resource "aws_iam_instance_profile" "this" {
   name  = var.role_name
   path  = var.role_path
   role  = aws_iam_role.this[0].name
+
+  tags = var.tags
 }

--- a/modules/iam-assumable-role/versions.tf
+++ b/modules/iam-assumable-role/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.23"
+    aws = ">= 3.34"
   }
 }

--- a/modules/iam-group-with-assumable-roles-policy/README.md
+++ b/modules/iam-group-with-assumable-roles-policy/README.md
@@ -37,6 +37,7 @@ No modules.
 | <a name="input_assumable_roles"></a> [assumable\_roles](#input\_assumable\_roles) | List of IAM roles ARNs which can be assumed by the group | `list(string)` | `[]` | no |
 | <a name="input_group_users"></a> [group\_users](#input\_group\_users) | List of IAM users to have in an IAM group which can assume the role | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of IAM policy and IAM group | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/iam-group-with-assumable-roles-policy/main.tf
+++ b/modules/iam-group-with-assumable-roles-policy/main.tf
@@ -10,6 +10,8 @@ resource "aws_iam_policy" "this" {
   name        = var.name
   description = "Allows to assume role in another AWS account"
   policy      = data.aws_iam_policy_document.assume_role.json
+
+  tags = var.tags
 }
 
 resource "aws_iam_group" "this" {

--- a/modules/iam-group-with-assumable-roles-policy/variables.tf
+++ b/modules/iam-group-with-assumable-roles-policy/variables.tf
@@ -15,3 +15,9 @@ variable "group_users" {
   default     = []
 }
 
+variable "tags" {
+  description = "A map of tags to add to all resources."
+  type        = map(string)
+  default     = {}
+}
+

--- a/modules/iam-group-with-policies/README.md
+++ b/modules/iam-group-with-policies/README.md
@@ -47,6 +47,7 @@ No modules.
 | <a name="input_group_users"></a> [group\_users](#input\_group\_users) | List of IAM users to have in an IAM group which can assume the role | `list(string)` | `[]` | no |
 | <a name="input_iam_self_management_policy_name_prefix"></a> [iam\_self\_management\_policy\_name\_prefix](#input\_iam\_self\_management\_policy\_name\_prefix) | Name prefix for IAM policy to create with IAM self-management permissions | `string` | `"IAMSelfManagement-"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of IAM group | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/iam-group-with-policies/main.tf
+++ b/modules/iam-group-with-policies/main.tf
@@ -48,6 +48,8 @@ resource "aws_iam_policy" "iam_self_management" {
 
   name_prefix = var.iam_self_management_policy_name_prefix
   policy      = data.aws_iam_policy_document.iam_self_management.json
+
+  tags = var.tags
 }
 
 resource "aws_iam_policy" "custom" {
@@ -56,5 +58,7 @@ resource "aws_iam_policy" "custom" {
   name        = var.custom_group_policies[count.index]["name"]
   policy      = var.custom_group_policies[count.index]["policy"]
   description = lookup(var.custom_group_policies[count.index], "description", null)
+
+  tags = var.tags
 }
 

--- a/modules/iam-group-with-policies/variables.tf
+++ b/modules/iam-group-with-policies/variables.tf
@@ -46,3 +46,8 @@ variable "aws_account_id" {
   default     = ""
 }
 
+variable "tags" {
+  description = "A map of tags to add to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/iam-policy/README.md
+++ b/modules/iam-policy/README.md
@@ -8,13 +8,13 @@ Creates IAM policy.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.23 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.23 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35 |
 
 ## Modules
 

--- a/modules/iam-policy/README.md
+++ b/modules/iam-policy/README.md
@@ -34,6 +34,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The name of the policy | `string` | `""` | no |
 | <a name="input_path"></a> [path](#input\_path) | The path of the policy in IAM | `string` | `"/"` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | The path of the policy in IAM (tpl file) | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/iam-policy/main.tf
+++ b/modules/iam-policy/main.tf
@@ -4,5 +4,7 @@ resource "aws_iam_policy" "policy" {
   description = var.description
 
   policy = var.policy
+
+  tags = var.tags
 }
 

--- a/modules/iam-policy/variables.tf
+++ b/modules/iam-policy/variables.tf
@@ -22,3 +22,8 @@ variable "policy" {
   default     = ""
 }
 
+variable "tags" {
+  description = "A map of tags to add to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/iam-policy/versions.tf
+++ b/modules/iam-policy/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.23"
+    aws = ">= 3.35"
   }
 }

--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -5,6 +5,7 @@ resource "aws_iam_user" "this" {
   path                 = var.path
   force_destroy        = var.force_destroy
   permissions_boundary = var.permissions_boundary
+
   tags                 = var.tags
 }
 

--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -6,7 +6,7 @@ resource "aws_iam_user" "this" {
   force_destroy        = var.force_destroy
   permissions_boundary = var.permissions_boundary
 
-  tags                 = var.tags
+  tags = var.tags
 }
 
 resource "aws_iam_user_login_profile" "this" {


### PR DESCRIPTION
## Description

Add `tags` variable:

`aws_iam_instance_profile` [released in TerraformAWS provider v3.34](https://github.com/hashicorp/terraform-provider-aws/blob/v3.34.0/CHANGELOG.md) on PR [#17962](https://github.com/hashicorp/terraform-provider-aws/pull/17962)
`aws_iam_policy` [released in terraform-aws-provider v3.35](https://github.com/hashicorp/terraform-provider-aws/blob/v3.35.0/CHANGELOG.md) on PR [#18276](https://github.com/hashicorp/terraform-provider-aws/pull/18276)

## Motivation and Context
I need to tag all (or at least I would like that) resources provisioned, Its help me with cost management and organization

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects