### PR TITLE
Feature/terraform v15 update

### DIFF
--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -1,5 +1,5 @@
 locals {
-  role_sts_externalid = flatten(list(var.role_sts_externalid))
+  role_sts_externalid = flatten(tolist(var.role_sts_externalid))
 }
 
 data "aws_iam_policy_document" "assume_role" {

--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -30,19 +30,19 @@ output "this_iam_user_login_profile_encrypted_password" {
 
 output "this_iam_access_key_id" {
   description = "The access key ID"
-  value = nonsensitive(element(
+  value = element(
     concat(
       aws_iam_access_key.this.*.id,
-      aws_iam_access_key.this_no_pgp.*.id,
+      nonsensitive(aws_iam_access_key.this_no_pgp.*.id),
       [""],
     ),
     0
-  ))
+  )
 }
 
 output "this_iam_access_key_secret" {
   description = "The access key secret"
-  value       = nonsensitive(element(concat(aws_iam_access_key.this_no_pgp.*.secret, [""]), 0))
+  value       = element(concat(nonsensitive(aws_iam_access_key.this_no_pgp.*.secret), [""]), 0)
 }
 
 output "this_iam_access_key_key_fingerprint" {
@@ -57,26 +57,26 @@ output "this_iam_access_key_encrypted_secret" {
 
 output "this_iam_access_key_ses_smtp_password_v4" {
   description = "The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm"
-  value = nonsensitive(element(
+  value = element(
     concat(
       aws_iam_access_key.this.*.ses_smtp_password_v4,
-      aws_iam_access_key.this_no_pgp.*.ses_smtp_password_v4,
+      nonsensitive(aws_iam_access_key.this_no_pgp.*.ses_smtp_password_v4),
       [""],
     ),
     0
-  ))
+  )
 }
 
 output "this_iam_access_key_status" {
   description = "Active or Inactive. Keys are initially active, but can be made inactive by other means."
-  value = nonsensitive(element(
+  value = element(
     concat(
       aws_iam_access_key.this.*.status,
-      aws_iam_access_key.this_no_pgp.*.status,
+      nonsensitive(aws_iam_access_key.this_no_pgp.*.status),
       [""],
     ),
     0
-  ))
+  )
 }
 
 output "pgp_key" {

--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -30,19 +30,19 @@ output "this_iam_user_login_profile_encrypted_password" {
 
 output "this_iam_access_key_id" {
   description = "The access key ID"
-  value = element(
+  value = nonsensitive(element(
     concat(
       aws_iam_access_key.this.*.id,
       aws_iam_access_key.this_no_pgp.*.id,
       [""],
     ),
     0
-  )
+  ))
 }
 
 output "this_iam_access_key_secret" {
   description = "The access key secret"
-  value       = element(concat(aws_iam_access_key.this_no_pgp.*.secret, [""]), 0)
+  value       = nonsensitive(element(concat(aws_iam_access_key.this_no_pgp.*.secret, [""]), 0))
 }
 
 output "this_iam_access_key_key_fingerprint" {
@@ -57,26 +57,26 @@ output "this_iam_access_key_encrypted_secret" {
 
 output "this_iam_access_key_ses_smtp_password_v4" {
   description = "The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm"
-  value = element(
+  value = nonsensitive(element(
     concat(
       aws_iam_access_key.this.*.ses_smtp_password_v4,
       aws_iam_access_key.this_no_pgp.*.ses_smtp_password_v4,
       [""],
     ),
     0
-  )
+  ))
 }
 
 output "this_iam_access_key_status" {
   description = "Active or Inactive. Keys are initially active, but can be made inactive by other means."
-  value = element(
+  value = nonsensitive(element(
     concat(
       aws_iam_access_key.this.*.status,
       aws_iam_access_key.this_no_pgp.*.status,
       [""],
     ),
     0
-  )
+  ))
 }
 
 output "pgp_key" {


### PR DESCRIPTION
## Description
Terraform release v0.15.0 several old function have been removed.
https://www.hashicorp.com/blog/announcing-hashicorp-terraform-0-15-general-availability
https://github.com/hashicorp/terraform/releases/tag/v0.15.0
https://www.terraform.io/upgrade-guides/0-15.html



The outputs of the `aws_iam_access_key.this_no_pgp` resource is consider as sensitive and creating the following error
```
│ Expressions used in outputs can only refer to sensitive values if the
│ sensitive attribute is true.
```

I have wrapped the outputs this resource(s) in the `nonsensitive` function, however I could not tested.
**I need support in the testing before merging**