### PR TITLE
fix: Correct policy attachment to cert_manager in example

### DIFF
--- a/examples/iam-role-for-service-accounts-eks/main.tf
+++ b/examples/iam-role-for-service-accounts-eks/main.tf
@@ -51,7 +51,7 @@ module "cert_manager_irsa_role" {
   source = "../../modules/iam-role-for-service-accounts-eks"
 
   role_name                     = "cert-manager"
-  attach_external_dns_policy    = true
+  attach_cert_manager_policy    = true
   cert_manager_hosted_zone_arns = ["arn:aws:route53:::hostedzone/IClearlyMadeThisUp"]
 
   oidc_providers = {


### PR DESCRIPTION
## Description
The example attaches the wrong policy.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
