### PR TITLE
fix: Add ec2:DescribeInstanceTypes permission for Kubernetes Autoscaler 1.23.0

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -20,6 +20,7 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
       "autoscaling:DescribeLaunchConfigurations",
       "autoscaling:DescribeTags",
       "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
## Description

cluster-autoscaler >=[v1.23.0](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.23.0) requires an extra IAM permission - ec2:DescribeInstanceTypes

## Motivation and Context
The merging of https://github.com/kubernetes/autoscaler/pull/4468 means that the default configuration of the CA will now require an extra IAM permission - `ec2:DescribeInstanceTypes`

## Breaking Changes
No breaking change.