### PR TITLE
fix: Correct permission on AWS load balancer controller

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -718,7 +718,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "elasticloadbalancing:RemoveListenerCertificates",
       "elasticloadbalancing:ModifyRule",
     ]
-    resources = ["arn:${local.partition}:elasticloadbalancing:*:*:targetgroup/*/*"]
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
## Description
- Correct permission on AWS load balancer controller; looks like it was a copy past error https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/694a0b14184e388806f9f34be0dd9075aa8fb0a7/docs/install/iam_policy.json#L216

## Motivation and Context
- Closes #190 

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
