### PR TITLE
feat: Allow resource tagging

### DIFF
--- a/modules/iam-policy/main.tf
+++ b/modules/iam-policy/main.tf
@@ -2,7 +2,6 @@ resource "aws_iam_policy" "policy" {
   name        = var.name
   path        = var.path
   description = var.description
-
   policy = var.policy
+  tags = var.tags
 }
-

--- a/modules/iam-policy/variables.tf
+++ b/modules/iam-policy/variables.tf
@@ -22,3 +22,8 @@ variable "policy" {
   default     = ""
 }
 
+variable "tags" {
+  description = "A map of tags to add to IAM policy resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This will support adding tags to an IAM policy.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves the issue of not being able to tag policies with the current module. In a high compliance/cost control environment this is necessary.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No the default value is an empty map.
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
I have forked the repo, referenced it in a project and deployed tags against a policy.
<!--- Include details of your testing environment, and the tests you ran to -->
```
module "generic_instance_policy" {
  source = "git@github.com:dogfish182/terraform-aws-iam.git//modules/iam-policy"
  //  version = "~> 3.0"
  name        = "generic-instance"
  path        = "/"
  description = "permissions to do things"
  policy      = data.aws_iam_policy_document.generic_instance_policy.json
  tags        = merge(var.organisational_tags, var.project_tags)
}
<!--- see how your change affects other areas of the code, etc. -->
