### PR TITLE
fix: Updates required tf version for iam-user to 0.15

### DIFF
--- a/examples/iam-user/README.md
+++ b/examples/iam-user/README.md
@@ -20,7 +20,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.50 |
 
 ## Providers

--- a/examples/iam-user/versions.tf
+++ b/examples/iam-user/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.15"
 
   required_providers {
     aws = {

--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -23,7 +23,7 @@ This module outputs commands and PGP messages which can be decrypted either usin
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.50 |
 
 ## Providers

--- a/modules/iam-user/versions.tf
+++ b/modules/iam-user/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.15.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Updates the required terraform version for iam-user to `>= 0.15.0`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The [`sensitive` function](https://www.terraform.io/language/functions/sensitive) is only available in terraform v0.15 and later.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No, it is already broken for user's using terraform 0.14 and below.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
