### PR TITLE
feat: Add iam role unique_id to outputs

### DIFF
--- a/examples/iam-assumable-role-with-oidc/README.md
+++ b/examples/iam-assumable-role-with-oidc/README.md
@@ -47,4 +47,5 @@ No inputs.
 | <a name="output_this_iam_role_arn"></a> [this\_iam\_role\_arn](#output\_this\_iam\_role\_arn) | ARN of IAM role |
 | <a name="output_this_iam_role_name"></a> [this\_iam\_role\_name](#output\_this\_iam\_role\_name) | Name of IAM role |
 | <a name="output_this_iam_role_path"></a> [this\_iam\_role\_path](#output\_this\_iam\_role\_path) | Path of IAM role |
+| <a name="output_this_iam_role_unique_id"></a> [this\_iam\_role\_unique\_id](#output\_this\_iam\_role\_unique\_id) | Unique ID of IAM role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-role-with-oidc/outputs.tf
+++ b/examples/iam-assumable-role-with-oidc/outputs.tf
@@ -12,3 +12,8 @@ output "this_iam_role_path" {
   description = "Path of IAM role"
   value       = module.iam_assumable_role_admin.this_iam_role_path
 }
+
+output "this_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.iam_assumable_role_admin.this_iam_role_unique_id
+}

--- a/examples/iam-assumable-role-with-saml/README.md
+++ b/examples/iam-assumable-role-with-saml/README.md
@@ -52,4 +52,5 @@ No inputs.
 | <a name="output_this_iam_role_arn"></a> [this\_iam\_role\_arn](#output\_this\_iam\_role\_arn) | ARN of IAM role |
 | <a name="output_this_iam_role_name"></a> [this\_iam\_role\_name](#output\_this\_iam\_role\_name) | Name of IAM role |
 | <a name="output_this_iam_role_path"></a> [this\_iam\_role\_path](#output\_this\_iam\_role\_path) | Path of IAM role |
+| <a name="output_this_iam_role_unique_id"></a> [this\_iam\_role\_unique\_id](#output\_this\_iam\_role\_unique\_id) | Unique ID of IAM role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-role-with-saml/outputs.tf
+++ b/examples/iam-assumable-role-with-saml/outputs.tf
@@ -12,3 +12,8 @@ output "this_iam_role_path" {
   description = "Path of IAM role"
   value       = module.iam_assumable_role_admin.this_iam_role_path
 }
+
+output "this_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.iam_assumable_role_admin.this_iam_role_unique_id
+}

--- a/examples/iam-assumable-role/README.md
+++ b/examples/iam-assumable-role/README.md
@@ -53,4 +53,5 @@ No inputs.
 | <a name="output_this_iam_role_arn"></a> [this\_iam\_role\_arn](#output\_this\_iam\_role\_arn) | ARN of IAM role |
 | <a name="output_this_iam_role_name"></a> [this\_iam\_role\_name](#output\_this\_iam\_role\_name) | Name of IAM role |
 | <a name="output_this_iam_role_path"></a> [this\_iam\_role\_path](#output\_this\_iam\_role\_path) | Path of IAM role |
+| <a name="output_this_iam_role_unique_id"></a> [this\_iam\_role\_unique\_id](#output\_this\_iam\_role\_unique\_id) | Unique ID of IAM role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-role/outputs.tf
+++ b/examples/iam-assumable-role/outputs.tf
@@ -13,6 +13,11 @@ output "this_iam_role_path" {
   value       = module.iam_assumable_role_admin.this_iam_role_path
 }
 
+output "this_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.iam_assumable_role_admin.this_iam_role_unique_id
+}
+
 output "role_requires_mfa" {
   description = "Whether admin IAM role requires MFA"
   value       = module.iam_assumable_role_admin.role_requires_mfa

--- a/examples/iam-assumable-roles-with-saml/README.md
+++ b/examples/iam-assumable-roles-with-saml/README.md
@@ -54,10 +54,13 @@ No inputs.
 | <a name="output_admin_iam_role_arn"></a> [admin\_iam\_role\_arn](#output\_admin\_iam\_role\_arn) | ARN of admin IAM role |
 | <a name="output_admin_iam_role_name"></a> [admin\_iam\_role\_name](#output\_admin\_iam\_role\_name) | Name of admin IAM role |
 | <a name="output_admin_iam_role_path"></a> [admin\_iam\_role\_path](#output\_admin\_iam\_role\_path) | Path of admin IAM role |
+| <a name="output_admin_iam_role_unique_id"></a> [admin\_iam\_role\_unique\_id](#output\_admin\_iam\_role\_unique\_id) | Unique ID of IAM role |
 | <a name="output_poweruser_iam_role_arn"></a> [poweruser\_iam\_role\_arn](#output\_poweruser\_iam\_role\_arn) | ARN of poweruser IAM role |
 | <a name="output_poweruser_iam_role_name"></a> [poweruser\_iam\_role\_name](#output\_poweruser\_iam\_role\_name) | Name of poweruser IAM role |
 | <a name="output_poweruser_iam_role_path"></a> [poweruser\_iam\_role\_path](#output\_poweruser\_iam\_role\_path) | Path of poweruser IAM role |
+| <a name="output_poweruser_iam_role_unique_id"></a> [poweruser\_iam\_role\_unique\_id](#output\_poweruser\_iam\_role\_unique\_id) | Unique ID of IAM role |
 | <a name="output_readonly_iam_role_arn"></a> [readonly\_iam\_role\_arn](#output\_readonly\_iam\_role\_arn) | ARN of readonly IAM role |
 | <a name="output_readonly_iam_role_name"></a> [readonly\_iam\_role\_name](#output\_readonly\_iam\_role\_name) | Name of readonly IAM role |
 | <a name="output_readonly_iam_role_path"></a> [readonly\_iam\_role\_path](#output\_readonly\_iam\_role\_path) | Path of readonly IAM role |
+| <a name="output_readonly_iam_role_unique_id"></a> [readonly\_iam\_role\_unique\_id](#output\_readonly\_iam\_role\_unique\_id) | Unique ID of IAM role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-roles-with-saml/outputs.tf
+++ b/examples/iam-assumable-roles-with-saml/outputs.tf
@@ -14,6 +14,11 @@ output "admin_iam_role_path" {
   value       = module.iam_assumable_roles_with_saml.admin_iam_role_path
 }
 
+output "admin_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.iam_assumable_roles_with_saml.admin_iam_role_unique_id
+}
+
 # Poweruser
 output "poweruser_iam_role_arn" {
   description = "ARN of poweruser IAM role"
@@ -30,6 +35,11 @@ output "poweruser_iam_role_path" {
   value       = module.iam_assumable_roles_with_saml.poweruser_iam_role_path
 }
 
+output "poweruser_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.iam_assumable_roles_with_saml.poweruser_iam_role_unique_id
+}
+
 # Readonly
 output "readonly_iam_role_arn" {
   description = "ARN of readonly IAM role"
@@ -44,4 +54,9 @@ output "readonly_iam_role_name" {
 output "readonly_iam_role_path" {
   description = "Path of readonly IAM role"
   value       = module.iam_assumable_roles_with_saml.readonly_iam_role_path
+}
+
+output "readonly_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.iam_assumable_roles_with_saml.readonly_iam_role_unique_id
 }

--- a/examples/iam-assumable-roles/README.md
+++ b/examples/iam-assumable-roles/README.md
@@ -48,12 +48,15 @@ No inputs.
 | <a name="output_admin_iam_role_name"></a> [admin\_iam\_role\_name](#output\_admin\_iam\_role\_name) | Name of admin IAM role |
 | <a name="output_admin_iam_role_path"></a> [admin\_iam\_role\_path](#output\_admin\_iam\_role\_path) | Path of admin IAM role |
 | <a name="output_admin_iam_role_requires_mfa"></a> [admin\_iam\_role\_requires\_mfa](#output\_admin\_iam\_role\_requires\_mfa) | Whether admin IAM role requires MFA |
+| <a name="output_admin_iam_role_unique_id"></a> [admin\_iam\_role\_unique\_id](#output\_admin\_iam\_role\_unique\_id) | Unique ID of IAM role |
 | <a name="output_poweruser_iam_role_arn"></a> [poweruser\_iam\_role\_arn](#output\_poweruser\_iam\_role\_arn) | ARN of poweruser IAM role |
 | <a name="output_poweruser_iam_role_name"></a> [poweruser\_iam\_role\_name](#output\_poweruser\_iam\_role\_name) | Name of poweruser IAM role |
 | <a name="output_poweruser_iam_role_path"></a> [poweruser\_iam\_role\_path](#output\_poweruser\_iam\_role\_path) | Path of poweruser IAM role |
 | <a name="output_poweruser_iam_role_requires_mfa"></a> [poweruser\_iam\_role\_requires\_mfa](#output\_poweruser\_iam\_role\_requires\_mfa) | Whether poweruser IAM role requires MFA |
+| <a name="output_poweruser_iam_role_unique_id"></a> [poweruser\_iam\_role\_unique\_id](#output\_poweruser\_iam\_role\_unique\_id) | Unique ID of IAM role |
 | <a name="output_readonly_iam_role_arn"></a> [readonly\_iam\_role\_arn](#output\_readonly\_iam\_role\_arn) | ARN of readonly IAM role |
 | <a name="output_readonly_iam_role_name"></a> [readonly\_iam\_role\_name](#output\_readonly\_iam\_role\_name) | Name of readonly IAM role |
 | <a name="output_readonly_iam_role_path"></a> [readonly\_iam\_role\_path](#output\_readonly\_iam\_role\_path) | Path of readonly IAM role |
 | <a name="output_readonly_iam_role_requires_mfa"></a> [readonly\_iam\_role\_requires\_mfa](#output\_readonly\_iam\_role\_requires\_mfa) | Whether readonly IAM role requires MFA |
+| <a name="output_readonly_iam_role_unique_id"></a> [readonly\_iam\_role\_unique\_id](#output\_readonly\_iam\_role\_unique\_id) | Unique ID of IAM role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-assumable-roles/outputs.tf
+++ b/examples/iam-assumable-roles/outputs.tf
@@ -19,6 +19,11 @@ output "admin_iam_role_path" {
   value       = module.iam_assumable_roles.admin_iam_role_path
 }
 
+output "admin_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.iam_assumable_role_admin.admin_iam_role_unique_id
+}
+
 # Poweruser
 output "poweruser_iam_role_arn" {
   description = "ARN of poweruser IAM role"
@@ -40,6 +45,11 @@ output "poweruser_iam_role_path" {
   value       = module.iam_assumable_roles.poweruser_iam_role_path
 }
 
+output "poweruser_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.iam_assumable_roles.poweruser_iam_role_unique_id
+}
+
 # Readonly
 output "readonly_iam_role_arn" {
   description = "ARN of readonly IAM role"
@@ -54,6 +64,11 @@ output "readonly_iam_role_name" {
 output "readonly_iam_role_path" {
   description = "Path of readonly IAM role"
   value       = module.iam_assumable_roles.readonly_iam_role_path
+}
+
+output "readonly_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.iam_assumable_roles.readonly_iam_role_unique_id
 }
 
 output "readonly_iam_role_requires_mfa" {

--- a/examples/iam-assumable-roles/outputs.tf
+++ b/examples/iam-assumable-roles/outputs.tf
@@ -21,7 +21,7 @@ output "admin_iam_role_path" {
 
 output "admin_iam_role_unique_id" {
   description = "Unique ID of IAM role"
-  value       = module.iam_assumable_role_admin.admin_iam_role_unique_id
+  value       = module.iam_assumable_roles.admin_iam_role_unique_id
 }
 
 # Poweruser

--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -62,4 +62,5 @@ No modules.
 | <a name="output_this_iam_role_arn"></a> [this\_iam\_role\_arn](#output\_this\_iam\_role\_arn) | ARN of IAM role |
 | <a name="output_this_iam_role_name"></a> [this\_iam\_role\_name](#output\_this\_iam\_role\_name) | Name of IAM role |
 | <a name="output_this_iam_role_path"></a> [this\_iam\_role\_path](#output\_this\_iam\_role\_path) | Path of IAM role |
+| <a name="output_this_iam_role_unique_id"></a> [this\_iam\_role\_unique\_id](#output\_this\_iam\_role\_unique\_id) | Unique ID of IAM role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-role-with-oidc/outputs.tf
+++ b/modules/iam-assumable-role-with-oidc/outputs.tf
@@ -12,3 +12,8 @@ output "this_iam_role_path" {
   description = "Path of IAM role"
   value       = element(concat(aws_iam_role.this.*.path, [""]), 0)
 }
+
+output "this_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = element(concat(aws_iam_role.this.*.unique_id, [""]), 0)
+}

--- a/modules/iam-assumable-role-with-saml/README.md
+++ b/modules/iam-assumable-role-with-saml/README.md
@@ -57,4 +57,5 @@ No modules.
 | <a name="output_this_iam_role_arn"></a> [this\_iam\_role\_arn](#output\_this\_iam\_role\_arn) | ARN of IAM role |
 | <a name="output_this_iam_role_name"></a> [this\_iam\_role\_name](#output\_this\_iam\_role\_name) | Name of IAM role |
 | <a name="output_this_iam_role_path"></a> [this\_iam\_role\_path](#output\_this\_iam\_role\_path) | Path of IAM role |
+| <a name="output_this_iam_role_unique_id"></a> [this\_iam\_role\_unique\_id](#output\_this\_iam\_role\_unique\_id) | Unique ID of IAM role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-role-with-saml/outputs.tf
+++ b/modules/iam-assumable-role-with-saml/outputs.tf
@@ -12,3 +12,8 @@ output "this_iam_role_path" {
   description = "Path of IAM role"
   value       = element(concat(aws_iam_role.this.*.path, [""]), 0)
 }
+
+output "this_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = element(concat(aws_iam_role.this.*.unique_id, [""]), 0)
+}

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -71,10 +71,13 @@ No modules.
 | <a name="output_admin_iam_role_arn"></a> [admin\_iam\_role\_arn](#output\_admin\_iam\_role\_arn) | ARN of admin IAM role |
 | <a name="output_admin_iam_role_name"></a> [admin\_iam\_role\_name](#output\_admin\_iam\_role\_name) | Name of admin IAM role |
 | <a name="output_admin_iam_role_path"></a> [admin\_iam\_role\_path](#output\_admin\_iam\_role\_path) | Path of admin IAM role |
+| <a name="output_admin_iam_role_unique_id"></a> [admin\_iam\_role\_unique\_id](#output\_admin\_iam\_role\_unique\_id) | Unique ID of IAM role |
 | <a name="output_poweruser_iam_role_arn"></a> [poweruser\_iam\_role\_arn](#output\_poweruser\_iam\_role\_arn) | ARN of poweruser IAM role |
 | <a name="output_poweruser_iam_role_name"></a> [poweruser\_iam\_role\_name](#output\_poweruser\_iam\_role\_name) | Name of poweruser IAM role |
 | <a name="output_poweruser_iam_role_path"></a> [poweruser\_iam\_role\_path](#output\_poweruser\_iam\_role\_path) | Path of poweruser IAM role |
+| <a name="output_poweruser_iam_role_unique_id"></a> [poweruser\_iam\_role\_unique\_id](#output\_poweruser\_iam\_role\_unique\_id) | Unique ID of IAM role |
 | <a name="output_readonly_iam_role_arn"></a> [readonly\_iam\_role\_arn](#output\_readonly\_iam\_role\_arn) | ARN of readonly IAM role |
 | <a name="output_readonly_iam_role_name"></a> [readonly\_iam\_role\_name](#output\_readonly\_iam\_role\_name) | Name of readonly IAM role |
 | <a name="output_readonly_iam_role_path"></a> [readonly\_iam\_role\_path](#output\_readonly\_iam\_role\_path) | Path of readonly IAM role |
+| <a name="output_readonly_iam_role_unique_id"></a> [readonly\_iam\_role\_unique\_id](#output\_readonly\_iam\_role\_unique\_id) | Unique ID of IAM role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-roles-with-saml/outputs.tf
+++ b/modules/iam-assumable-roles-with-saml/outputs.tf
@@ -14,6 +14,11 @@ output "admin_iam_role_path" {
   value       = element(concat(aws_iam_role.admin.*.path, [""]), 0)
 }
 
+output "admin_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = element(concat(aws_iam_role.admin.*.unique_id, [""]), 0)
+}
+
 output "poweruser_iam_role_arn" {
   description = "ARN of poweruser IAM role"
   value       = element(concat(aws_iam_role.poweruser.*.arn, [""]), 0)
@@ -27,6 +32,11 @@ output "poweruser_iam_role_name" {
 output "poweruser_iam_role_path" {
   description = "Path of poweruser IAM role"
   value       = element(concat(aws_iam_role.poweruser.*.path, [""]), 0)
+}
+
+output "poweruser_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = element(concat(aws_iam_role.poweruser.*.unique_id, [""]), 0)
 }
 
 # Readonly
@@ -43,4 +53,9 @@ output "readonly_iam_role_name" {
 output "readonly_iam_role_path" {
   description = "Path of readonly IAM role"
   value       = element(concat(aws_iam_role.readonly.*.path, [""]), 0)
+}
+
+output "readonly_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = element(concat(aws_iam_role.readonly.*.unique_id, [""]), 0)
 }

--- a/modules/iam-assumable-roles/README.md
+++ b/modules/iam-assumable-roles/README.md
@@ -74,12 +74,15 @@ No modules.
 | <a name="output_admin_iam_role_name"></a> [admin\_iam\_role\_name](#output\_admin\_iam\_role\_name) | Name of admin IAM role |
 | <a name="output_admin_iam_role_path"></a> [admin\_iam\_role\_path](#output\_admin\_iam\_role\_path) | Path of admin IAM role |
 | <a name="output_admin_iam_role_requires_mfa"></a> [admin\_iam\_role\_requires\_mfa](#output\_admin\_iam\_role\_requires\_mfa) | Whether admin IAM role requires MFA |
+| <a name="output_admin_iam_role_unique_id"></a> [admin\_iam\_role\_unique\_id](#output\_admin\_iam\_role\_unique\_id) | Unique ID of IAM role |
 | <a name="output_poweruser_iam_role_arn"></a> [poweruser\_iam\_role\_arn](#output\_poweruser\_iam\_role\_arn) | ARN of poweruser IAM role |
 | <a name="output_poweruser_iam_role_name"></a> [poweruser\_iam\_role\_name](#output\_poweruser\_iam\_role\_name) | Name of poweruser IAM role |
 | <a name="output_poweruser_iam_role_path"></a> [poweruser\_iam\_role\_path](#output\_poweruser\_iam\_role\_path) | Path of poweruser IAM role |
 | <a name="output_poweruser_iam_role_requires_mfa"></a> [poweruser\_iam\_role\_requires\_mfa](#output\_poweruser\_iam\_role\_requires\_mfa) | Whether poweruser IAM role requires MFA |
+| <a name="output_poweruser_iam_role_unique_id"></a> [poweruser\_iam\_role\_unique\_id](#output\_poweruser\_iam\_role\_unique\_id) | Unique ID of IAM role |
 | <a name="output_readonly_iam_role_arn"></a> [readonly\_iam\_role\_arn](#output\_readonly\_iam\_role\_arn) | ARN of readonly IAM role |
 | <a name="output_readonly_iam_role_name"></a> [readonly\_iam\_role\_name](#output\_readonly\_iam\_role\_name) | Name of readonly IAM role |
 | <a name="output_readonly_iam_role_path"></a> [readonly\_iam\_role\_path](#output\_readonly\_iam\_role\_path) | Path of readonly IAM role |
 | <a name="output_readonly_iam_role_requires_mfa"></a> [readonly\_iam\_role\_requires\_mfa](#output\_readonly\_iam\_role\_requires\_mfa) | Whether readonly IAM role requires MFA |
+| <a name="output_readonly_iam_role_unique_id"></a> [readonly\_iam\_role\_unique\_id](#output\_readonly\_iam\_role\_unique\_id) | Unique ID of IAM role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-assumable-roles/outputs.tf
+++ b/modules/iam-assumable-roles/outputs.tf
@@ -14,6 +14,11 @@ output "admin_iam_role_path" {
   value       = element(concat(aws_iam_role.admin.*.path, [""]), 0)
 }
 
+output "admin_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = element(concat(aws_iam_role.admin.*.unique_id, [""]), 0)
+}
+
 output "admin_iam_role_requires_mfa" {
   description = "Whether admin IAM role requires MFA"
   value       = var.admin_role_requires_mfa
@@ -35,6 +40,11 @@ output "poweruser_iam_role_path" {
   value       = element(concat(aws_iam_role.poweruser.*.path, [""]), 0)
 }
 
+output "poweruser_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = element(concat(aws_iam_role.poweruser.*.unique_id, [""]), 0)
+}
+
 output "poweruser_iam_role_requires_mfa" {
   description = "Whether poweruser IAM role requires MFA"
   value       = var.poweruser_role_requires_mfa
@@ -54,6 +64,11 @@ output "readonly_iam_role_name" {
 output "readonly_iam_role_path" {
   description = "Path of readonly IAM role"
   value       = element(concat(aws_iam_role.readonly.*.path, [""]), 0)
+}
+
+output "readonly_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = element(concat(aws_iam_role.readonly.*.unique_id, [""]), 0)
 }
 
 output "readonly_iam_role_requires_mfa" {


### PR DESCRIPTION
## Description
Adds unique_id from aws_iam_role to outputs.

## Motivation and Context
Resolves #141. The unique_id is required in certain AWS contexts, so it is a needed output.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
Deployed module from personal fork and verified that unique_ids are present in the output.

