### PR TITLE
feat: iam-group-with-policies output group_arn

### DIFF
--- a/examples/iam-group-with-policies/README.md
+++ b/examples/iam-group-with-policies/README.md
@@ -51,6 +51,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_group_arn"></a> [group\_arn](#output\_group\_arn) | IAM group arn |
 | <a name="output_group_name"></a> [group\_name](#output\_group\_name) | IAM group name |
 | <a name="output_group_users"></a> [group\_users](#output\_group\_users) | List of IAM users in IAM group |
 | <a name="output_iam_account_id"></a> [iam\_account\_id](#output\_iam\_account\_id) | IAM AWS account id |

--- a/examples/iam-group-with-policies/outputs.tf
+++ b/examples/iam-group-with-policies/outputs.tf
@@ -3,6 +3,11 @@ output "iam_account_id" {
   value       = module.iam_group_superadmins.aws_account_id
 }
 
+output "group_arn" {
+  description = "IAM group arn"
+  value       = module.iam_group_superadmins.group_arn
+}
+
 output "group_users" {
   description = "List of IAM users in IAM group"
   value       = module.iam_group_superadmins.group_users

--- a/modules/iam-group-with-policies/README.md
+++ b/modules/iam-group-with-policies/README.md
@@ -54,6 +54,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_aws_account_id"></a> [aws\_account\_id](#output\_aws\_account\_id) | IAM AWS account id |
+| <a name="output_group_arn"></a> [group\_arn](#output\_group\_arn) | IAM group arn |
 | <a name="output_group_name"></a> [group\_name](#output\_group\_name) | IAM group name |
 | <a name="output_group_users"></a> [group\_users](#output\_group\_users) | List of IAM users in IAM group |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-group-with-policies/outputs.tf
+++ b/modules/iam-group-with-policies/outputs.tf
@@ -5,7 +5,7 @@ output "aws_account_id" {
 
 output "group_arn" {
   description = "IAM group arn"
-  value       = element(aws_iam_group.this.*.arn, 0)
+  value       = element(concat(aws_iam_group.this.*.arn, [""]), 0)
 }
 
 output "group_users" {

--- a/modules/iam-group-with-policies/outputs.tf
+++ b/modules/iam-group-with-policies/outputs.tf
@@ -3,6 +3,11 @@ output "aws_account_id" {
   value       = local.aws_account_id
 }
 
+output "group_arn" {
+  description = "IAM group arn"
+  value       = element(aws_iam_group.this.*.arn, 0)
+}
+
 output "group_users" {
   description = "List of IAM users in IAM group"
   value       = flatten(aws_iam_group_membership.this.*.users)


### PR DESCRIPTION
## Description
Add `group_arn` to the outputs of the `iam-group-with-policies` module.

## Motivation and Context
I was missing this feature for a personal project, where I am using the `iam-assumable-roles` module and want to refer to a group by its ARN.

## Breaking Changes
No breaking changes, just adding a new output.

## How Has This Been Tested?
I have tested this change on my aforementioned project. The output is there and I can refer to it in other resources.
