### PR TITLE
feat: Add ability for controlling whether or not to create a policy

### DIFF
--- a/examples/iam-policy/README.md
+++ b/examples/iam-policy/README.md
@@ -34,6 +34,7 @@ Run `terraform destroy` when you don't need these resources.
 |------|--------|---------|
 | <a name="module_iam_policy"></a> [iam\_policy](#module\_iam\_policy) | ../../modules/iam-policy |  |
 | <a name="module_iam_policy_from_data_source"></a> [iam\_policy\_from\_data\_source](#module\_iam\_policy\_from\_data\_source) | ../../modules/iam-policy |  |
+| <a name="module_iam_policy_optional"></a> [iam\_policy\_optional](#module\_iam\_policy\_optional) | ../../modules/iam-policy |  |
 
 ## Resources
 

--- a/examples/iam-policy/main.tf
+++ b/examples/iam-policy/main.tf
@@ -53,3 +53,9 @@ module "iam_policy_from_data_source" {
     PolicyDescription = "Policy created using example from data source"
   }
 }
+
+module "iam_policy_optional" {
+  source = "../../modules/iam-policy"
+
+  create_policy = false
+}

--- a/modules/iam-policy/README.md
+++ b/modules/iam-policy/README.md
@@ -30,6 +30,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | Whether to create the IAM policy | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the policy | `string` | `"IAM Policy"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the policy | `string` | `""` | no |
 | <a name="input_path"></a> [path](#input\_path) | The path of the policy in IAM | `string` | `"/"` | no |

--- a/modules/iam-policy/main.tf
+++ b/modules/iam-policy/main.tf
@@ -1,4 +1,6 @@
 resource "aws_iam_policy" "policy" {
+  count = var.create_policy ? 1 : 0
+
   name        = var.name
   path        = var.path
   description = var.description
@@ -7,4 +9,3 @@ resource "aws_iam_policy" "policy" {
 
   tags = var.tags
 }
-

--- a/modules/iam-policy/outputs.tf
+++ b/modules/iam-policy/outputs.tf
@@ -1,30 +1,29 @@
 output "id" {
   description = "The policy's ID"
-  value       = aws_iam_policy.policy.id
+  value       = element(concat(aws_iam_policy.policy.*.id, [""]), 0)
 }
 
 output "arn" {
   description = "The ARN assigned by AWS to this policy"
-  value       = aws_iam_policy.policy.arn
+  value       = element(concat(aws_iam_policy.policy.*.arn, [""]), 0)
 }
 
 output "description" {
   description = "The description of the policy"
-  value       = aws_iam_policy.policy.description
+  value       = element(concat(aws_iam_policy.policy.*.description, [""]), 0)
 }
 
 output "name" {
   description = "The name of the policy"
-  value       = aws_iam_policy.policy.name
+  value       = element(concat(aws_iam_policy.policy.*.name, [""]), 0)
 }
 
 output "path" {
   description = "The path of the policy in IAM"
-  value       = aws_iam_policy.policy.path
+  value       = element(concat(aws_iam_policy.policy.*.path, [""]), 0)
 }
 
 output "policy" {
   description = "The policy document"
-  value       = aws_iam_policy.policy.policy
+  value       = element(concat(aws_iam_policy.policy.*.policy, [""]), 0)
 }
-

--- a/modules/iam-policy/variables.tf
+++ b/modules/iam-policy/variables.tf
@@ -1,3 +1,9 @@
+variable "create_policy" {
+  description = "Whether to create the IAM policy"
+  type        = bool
+  default     = true
+}
+
 variable "name" {
   description = "The name of the policy"
   type        = string


### PR DESCRIPTION
## Description
Add ability for controlling whether or not to create a policy

## Motivation and Context
In certain scenarios can be useful to decide which specific policy should be created or not. Let's imagine that we create a module from this module for creating a set of policies that might change depending on the account you are targeting. This change allows you to do that.

## Breaking Changes
There is no breaking change as the module still behaving the same by default.

## How Has This Been Tested?
- [✅] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [✅] Tested over my own AWS account.