### PR TITLE
fix: Use count instead of for_each in iam-eks-role (#193)

### DIFF
--- a/modules/iam-eks-role/main.tf
+++ b/modules/iam-eks-role/main.tf
@@ -73,8 +73,8 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {
-  for_each = toset([for arn in var.role_policy_arns : arn if var.create_role])
+  count = var.create_role ? length(var.role_policy_arns) : 0
 
   role       = aws_iam_role.this[0].name
-  policy_arn = each.key
+  policy_arn = var.role_policy_arns[count.index]
 }


### PR DESCRIPTION
## Description
This is the same method as is used in iam-assumable-role-with-oidc. Since the argument to count is a list, not a set, the number of elements doesn't depend on the values, and terraform can decide how many elements are needed before creating the policies.

## Motivation and Context
This fixes https://github.com/terraform-aws-modules/terraform-aws-iam/issues/193

This issue is a blocker for using this module in automation.

## Breaking Changes
This changes the address of the `aws_iam_role_policy_attachment` resource, since it's index by a number instead of a string.
This will cause the resource to be recreated when applying the module after changes.

There are no changes to the outputs of the module, and the created resources should be identical.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

This was also tested in our automated tests, which create a role and a policy to attach to a service account, like so:

```
resource "aws_iam_policy" "foo" {
  name   = "${var.cluster_name}-foo"
  policy = data.aws_iam_policy_document.foo.json
}

module "foo_role" {
  source  = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
  version = "4.13.1"

  role_description = "IRSA role for foo"
  role_name_prefix = "foo-"
  role_policy_arns = [aws_iam_policy.foo.arn]

  cluster_service_accounts = {
    (var.cluster_name) = ["${var.namespace}:${local.service_account_name}"]
  }
}
```

The change has no effects on the code that uses the module - except that it works when applying in an empty workspace.
