### PR TITLE
feat: Make PGP Key Optional in All Cases

### DIFF
--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -24,13 +24,13 @@ This module outputs commands and PGP messages which can be decrypted either usin
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.50 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.50 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
 
 ## Modules
 
@@ -59,7 +59,7 @@ No modules.
 | <a name="input_password_reset_required"></a> [password\_reset\_required](#input\_password\_reset\_required) | Whether the user should be forced to reset the generated password on first login. | `bool` | `true` | no |
 | <a name="input_path"></a> [path](#input\_path) | Desired path for the IAM user | `string` | `"/"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the user. | `string` | `""` | no |
-| <a name="input_pgp_key"></a> [pgp\_key](#input\_pgp\_key) | Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Used to encrypt password and access key. `pgp_key` is required when `create_iam_user_login_profile` is set to `true` | `string` | `""` | no |
+| <a name="input_pgp_key"></a> [pgp\_key](#input\_pgp\_key) | Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Used to encrypt password and access key. | `string` | `""` | no |
 | <a name="input_ssh_key_encoding"></a> [ssh\_key\_encoding](#input\_ssh\_key\_encoding) | Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH. To retrieve the public key in PEM format, use PEM | `string` | `"SSH"` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The SSH public key. The public key must be encoded in ssh-rsa format or PEM format | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
@@ -78,6 +78,7 @@ No modules.
 | <a name="output_iam_user_arn"></a> [iam\_user\_arn](#output\_iam\_user\_arn) | The ARN assigned by AWS for this user |
 | <a name="output_iam_user_login_profile_encrypted_password"></a> [iam\_user\_login\_profile\_encrypted\_password](#output\_iam\_user\_login\_profile\_encrypted\_password) | The encrypted password, base64 encoded |
 | <a name="output_iam_user_login_profile_key_fingerprint"></a> [iam\_user\_login\_profile\_key\_fingerprint](#output\_iam\_user\_login\_profile\_key\_fingerprint) | The fingerprint of the PGP key used to encrypt the password |
+| <a name="output_iam_user_login_profile_password"></a> [iam\_user\_login\_profile\_password](#output\_iam\_user\_login\_profile\_password) | The user password |
 | <a name="output_iam_user_name"></a> [iam\_user\_name](#output\_iam\_user\_name) | The user's name |
 | <a name="output_iam_user_ssh_key_fingerprint"></a> [iam\_user\_ssh\_key\_fingerprint](#output\_iam\_user\_ssh\_key\_fingerprint) | The MD5 message digest of the SSH public key |
 | <a name="output_iam_user_ssh_key_ssh_public_key_id"></a> [iam\_user\_ssh\_key\_ssh\_public\_key\_id](#output\_iam\_user\_ssh\_key\_ssh\_public\_key\_id) | The unique identifier for the SSH public key |

--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -28,6 +28,12 @@ output "iam_user_login_profile_encrypted_password" {
   value       = try(aws_iam_user_login_profile.this[0].encrypted_password, "")
 }
 
+output "iam_user_login_profile_password" {
+  description = "The user password"
+  value       = try(aws_iam_user_login_profile.this[0].password, "")
+  sensitive = true
+}
+
 output "iam_access_key_id" {
   description = "The access key ID"
   value       = try(aws_iam_access_key.this[0].id, aws_iam_access_key.this_no_pgp[0].id, "")

--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -31,7 +31,7 @@ output "iam_user_login_profile_encrypted_password" {
 output "iam_user_login_profile_password" {
   description = "The user password"
   value       = try(aws_iam_user_login_profile.this[0].password, "")
-  sensitive = true
+  sensitive   = true
 }
 
 output "iam_access_key_id" {

--- a/modules/iam-user/variables.tf
+++ b/modules/iam-user/variables.tf
@@ -34,7 +34,7 @@ variable "force_destroy" {
 }
 
 variable "pgp_key" {
-  description = "Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Used to encrypt password and access key. `pgp_key` is required when `create_iam_user_login_profile` is set to `true`"
+  description = "Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Used to encrypt password and access key."
   type        = string
   default     = ""
 }

--- a/modules/iam-user/versions.tf
+++ b/modules/iam-user/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.50"
+      version = ">= 4.4.0"
     }
   }
 }

--- a/modules/iam-user/versions.tf
+++ b/modules/iam-user/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.4.0"
+      version = ">= 4.1.0"
     }
   }
 }


### PR DESCRIPTION
## Description
This will make the `pgp_key` argument optional in all configurations and add the unencrypted user password to the list of outputs. This will also raise the minimum required `aws` provider version to `4.1.0`

## Motivation and Context
When trying to create an iam user without a `pgp_key` but with an `iam_user_login_profile` the creation would fail.
Since version `4.1.0` of the `aws` provider the `pgp_key` argument of the resource `aws_iam_user_login_profile` is **optional**. Thus the constraint that a `pgp_key` is required when using `create_iam_user_login_profile = true` is not needed anymore.

👉 [Terraform docs for `aws_iam_user_login_profile` (`4.1.0`)](https://registry.terraform.io/providers/hashicorp/aws/4.1.0/docs/resources/iam_user_login_profile)

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided examples/* projects