### PR TITLE
Add a policy for FSx Lustre CSI driver

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/README.md
+++ b/modules/iam-role-for-service-accounts-eks/README.md
@@ -111,6 +111,7 @@ No modules.
 | [aws_iam_policy.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.fsx_lustre_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -119,6 +120,7 @@ No modules.
 | [aws_iam_role_policy_attachment.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.fsx_lustre_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -127,6 +129,7 @@ No modules.
 | [aws_iam_policy_document.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.fsx_lustre_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -142,6 +145,7 @@ No modules.
 | <a name="input_attach_cluster_autoscaler_policy"></a> [attach\_cluster\_autoscaler\_policy](#input\_attach\_cluster\_autoscaler\_policy) | Determines whether to attach the Cluster Autoscaler IAM policy to the role | `bool` | `false` | no |
 | <a name="input_attach_ebs_csi_policy"></a> [attach\_ebs\_csi\_policy](#input\_attach\_ebs\_csi\_policy) | Determines whether to attach the EBS CSI IAM policy to the role | `bool` | `false` | no |
 | <a name="input_attach_external_dns_policy"></a> [attach\_external\_dns\_policy](#input\_attach\_external\_dns\_policy) | Determines whether to attach the External DNS IAM policy to the role | `bool` | `false` | no |
+| <a name="input_attach_fsx_lustre_csi_policy"></a> [attach\_fsx\_lustre\_csi\_policy](#input\_attach\_fsx\_lustre\_csi\_policy) | Determines whether to attach the FSx Lustre CSI IAM policy to the role | `bool` | `false` | no |
 | <a name="input_attach_karpenter_controller_policy"></a> [attach\_karpenter\_controller\_policy](#input\_attach\_karpenter\_controller\_policy) | Determines whether to attach the Karpenter Controller policy to the role | `bool` | `false` | no |
 | <a name="input_attach_load_balancer_controller_policy"></a> [attach\_load\_balancer\_controller\_policy](#input\_attach\_load\_balancer\_controller\_policy) | Determines whether to attach the Load Balancer Controller policy to the role | `bool` | `false` | no |
 | <a name="input_attach_node_termination_handler_policy"></a> [attach\_node\_termination\_handler\_policy](#input\_attach\_node\_termination\_handler\_policy) | Determines whether to attach the Node Termination Handler policy to the role | `bool` | `false` | no |

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -300,6 +300,78 @@ resource "aws_iam_role_policy_attachment" "ebs_csi" {
   policy_arn = aws_iam_policy.ebs_csi[0].arn
 }
 
+
+
+################################################################################
+# FSx Lustre Policy
+################################################################################
+
+# https://github.com/kubernetes-sigs/aws-fsx-csi-driver/blob/master/docs/README.md
+data "aws_iam_policy_document" "fsx_lustre_csi" {
+  count = var.create_role && var.attach_fsx_lustre_csi_policy ? 1 : 0
+
+  statement {
+    actions = [
+      "iam:CreateServiceLinkedRole",
+      "iam:AttachRolePolicy",
+      "iam:PutRolePolicy"
+    ]
+    resources = [
+      "arn:aws:iam::*:role/aws-service-role/s3.data-source.lustre.fsx.amazonaws.com/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "iam:CreateServiceLinkedRole",
+      "iam:AttachRolePolicy",
+      "iam:PutRolePolicy"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "iam:AWSServiceName"
+      values   = ["fsx.amazonaws.com"]
+    }
+  }
+
+  statement {
+    actions = [
+      "fsx:*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "s3:List*",
+      "s3:Get*",
+      "s3:PutObject",
+    ]
+    resources = ["*"]
+  }
+
+
+}
+
+resource "aws_iam_policy" "fsx_lustre_csi" {
+  count = var.create_role && var.attach_fsx_lustre_csi_policy ? 1 : 0
+
+  name_prefix = "AmazonEKS_FSx_Lustre_CSI_Policy-"
+  path        = var.role_path
+  description = "Provides permissions to manage FSx Lustre volumes via the container storage interface driver"
+  policy      = data.aws_iam_policy_document.fsx_lustre_csi[0].json
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "fsx_lustre_csi" {
+  count = var.create_role && var.attach_fsx_lustre_csi_policy ? 1 : 0
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = aws_iam_policy.fsx_lustre_csi[0].arn
+}
+
 ################################################################################
 # VPC CNI Policy
 ################################################################################

--- a/modules/iam-role-for-service-accounts-eks/variables.tf
+++ b/modules/iam-role-for-service-accounts-eks/variables.tf
@@ -113,6 +113,13 @@ variable "ebs_csi_kms_cmk_ids" {
   default     = []
 }
 
+# FSx Lustre CSI
+variable "attach_fsx_lustre_csi_policy" {
+  description = "Determines whether to attach the FSx Lustre CSI IAM policy to the role"
+  type        = bool
+  default     = false
+}
+
 # VPC CNI
 variable "attach_vpc_cni_policy" {
   description = "Determines whether to attach the VPC CNI IAM policy to the role"
@@ -145,7 +152,7 @@ variable "node_termination_handler_sqs_queue_arns" {
   default     = ["*"]
 }
 
-# Karpetner controller
+# Karpenter controller
 variable "attach_karpenter_controller_policy" {
   description = "Determines whether to attach the Karpenter Controller policy to the role"
   type        = bool


### PR DESCRIPTION
## Description
Added a policy and attachment for FSx Lustre CSI driver

## Motivation and Context
Satisfies #204 

## Breaking Changes
Does not break backwards compatibility

## How Has This Been Tested?
- [ ] I have tested and validated these changes using an internal project
excerpt:
```hcl
locals {
  fsx_controller_namespace = "kube-system"
}

resource "helm_release" "fsx_controller" {
  name = "fsx-controller"

  repository = "https://kubernetes-sigs.github.io/aws-fsx-csi-driver/"
  chart      = "aws-fsx-csi-driver"
  version    = "1.4.1"

  namespace        = local.fsx_controller_namespace
  create_namespace = true

  set {
    name  = "controller.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
    value = module.fsx_controller_role.iam_role_arn
  }

  set {
    name  = "node.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
    value = module.fsx_controller_role.iam_role_arn
  }
}

module "fsx_controller_role" {
  # source  = "terraform-aws-modules/iam/aws/modules/iam-role-for-service-accounts-eks"
  # version = "4.14.0"
  source = "<local project dir>"

  role_name                    = "${local.cluster_name}-FSx-Controller"
  attach_fsx_lustre_csi_policy = true
  assume_role_condition_test   = "StringLike"

  oidc_providers = {
    (local.cluster_name) = {
      provider_arn               = local.eks_oidc_provider_arn
      namespace_service_accounts = ["kube-system:fsx-csi-*-sa"]
    }
  }
}

resource "aws_security_group" "fsx_lustre" {
  name        = "${local.cluster_name}-FSx-Controller"
  description = "FSx Controller Communication"
  vpc_id      = local.vpc_id
  ingress {
    from_port = 988
    protocol  = "tcp"
    to_port   = 988
    cidr_blocks = [data.aws_vpc.main.cidr_block]
  }
  tags = {
    Name = "${local.cluster_name}-FSx-Controller"
  }
}

resource "kubernetes_storage_class" "example" {
  for_each = toset(local.s3_bucket_names)

  metadata {
    name = "fsx-sc-${each.value}"
  }
  storage_provisioner = "fsx.csi.aws.com"
  parameters = {
    subnetId = local.private_subnets[0]
    securityGroupIds = aws_security_group.fsx_lustre.id
    s3ImportPath = "s3://${each.value}"
    s3ExportPath = "s3://${each.value}"
    deploymentType = "PERSISTENT_1"
    autoImportPolicy = "NEW_CHANGED_DELETED"
    perUnitStorageThroughput = "50"
  }
}
```
