### PR TITLE
feat: Include cost explorer to default console services in `iam-read-only-policy` module

### DIFF
--- a/modules/iam-read-only-policy/README.md
+++ b/modules/iam-read-only-policy/README.md
@@ -46,7 +46,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The name of the policy | `string` | `""` | no |
 | <a name="input_path"></a> [path](#input\_path) | The path of the policy in IAM | `string` | `"/"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
-| <a name="input_web_console_services"></a> [web\_console\_services](#input\_web\_console\_services) | List of web console services to allow | `list(string)` | <pre>[<br>  "resource-groups",<br>  "tag",<br>  "health"<br>]</pre> | no |
+| <a name="input_web_console_services"></a> [web\_console\_services](#input\_web\_console\_services) | List of web console services to allow | `list(string)` | <pre>[<br>  "resource-groups",<br>  "tag",<br>  "health",<br>  "ce"<br>]</pre> | no |
 
 ## Outputs
 

--- a/modules/iam-read-only-policy/variables.tf
+++ b/modules/iam-read-only-policy/variables.tf
@@ -60,5 +60,5 @@ variable "allow_web_console_services" {
 variable "web_console_services" {
   description = "List of web console services to allow"
   type        = list(string)
-  default     = ["resource-groups", "tag", "health"]
+  default     = ["resource-groups", "tag", "health", "ce"]
 }


### PR DESCRIPTION
## Description
Added Cost Explorer to default console services defaults.
 
## Motivation and Context
AWS updated home screen and now it shows data from cost explorer thus generating Cloud Trail accessed denied events if policy does not container Cost Explorer

## Breaking Changes
N/A

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
Plus local tests