### PR TITLE
docs: Correct EKS IRSA example to use the correct service account name for the Amazon EBS CSI driver

### DIFF
--- a/examples/iam-role-for-service-accounts-eks/main.tf
+++ b/examples/iam-role-for-service-accounts-eks/main.tf
@@ -90,7 +90,7 @@ module "ebs_csi_irsa_role" {
   oidc_providers = {
     ex = {
       provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:aws-ebs-csi-driver"]
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
     }
   }
 


### PR DESCRIPTION
## Description

Changed the name of the service account from `aws-ebs-csi-driver` to `ebs-csi-controller-sa`

## Motivation and Context
ebs-csi plugin expects a specific service account name as mentioned here - https://docs.aws.amazon.com/eks/latest/userguide/csi-iam-role.html


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
