### PR TITLE
feat: Allow access to keypairs for Karpenter controller policy

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -571,6 +571,7 @@ data "aws_iam_policy_document" "karpenter_controller" {
       "arn:${local.partition}:ec2:*:${local.account_id}:volume/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:network-interface/*",
       "arn:${local.partition}:ec2:*:${coalesce(var.karpenter_subnet_account_id, local.account_id)}:subnet/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:key-pair/*",
     ]
   }
 


### PR DESCRIPTION
When Karpenter provisioners are using a custom `LaunchTemplate` there is a chance that it includes a custom key-pair.
