### PR TITLE
docs: Fixed a typo in `var.custom_role_trust_policy` description

### DIFF
--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -46,7 +46,7 @@ No modules.
 | <a name="input_create_instance_profile"></a> [create\_instance\_profile](#input\_create\_instance\_profile) | Whether to create an instance profile | `bool` | `false` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Whether to create a role | `bool` | `false` | no |
 | <a name="input_custom_role_policy_arns"></a> [custom\_role\_policy\_arns](#input\_custom\_role\_policy\_arns) | List of ARNs of IAM policies to attach to IAM role | `list(string)` | `[]` | no |
-| <a name="input_custom_role_trust_policy"></a> [custom\_role\_trust\_policy](#input\_custom\_role\_trust\_policy) | A custorm role trust policy | `string` | `""` | no |
+| <a name="input_custom_role_trust_policy"></a> [custom\_role\_trust\_policy](#input\_custom\_role\_trust\_policy) | A custom role trust policy | `string` | `""` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `false` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
 | <a name="input_mfa_age"></a> [mfa\_age](#input\_mfa\_age) | Max age of valid MFA (in seconds) for roles which require MFA | `number` | `86400` | no |

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -77,7 +77,7 @@ variable "custom_role_policy_arns" {
 }
 
 variable "custom_role_trust_policy" {
-  description = "A custorm role trust policy"
+  description = "A custom role trust policy"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Description
Corrects a typo in the variable description for `var.custom_role_trust_policy`.

## Motivation and Context
Noticed while reviewing docs.

## Breaking Changes
No.

## How Has This Been Tested?
N/A
