### PR TITLE
fix(iam-user): Add 'sensitive' flag to output 'pgp_key'

### DIFF
--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -83,6 +83,7 @@ output "iam_access_key_status" {
 
 output "pgp_key" {
   description = "PGP key used to encrypt sensitive data for this user (if empty - secrets are not encrypted)"
+  sensitive   = true
   value       = var.pgp_key
 }
 


### PR DESCRIPTION
## Description

Add "sensitive" flag to output "pgp_key" for module iam-user.  
Fix `Error: Output refers to sensitive values`.

## Motivation and Context

Fix `Error: Output refers to sensitive values`.

## Breaking Changes

None

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
