### PR TITLE
fix: AWS arn partition fix for Karpenter

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "this" {
 
       condition {
         test     = var.assume_role_condition_test
-        variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:sub"
+        variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:aud:sub"
         values   = [for sa in statement.value.namespace_service_accounts : "system:serviceaccount:${sa}"]
       }
     }

--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -18,6 +18,12 @@ data "aws_iam_policy_document" "this" {
         variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:sub"
         values   = [for sa in statement.value.namespace_service_accounts : "system:serviceaccount:${sa}"]
       }
+
+      condition {
+        test     = var.assume_role_condition_test
+        variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:aud"
+        values   = ["sts.amazonaws.com"]
+      }
     }
   }
 }

--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -15,14 +15,14 @@ data "aws_iam_policy_document" "this" {
 
       condition {
         test     = var.assume_role_condition_test
-        variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:sub"
-        values   = [for sa in statement.value.namespace_service_accounts : "system:serviceaccount:${sa}"]
+        variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:aud"
+        values   = ["sts.amazonaws.com"]
       }
 
       condition {
         test     = var.assume_role_condition_test
-        variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:aud"
-        values   = ["sts.amazonaws.com"]
+        variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:sub"
+        values   = [for sa in statement.value.namespace_service_accounts : "system:serviceaccount:${sa}"]
       }
     }
   }

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "cert_manager" {
 
   statement {
     actions   = ["route53:GetChange"]
-    resources = ["arn:aws:route53:::change/*"]
+    resources = ["arn:${local.partition}:route53:::change/*"]
   }
 
   statement {
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "cert_manager" {
       "route53:ListResourceRecordSets"
     ]
 
-    resources = var.cert_manager_hosted_zone_arns
+    resources = [for s in var.cert_manager_hosted_zone_arns : replace(s, "arn:aws:", "arn:${local.partition}:")]
   }
 
   statement {
@@ -263,7 +263,7 @@ data "aws_iam_policy_document" "ebs_csi" {
         "kms:RevokeGrant",
       ]
 
-      resources = var.ebs_csi_kms_cmk_ids
+      resources = [for s in var.ebs_csi_kms_cmk_ids : replace(s, "arn:aws:", "arn:${local.partition}:")]
 
       condition {
         test     = "Bool"
@@ -284,7 +284,7 @@ data "aws_iam_policy_document" "ebs_csi" {
         "kms:DescribeKey",
       ]
 
-      resources = var.ebs_csi_kms_cmk_ids
+      resources = [for s in var.ebs_csi_kms_cmk_ids : replace(s, "arn:aws:", "arn:${local.partition}:")]
     }
   }
 }
@@ -375,7 +375,7 @@ data "aws_iam_policy_document" "external_dns" {
 
   statement {
     actions   = ["route53:ChangeResourceRecordSets"]
-    resources = var.external_dns_hosted_zone_arns
+    resources = [for s in var.external_dns_hosted_zone_arns : replace(s, "arn:aws:", "arn:${local.partition}:")]
   }
 
   statement {
@@ -416,7 +416,7 @@ data "aws_iam_policy_document" "external_secrets" {
 
   statement {
     actions   = ["ssm:GetParameter"]
-    resources = var.external_secrets_ssm_parameter_arns
+    resources = [for s in var.external_secrets_ssm_parameter_arns : replace(s, "arn:aws:", "arn:${local.partition}:")]
   }
 
   statement {
@@ -426,7 +426,8 @@ data "aws_iam_policy_document" "external_secrets" {
       "secretsmanager:DescribeSecret",
       "secretsmanager:ListSecretVersionIds",
     ]
-    resources = var.external_secrets_secrets_manager_arns
+
+    resources = [for s in var.external_secrets_secrets_manager_arns : replace(s, "arn:aws:", "arn:${local.partition}:")]
   }
 }
 
@@ -462,7 +463,8 @@ data "aws_iam_policy_document" "fsx_lustre_csi" {
       "iam:AttachRolePolicy",
       "iam:PutRolePolicy"
     ]
-    resources = var.fsx_lustre_csi_service_role_arns
+
+    resources = [for s in var.fsx_lustre_csi_service_role_arns : replace(s, "arn:aws:", "arn:${local.partition}:")]
   }
 
   statement {
@@ -548,9 +550,9 @@ data "aws_iam_policy_document" "karpenter_controller" {
   statement {
     actions = ["ec2:RunInstances"]
     resources = [
-      "arn:aws:ec2:*:${local.account_id}:launch-template/*",
-      "arn:aws:ec2:*:${local.account_id}:security-group/*",
-      "arn:aws:ec2:*:${local.account_id}:subnet/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:launch-template/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:security-group/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:subnet/*",
     ]
 
     condition {
@@ -563,21 +565,21 @@ data "aws_iam_policy_document" "karpenter_controller" {
   statement {
     actions = ["ec2:RunInstances"]
     resources = [
-      "arn:aws:ec2:*::image/*",
-      "arn:aws:ec2:*:${local.account_id}:instance/*",
-      "arn:aws:ec2:*:${local.account_id}:volume/*",
-      "arn:aws:ec2:*:${local.account_id}:network-interface/*",
+      "arn:${local.partition}:ec2:*::image/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:instance/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:volume/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:network-interface/*",
     ]
   }
 
   statement {
     actions   = ["ssm:GetParameter"]
-    resources = var.karpenter_controller_ssm_parameter_arns
+    resources = [for s in var.karpenter_controller_ssm_parameter_arns : replace(s, "arn:aws:", "arn:${local.partition}:")]
   }
 
   statement {
     actions   = ["iam:PassRole"]
-    resources = var.karpenter_controller_node_iam_role_arns
+    resources = [for s in var.karpenter_controller_node_iam_role_arns : replace(s, "arn:aws:", "arn:${local.partition}:")]
   }
 }
 
@@ -911,7 +913,7 @@ data "aws_iam_policy_document" "amazon_managed_service_prometheus" {
       "aps:GetMetricMetadata",
     ]
 
-    resources = var.amazon_managed_service_prometheus_workspace_arns
+    resources = [for s in var.amazon_managed_service_prometheus_workspace_arns : replace(s, "arn:aws:", "arn:${local.partition}:")]
   }
 }
 
@@ -958,7 +960,7 @@ data "aws_iam_policy_document" "node_termination_handler" {
       "sqs:ReceiveMessage",
     ]
 
-    resources = var.node_termination_handler_sqs_queue_arns
+    resources = [for s in var.node_termination_handler_sqs_queue_arns : replace(s, "arn:aws:", "arn:${local.partition}:")]
   }
 }
 
@@ -987,7 +989,7 @@ resource "aws_iam_role_policy_attachment" "node_termination_handler" {
 data "aws_iam_policy_document" "vpc_cni" {
   count = var.create_role && var.attach_vpc_cni_policy ? 1 : 0
 
-  # arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+  # arn:${local.partition}:iam::aws:policy/AmazonEKS_CNI_Policy
   dynamic "statement" {
     for_each = var.vpc_cni_enable_ipv4 ? [1] : []
     content {


### PR DESCRIPTION
## Description

This fix will replace all hardcoded aws arn to be parition targed

## Motivation and Context

https://github.com/terraform-aws-modules/terraform-aws-iam/issues/226

## Breaking Changes

N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [*] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I have successfully launched Karpenter on "aws-cn" partiton. This fix should also make "aws-gov" work as well