### PR TITLE
feat: Cross-account in iam-assumable-role-with-oidc

### DIFF
--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -43,6 +43,7 @@ No modules.
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `false` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
 | <a name="input_number_of_role_policy_arns"></a> [number\_of\_role\_policy\_arns](#input\_number\_of\_role\_policy\_arns) | Number of IAM policies to attach to IAM role | `number` | `null` | no |
+| <a name="input_oidc_fully_qualified_audiences"></a> [oidc\_fully\_qualified\_audiences](#input\_oidc\_fully\_qualified\_audiences) | The audience to be added to the role policy. Set to sts.amazonaws.com for cross-account assumable role. Leave empty otherwise. | `set(string)` | `[]` | no |
 | <a name="input_oidc_fully_qualified_subjects"></a> [oidc\_fully\_qualified\_subjects](#input\_oidc\_fully\_qualified\_subjects) | The fully qualified OIDC subjects to be added to the role policy | `set(string)` | `[]` | no |
 | <a name="input_oidc_subjects_with_wildcards"></a> [oidc\_subjects\_with\_wildcards](#input\_oidc\_subjects\_with\_wildcards) | The OIDC subject using wildcards to be added to the role policy | `set(string)` | `[]` | no |
 | <a name="input_provider_url"></a> [provider\_url](#input\_provider\_url) | URL of the OIDC Provider. Use provider\_urls to specify several URLs. | `string` | `""` | no |

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -50,12 +50,12 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       }
 
       dynamic "condition" {
-        for_each = length(var.oidc_fully_qualified_audience) > 0 ? local.urls : []
+        for_each = length(var.oidc_fully_qualified_audiences) > 0 ? local.urls : []
 
         content {
           test     = "StringLike"
           variable = "${statement.value}:aud"
-          values   = var.oidc_fully_qualified_audience
+          values   = var.oidc_fully_qualified_audiences
         }
       }
     }

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -48,6 +48,16 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
           values   = var.oidc_subjects_with_wildcards
         }
       }
+
+      dynamic "condition" {
+        for_each = length(var.oidc_fully_qualified_audience) > 0 ? local.urls : []
+
+        content {
+          test     = "StringLike"
+          variable = "${statement.value}:aud"
+          values   = var.oidc_fully_qualified_audience
+        }
+      }
     }
   }
 }

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -76,6 +76,7 @@ variable "number_of_role_policy_arns" {
   default     = null
 }
 
+
 variable "oidc_fully_qualified_subjects" {
   description = "The fully qualified OIDC subjects to be added to the role policy"
   type        = set(string)

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -76,7 +76,6 @@ variable "number_of_role_policy_arns" {
   default     = null
 }
 
-
 variable "oidc_fully_qualified_subjects" {
   description = "The fully qualified OIDC subjects to be added to the role policy"
   type        = set(string)
@@ -85,6 +84,12 @@ variable "oidc_fully_qualified_subjects" {
 
 variable "oidc_subjects_with_wildcards" {
   description = "The OIDC subject using wildcards to be added to the role policy"
+  type        = set(string)
+  default     = []
+}
+
+variable "oidc_fully_qualified_audience" {
+  description = "The audience to be added to the role policy. Set to sts.amazonaws.com for cross-account assumable role. Leave empty otherwise."
   type        = set(string)
   default     = []
 }

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -89,7 +89,7 @@ variable "oidc_subjects_with_wildcards" {
   default     = []
 }
 
-variable "oidc_fully_qualified_audience" {
+variable "oidc_fully_qualified_audiences" {
   description = "The audience to be added to the role policy. Set to sts.amazonaws.com for cross-account assumable role. Leave empty otherwise."
   type        = set(string)
   default     = []


### PR DESCRIPTION
## Description
This adds support for cross-account assumable role with OIDC

## Motivation and Context
We have a use-case where a EKS service account in an account should be able to assume a role in a EKS cluster in another account.
Fixes https://github.com/terraform-aws-modules/terraform-aws-iam/issues/157

## Breaking Changes
It doesn't bring a breaking change.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

In my environment, the module `iam-assumable-role-with-oidc` is used as a submodule in our custom irsa terraform module. 
I created a new irsa module, calling my updated `terraform-aws-iam//modules/iam-assumable-role-with-oidc`.
As a variable, I've set `oidc_fully_qualified_audience` to `sts.amazonaws.com` and then ran `tf apply`

Below the relevant part of it:
```  
# module.k8s_crossaccount_irsa.module.iam_assumable_role_with_oidc.aws_iam_role.this[0] will be created
  + resource "aws_iam_role" "this" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRoleWithWebIdentity"
                      + Condition = {
                          + StringLike = {
                              + oidc.eks.eu-west-1.amazonaws.com/id/my_oidc_provider_id:aud = [
                                  + "sts.amazonaws.com",
                                ]
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::012345678901:oidc-provider/oidc.eks.eu-west-1.amazonaws.com/id/my_oidc_provider_id"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "cluster-a-test-role"
      + path                  = "/"
      + tags                  = {
          + "Role" = "role-with-oidc"
        }
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # module.k8s_crossaccount_irsa.module.iam_assumable_role_with_oidc.aws_iam_role_policy_attachment.custom[0] will be created
  + resource "aws_iam_role_policy_attachment" "custom" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "cluster-a-test-role"
    }
```

terraform version: `v0.14.6` 
aws provider version: `v3.37.0`

