### PR TITLE
fix: Backwards compatibility in 4.x.x series in iam-user submodule

### DIFF
--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -24,13 +24,13 @@ This module outputs commands and PGP messages which can be decrypted either usin
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.50 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.50 |
 
 ## Modules
 

--- a/modules/iam-user/versions.tf
+++ b/modules/iam-user/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 2.50"
     }
   }
 }


### PR DESCRIPTION
## Description
Revert AWS provider version requirement for recent release, in order to prevent something like the following error out of a `terraform init`:

```
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/aws:
│ no available releases match the given constraints >= 2.45.0, ~> 3.0, < 4.0.0,
│ >= 4.1.0
```

## Motivation and Context
Not break compatibility in workspaces that still couldn't upgrade their AWS provider -- but probably should eventually.

## Breaking Changes
The opposite, actually.

## How Has This Been Tested?
`terraform init` working again.
