### PR TITLE
fix: Correct aws arn partition for service account eks

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -18,6 +18,14 @@ data "aws_iam_policy_document" "this" {
         variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:sub"
         values   = [for sa in statement.value.namespace_service_accounts : "system:serviceaccount:${sa}"]
       }
+
+      # https://aws.amazon.com/premiumsupport/knowledge-center/eks-troubleshoot-oidc-and-irsa/?nc1=h_ls
+      condition {
+        test     = var.assume_role_condition_test
+        variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:aud"
+        values   = ["sts.amazonaws.com"]
+      }
+
     }
   }
 }

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "cert_manager" {
 
   statement {
     actions   = ["route53:GetChange"]
-    resources = ["arn:aws:route53:::change/*"]
+    resources = ["arn:${local.partition}:route53:::change/*"]
   }
 
   statement {
@@ -548,9 +548,9 @@ data "aws_iam_policy_document" "karpenter_controller" {
   statement {
     actions = ["ec2:RunInstances"]
     resources = [
-      "arn:aws:ec2:*:${local.account_id}:launch-template/*",
-      "arn:aws:ec2:*:${local.account_id}:security-group/*",
-      "arn:aws:ec2:*:${local.account_id}:subnet/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:launch-template/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:security-group/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:subnet/*",
     ]
 
     condition {
@@ -563,10 +563,10 @@ data "aws_iam_policy_document" "karpenter_controller" {
   statement {
     actions = ["ec2:RunInstances"]
     resources = [
-      "arn:aws:ec2:*::image/*",
-      "arn:aws:ec2:*:${local.account_id}:instance/*",
-      "arn:aws:ec2:*:${local.account_id}:volume/*",
-      "arn:aws:ec2:*:${local.account_id}:network-interface/*",
+      "arn:${local.partition}:ec2:*::image/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:instance/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:volume/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:network-interface/*",
     ]
   }
 
@@ -987,7 +987,7 @@ resource "aws_iam_role_policy_attachment" "node_termination_handler" {
 data "aws_iam_policy_document" "vpc_cni" {
   count = var.create_role && var.attach_vpc_cni_policy ? 1 : 0
 
-  # arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+  # arn:${local.partition}:iam::aws:policy/AmazonEKS_CNI_Policy
   dynamic "statement" {
     for_each = var.vpc_cni_enable_ipv4 ? [1] : []
     content {


### PR DESCRIPTION
## Description
This is a revised version of MR [229](https://github.com/terraform-aws-modules/terraform-aws-iam/pull/229)
It will fix all hardcoded arn to be partition targeted.

## Motivation and Context
Closes #226

## Breaking Changes
N/A

## How Has This Been Tested?
- [*] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request

I have successfully launched Karpenter on "aws-cn" partiton.
I will also create another MR for Karpenter examples in terraform-aws-modules.
