### PR TITLE
feat: Add additional permission for `karpenter` IAM policy added in v0.14.0 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.72.2
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -523,6 +523,7 @@ data "aws_iam_policy_document" "karpenter_controller" {
       "ec2:CreateFleet",
       "ec2:CreateTags",
       "ec2:DescribeLaunchTemplates",
+      "ec2:DescribeImages",
       "ec2:DescribeInstances",
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeSubnets",


### PR DESCRIPTION
## Description
- Add additional permission for `karpenter` IAM policy added in v0.14.0 release, which allows the use of custom AMIs without the need for an entire launch template

## Motivation and Context
- Support additional permission required in v0.14.0 https://karpenter.sh/v0.14.0/upgrade-guide/#upgrading-to-v0140

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
