### PR TITLE
fix!: Tighten permissions of the EBS CSI IAM Role

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -172,43 +172,20 @@ data "aws_iam_policy_document" "ebs_csi" {
 
     condition {
       test     = "StringLike"
+      variable = "aws:RequestTag/CSIVolumeName"
+      values   = ["*"]
+    }
+    condition {
+      test     = "StringLike"
       variable = "aws:RequestTag/ebs.csi.aws.com/cluster"
       values = [
         true
       ]
     }
-  }
-
-  statement {
-    actions   = ["ec2:CreateVolume"]
-    resources = ["*"]
-
     condition {
       test     = "StringLike"
-      variable = "aws:RequestTag/CSIVolumeName"
-      values   = ["*"]
-    }
-  }
-
-  statement {
-    actions   = ["ec2:CreateVolume"]
-    resources = ["*"]
-
-    condition {
-      test     = "StringLike"
-      variable = "aws:RequestTag/kubernetes.io/cluster/*"
+      variable = "aws:RequestTag/kubernetes.io/cluster/${var.cluster_id}"
       values   = ["owned"]
-    }
-  }
-
-  statement {
-    actions   = ["ec2:DeleteVolume"]
-    resources = ["*"]
-
-    condition {
-      test     = "StringLike"
-      variable = "ec2:ResourceTag/ebs.csi.aws.com/cluster"
-      values   = [true]
     }
   }
 
@@ -221,15 +198,14 @@ data "aws_iam_policy_document" "ebs_csi" {
       variable = "ec2:ResourceTag/CSIVolumeName"
       values   = ["*"]
     }
-  }
-
-  statement {
-    actions   = ["ec2:DeleteVolume"]
-    resources = ["*"]
-
     condition {
       test     = "StringLike"
-      variable = "ec2:ResourceTag/kubernetes.io/cluster/*"
+      variable = "ec2:ResourceTag/ebs.csi.aws.com/cluster"
+      values   = [true]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/kubernetes.io/cluster/${var.cluster_id}"
       values   = ["owned"]
     }
   }
@@ -243,16 +219,15 @@ data "aws_iam_policy_document" "ebs_csi" {
       variable = "ec2:ResourceTag/CSIVolumeSnapshotName"
       values   = ["*"]
     }
-  }
-
-  statement {
-    actions   = ["ec2:DeleteSnapshot"]
-    resources = ["*"]
-
     condition {
       test     = "StringLike"
       variable = "ec2:ResourceTag/ebs.csi.aws.com/cluster"
       values   = [true]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/kubernetes.io/cluster/${var.cluster_id}"
+      values   = ["owned"]
     }
   }
 

--- a/modules/iam-role-for-service-accounts-eks/variables.tf
+++ b/modules/iam-role-for-service-accounts-eks/variables.tf
@@ -295,3 +295,8 @@ variable "node_termination_handler_sqs_queue_arns" {
   type        = list(string)
   default     = ["*"]
 }
+
+variable "cluster_id" {
+  description = "The EKS Cluster ID"
+  type        = string
+}


### PR DESCRIPTION
Draft PR until more conversation happens around this change; after which I will do what is required in "How Has This Been Tested?"


## Description

The example policy, which is used by this module, provided by the official aws-ebs-csi-driver is too lax (https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/example-iam-policy.json).

This policy presents the following issues:

* It allows the IAM Role to delete *any* EBS volume tagged with "CSIVolumeName" OR "ebs.csi.aws.com/cluster" OR "kubernetes.io/cluster/*"
* It allows the IAM Role to delete *any* EBS snapshot tagged with "CSIVolumeSnapshotName" OR "ebs.csi.aws.com/cluster" OR "kubernetes.io/cluster/*"

This means the EBS CSI IAM Role can delete any volume or snapshot from any other cluster.

This commit changes this policy and replaces the OR conditions by AND conditions, as well as restricting `kubernetes.io/cluster/*` to `kubernetes.io/cluster/EKS_CLUSTER_ID`.

This means the EBS CSI IAM Role can only delete volume or snapshot it owns.

## Breaking Changes

This change requires passing a mandatory `cluster_id` argument to the module.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
