### PR TITLE
fix: Correct encrypted ses_smtp_password_v4 output

### DIFF
--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -15,8 +15,10 @@ When `pgp_key` is specified as `keybase:username`, make sure that that user has 
 This module outputs commands and PGP messages which can be decrypted either using [keybase.io web-site](https://keybase.io/decrypt) or using command line to get user's password and user's secret key:
 - `keybase_password_decrypt_command`
 - `keybase_secret_key_decrypt_command`
+- `keybase_ses_smtp_password_v4_decrypt_command`
 - `keybase_password_pgp_message`
 - `keybase_secret_key_pgp_message`
+- `keybase_ses_smtp_password_v4_pgp_message`
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -70,6 +72,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_iam_access_key_encrypted_secret"></a> [iam\_access\_key\_encrypted\_secret](#output\_iam\_access\_key\_encrypted\_secret) | The encrypted secret, base64 encoded |
+| <a name="output_iam_access_key_encrypted_ses_smtp_password_v4"></a> [iam\_access\_key\_encrypted\_ses\_smtp\_password\_v4](#output\_iam\_access\_key\_encrypted\_ses\_smtp\_password\_v4) | The encrypted secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm |
 | <a name="output_iam_access_key_id"></a> [iam\_access\_key\_id](#output\_iam\_access\_key\_id) | The access key ID |
 | <a name="output_iam_access_key_key_fingerprint"></a> [iam\_access\_key\_key\_fingerprint](#output\_iam\_access\_key\_key\_fingerprint) | The fingerprint of the PGP key used to encrypt the secret |
 | <a name="output_iam_access_key_secret"></a> [iam\_access\_key\_secret](#output\_iam\_access\_key\_secret) | The access key secret |
@@ -87,5 +90,7 @@ No modules.
 | <a name="output_keybase_password_pgp_message"></a> [keybase\_password\_pgp\_message](#output\_keybase\_password\_pgp\_message) | Encrypted password |
 | <a name="output_keybase_secret_key_decrypt_command"></a> [keybase\_secret\_key\_decrypt\_command](#output\_keybase\_secret\_key\_decrypt\_command) | Decrypt access secret key command |
 | <a name="output_keybase_secret_key_pgp_message"></a> [keybase\_secret\_key\_pgp\_message](#output\_keybase\_secret\_key\_pgp\_message) | Encrypted access secret key |
+| <a name="output_keybase_ses_smtp_password_v4_decrypt_command"></a> [keybase\_ses\_smtp\_password\_v4\_decrypt\_command](#output\_keybase\_ses\_smtp\_password\_v4\_decrypt\_command) | Decrypt SES SMTP password command |
+| <a name="output_keybase_ses_smtp_password_v4_pgp_message"></a> [keybase\_ses\_smtp\_password\_v4\_pgp\_message](#output\_keybase\_ses\_smtp\_password\_v4\_pgp\_message) | Encrypted SES SMTP password |
 | <a name="output_pgp_key"></a> [pgp\_key](#output\_pgp\_key) | PGP key used to encrypt sensitive data for this user (if empty - secrets are not encrypted) |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -57,8 +57,13 @@ output "iam_access_key_encrypted_secret" {
 
 output "iam_access_key_ses_smtp_password_v4" {
   description = "The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm"
-  value       = try(aws_iam_access_key.this[0].ses_smtp_password_v4, aws_iam_access_key.this_no_pgp[0].ses_smtp_password_v4, "")
+  value       = try(aws_iam_access_key.this_no_pgp[0].ses_smtp_password_v4, "")
   sensitive   = true
+}
+
+output "iam_access_key_encrypted_ses_smtp_password_v4" {
+  description = "The encrypted secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm"
+  value       = try(aws_iam_access_key.this[0].encrypted_ses_smtp_password_v4, "")
 }
 
 output "iam_access_key_status" {
@@ -108,6 +113,27 @@ Version: Keybase OpenPGP v2.0.76
 Comment: https://keybase.io/crypto
 
 ${try(aws_iam_access_key.this[0].encrypted_secret, "")}
+-----END PGP MESSAGE-----
+EOF
+
+}
+
+output "keybase_ses_smtp_password_v4_decrypt_command" {
+  description = "Decrypt SES SMTP password command"
+  value       = !local.has_encrypted_secret ? null : <<EOF
+echo "${try(aws_iam_access_key.this[0].encrypted_ses_smtp_password_v4, "")}" | base64 --decode | keybase pgp decrypt
+EOF
+
+}
+
+output "keybase_ses_smtp_password_v4_pgp_message" {
+  description = "Encrypted SES SMTP password"
+  value       = !local.has_encrypted_secret ? null : <<EOF
+-----BEGIN PGP MESSAGE-----
+Version: Keybase OpenPGP v2.0.76
+Comment: https://keybase.io/crypto
+
+${try(aws_iam_access_key.this[0].encrypted_ses_smtp_password_v4, "")}
 -----END PGP MESSAGE-----
 EOF
 


### PR DESCRIPTION
## Description
Add the way to expose encrypted ses_smtp_password_v4 in output.

## Motivation and Context
Currently `iam_access_key_ses_smtp_password_v4` is empty if entity encrypted with pgp key.
The way to expose an encrypted ses_smtp_password_v4 was introduced in https://github.com/hashicorp/terraform-provider-aws/pull/19579

## Breaking Changes
Most likely not

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
