### PR TITLE
chore: Fixed README karpenter_controller_cluster_ids parameter

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/README.md
+++ b/modules/iam-role-for-service-accounts-eks/README.md
@@ -62,7 +62,7 @@ module "karpenter_irsa_role" {
   role_name                          = "karpenter_controller"
   attach_karpenter_controller_policy = true
 
-  karpenter_controller_cluster_ids        = [module.eks.cluster_id]
+  karpenter_controller_cluster_id         = module.eks.cluster_id
   karpenter_controller_node_iam_role_arns = [module.eks.eks_managed_node_groups["default"].iam_role_arn]
 
   attach_vpc_cni_policy = true


### PR DESCRIPTION
## Description
- karpenter_controller_cluster_ids changed to karpenter_controller_cluster_id, but the README sample did not change, so I fixed it.
- https://github.com/terraform-aws-modules/terraform-aws-iam/pull/209 Thie
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
