### PR TITLE
fix: Avoid restricting Karpenter `RunInstances` subnets by tag key

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.68.1
+    rev: v1.71.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -552,7 +552,6 @@ data "aws_iam_policy_document" "karpenter_controller" {
     resources = [
       "arn:${local.partition}:ec2:*:${local.account_id}:launch-template/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:security-group/*",
-      "arn:${local.partition}:ec2:*:${coalesce(var.karpenter_subnet_account_id, local.account_id)}:subnet/*",
     ]
 
     condition {
@@ -569,6 +568,7 @@ data "aws_iam_policy_document" "karpenter_controller" {
       "arn:${local.partition}:ec2:*:${local.account_id}:instance/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:volume/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:network-interface/*",
+      "arn:${local.partition}:ec2:*:${coalesce(var.karpenter_subnet_account_id, local.account_id)}:subnet/*",
     ]
   }
 


### PR DESCRIPTION
## Description
- Avoid restricting Karpenter `RunInstances` subnets by tag key

## Motivation and Context
- Avoid having to over-tag VPC subnets for multiple Karpenter instances to run in a shared environment; restrictions are already set on launch template and security group

## Breaking Changes
- No; permissions are the same except now a tag is not required on the subnets for Karpenter to function

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
