### PR TITLE
fix: Add necessary permissions to EFS IRSA policy

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -317,8 +317,10 @@ data "aws_iam_policy_document" "efs_csi" {
 
   statement {
     actions = [
+      "ec2:DescribeAvailabilityZones",
       "elasticfilesystem:DescribeAccessPoints",
       "elasticfilesystem:DescribeFileSystems",
+      "elasticfilesystem:DescribeMountTargets",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
## Description
Fixes permissions for the AWS EFS CSI Driver IRSA.

## Motivation and Context
Necessary permissions for operation are omitted per the reference policy: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/iam-policy-example.json

## Breaking Changes
N/A

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
