### PR TITLE
fix: Fixed example where VPC CNI permissions should apply to the `aws-node` account

### DIFF
--- a/examples/iam-role-for-service-accounts-eks/main.tf
+++ b/examples/iam-role-for-service-accounts-eks/main.tf
@@ -255,7 +255,7 @@ module "vpc_cni_ipv4_irsa_role" {
   oidc_providers = {
     ex = {
       provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:aws-vpc-cni"]
+      namespace_service_accounts = ["kube-system:aws-node"]
     }
   }
 
@@ -272,7 +272,7 @@ module "vpc_cni_ipv6_irsa_role" {
   oidc_providers = {
     ex = {
       provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:aws-vpc-cni"]
+      namespace_service_accounts = ["kube-system:aws-node"]
     }
   }
 


### PR DESCRIPTION
## Description

The [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html) uses a service account name `aws-node` instead of `aws-vpc-cni`, the Helm chart name.

## Motivation and Context

Don't want someone to be misled by current documentation.

## Breaking Changes

None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

I've successfully used `aws-node` in my projects and was forced to double-check the AWS documentation after seeing the example here.