### PR TITLE
feat: Add additional permission for `cluster_autoscaler`

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -63,6 +63,7 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
 
   statement {
     actions = [
+      "autoscaling:SetDesiredCapacity",
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeLaunchConfigurations",


### PR DESCRIPTION
## Description
cluster_autoscaler missing required policy `autoscaling:SetDesiredCapacity` to scaling

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-iam/issues/263

## Breaking Changes
No Breaking Changes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
