### PR TITLE
feat: Update iam-read-only-policy - add default deny actions

### DIFF
--- a/examples/iam-read-only-policy/main.tf
+++ b/examples/iam-read-only-policy/main.tf
@@ -32,6 +32,7 @@ module "read_only_iam_policy" {
   description = "My read only example policy"
 
   allowed_services = local.allowed_services
+  denied_actions   = ["s3:GetObject", "dynamodb:GetRecords"]
 
   tags = {
     PolicyDescription = "My read only example policy"

--- a/modules/iam-read-only-policy/README.md
+++ b/modules/iam-read-only-policy/README.md
@@ -29,6 +29,7 @@ No modules.
 | [aws_iam_policy_document.allowed_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.console_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.deny](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logs_query](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -42,6 +43,7 @@ No modules.
 | <a name="input_allow_web_console_services"></a> [allow\_web\_console\_services](#input\_allow\_web\_console\_services) | Allows List/Get/Describe/View actions for services used when browsing AWS console (e.g. resource-groups, tag, health services) | `bool` | `true` | no |
 | <a name="input_allowed_services"></a> [allowed\_services](#input\_allowed\_services) | List of services to allow Get/List/Describe/View options. Service name should be the same as corresponding service IAM prefix. See what it is for each service here https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html | `list(string)` | n/a | yes |
 | <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | Whether to create the IAM policy | `bool` | `true` | no |
+| <a name="input_denied_actions"></a> [denied\_actions](#input\_denied\_actions) | List of actions to deny by default | `list(string)` | <pre>[<br>  "s3:GetObject"<br>]</pre> | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the policy | `string` | `"IAM Policy"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the policy | `string` | `""` | no |
 | <a name="input_path"></a> [path](#input\_path) | The path of the policy in IAM | `string` | `"/"` | no |

--- a/modules/iam-read-only-policy/main.tf
+++ b/modules/iam-read-only-policy/main.tf
@@ -79,12 +79,24 @@ data "aws_iam_policy_document" "logs_query" {
   }
 }
 
+data "aws_iam_policy_document" "deny" {
+  count = length(var.denied_actions) > 0 ? 1 : 0
+
+  statement {
+    effect    = "Deny"
+    sid       = "Deny"
+    actions   = var.denied_actions
+    resources = ["*"]
+  }
+}
+
 data "aws_iam_policy_document" "combined" {
   source_policy_documents = concat(
     [data.aws_iam_policy_document.allowed_services.json],
     data.aws_iam_policy_document.console_services.*.json,
     data.aws_iam_policy_document.sts.*.json,
     data.aws_iam_policy_document.logs_query.*.json,
+    data.aws_iam_policy_document.deny.*.json,
     [var.additional_policy_json]
   )
 }

--- a/modules/iam-read-only-policy/variables.tf
+++ b/modules/iam-read-only-policy/variables.tf
@@ -27,6 +27,12 @@ variable "allowed_services" {
   type        = list(string)
 }
 
+variable "denied_actions" {
+  description = "List of actions to deny by default"
+  type        = list(string)
+  default     = ["s3:GetObject"]
+}
+
 variable "additional_policy_json" {
   description = "JSON policy document if you want to add custom actions"
   type        = string


### PR DESCRIPTION
## Description
Added a variable to provide a list of IAM actions that will by denied. Default is set to s3:GetObject. See motivation and context for explanation why
 
## Motivation and Context
Based on the feedback from security community I want to add default deny actions since people can accidentally grant s3:GetObject and of objects are not encrypted with KMS CMK then S3 will be able to read object and return it to requester which might be undesired/can cause security issue

## Breaking Changes
N/A

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
Plus local tests