### PR TITLE
fix: Policy generation when `ebs_csi_kms_cmk_ids` is set

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -256,7 +256,7 @@ data "aws_iam_policy_document" "ebs_csi" {
         "kms:RevokeGrant",
       ]
 
-      resources = statement.value
+      resources = var.ebs_csi_kms_cmk_ids
 
       condition {
         test     = "Bool"
@@ -277,7 +277,7 @@ data "aws_iam_policy_document" "ebs_csi" {
         "kms:DescribeKey",
       ]
 
-      resources = statement.value
+      resources = var.ebs_csi_kms_cmk_ids
     }
   }
 }


### PR DESCRIPTION
## Description
Fixed a typo  causing plan/apply to fail when `ebs_csi_kms_cmk_ids` is set in the `"terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"` module.

## Motivation and Context
Without this change, setting `ebs_csi_kms_cmk_ids` results in the following error (`statement.value` is `1` instead of the list of CMK ARNs):
```
╷
│ Error: Incorrect attribute value type
│ 
│   on .terraform/modules/[redacted].aws_ebs_csi_driver_irsa/modules/iam-role-for-service-accounts-eks/policies.tf line 259, in data "aws_iam_policy_document" "ebs_csi":
│  259:       resources = statement.value
│ 
│ Inappropriate value for attribute "resources": set of string required.
╵
╷
│ Error: Incorrect attribute value type
│ 
│   on .terraform/modules/[redacted].aws_ebs_csi_driver_irsa/modules/iam-role-for-service-accounts-eks/policies.tf line 281, in data "aws_iam_policy_document" "ebs_csi":
│  281:       resources = statement.value
│ 
│ Inappropriate value for attribute "resources": set of string required.
```

## Breaking Changes
None

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
Tested, with and without setting `ebs_csi_kms_cmk_ids`, as well as with 0, 1 and multiple values.
