### PR TITLE
feat: Add audience options for oidc roles

### DIFF
--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -45,6 +45,8 @@ No modules.
 | <a name="input_number_of_role_policy_arns"></a> [number\_of\_role\_policy\_arns](#input\_number\_of\_role\_policy\_arns) | Number of IAM policies to attach to IAM role | `number` | `null` | no |
 | <a name="input_oidc_fully_qualified_subjects"></a> [oidc\_fully\_qualified\_subjects](#input\_oidc\_fully\_qualified\_subjects) | The fully qualified OIDC subjects to be added to the role policy | `set(string)` | `[]` | no |
 | <a name="input_oidc_subjects_with_wildcards"></a> [oidc\_subjects\_with\_wildcards](#input\_oidc\_subjects\_with\_wildcards) | The OIDC subject using wildcards to be added to the role policy | `set(string)` | `[]` | no |
+| <a name="input_oidc_fully_qualified_audiences"></a> [oidc\_fully\_qualified\_audiences](#input\_oidc\_fully\_qualified\_audiences) | The fully qualified OIDC audiences to be added to the role policy | `set(string)` | `[]` | no |
+| <a name="input_oidc_audiences_with_wildcards"></a> [oidc\_audiences\_with\_wildcards](#input\_oidc\_audiences\_with\_wildcards) | The OIDC audience using wildcards to be added to the role policy | `set(string)` | `[]` | no |
 | <a name="input_provider_url"></a> [provider\_url](#input\_provider\_url) | URL of the OIDC Provider. Use provider\_urls to specify several URLs. | `string` | `""` | no |
 | <a name="input_provider_urls"></a> [provider\_urls](#input\_provider\_urls) | List of URLs of the OIDC Providers | `list(string)` | `[]` | no |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | IAM Role description | `string` | `""` | no |

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -48,6 +48,27 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
           values   = var.oidc_subjects_with_wildcards
         }
       }
+
+      dynamic "condition" {
+        for_each = length(var.oidc_fully_qualified_audiences) > 0 ? local.urls : []
+
+        content {
+          test     = "StringEquals"
+          variable = "${statement.value}:aud"
+          values   = var.oidc_fully_qualified_audiences
+        }
+      }
+
+      dynamic "condition" {
+        for_each = length(var.oidc_audiences_with_wildcards) > 0 ? local.urls : []
+
+        content {
+          test     = "StringLike"
+          variable = "${statement.value}:aud"
+          values   = var.oidc_audiences_with_wildcards
+        }
+      }
+
     }
   }
 }

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -89,6 +89,18 @@ variable "oidc_subjects_with_wildcards" {
   default     = []
 }
 
+variable "oidc_fully_qualified_audiences" {
+  description = "The fully qualified OIDC audiences to be added to the role policy"
+  type        = set(string)
+  default     = []
+}
+
+variable "oidc_audiences_with_wildcards" {
+  description = "The OIDC audiences using wildcards to be added to the role policy"
+  type        = set(string)
+  default     = []
+}
+
 variable "force_detach_policies" {
   description = "Whether policies should be detached from this role when destroying"
   type        = bool


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add `oidc_fully_qualified_audiences` and `oidc_audiences_with_wildcards` options work like `oidc_fully_qualified_subjects` and `oidc_subjects_with_wildcards`.

For example, input
```
oidc_fully_qualified_audiences = ["sts.amazonaws.com", "test-records"]
``` 
will output
```
  ~ resource "aws_iam_role" "this" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringEquals = {
                              ~ oidc.eks.ap-southeast-1.amazonaws.com/id/XXXXXXXX:aud = "sts.amazonaws.com" -> [
                                  + "sts.amazonaws.com",
                                  + "test-records",
                                  ...
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enable [IRSA option](https://github.com/terraform-aws-modules/terraform-aws-eks#input_enable_irsa) in EKS module will create a OIDC provider with `sts.amazonaws.com` audience. It's need to be configured for making service account association works. 

EKS module version: `v.16.1.0`

## Breaking Changes
None.
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
