### PR TITLE
feat: Added support for trusted_role_actions for MFA in iam-assumable-role

### DIFF
--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "assume_role_with_mfa" {
   statement {
     effect = "Allow"
 
-    actions = ["sts:AssumeRole"]
+    actions = var.trusted_role_actions
 
     principals {
       type        = "AWS"


### PR DESCRIPTION
Fixes #152 

## Description
This is a small patch change discussed with @antonbabenko to make sure there is no discrepancy when using  trusted_role_actions with or without MFA

## Motivation and Context
Consistent module behaviour based on inputs

## Breaking Changes
none

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
