### PR TITLE
fix: Fixed iam-user module when `encrypted_ses_smtp_password_v4` is `null`

### DIFF
--- a/modules/iam-user/outputs.tf
+++ b/modules/iam-user/outputs.tf
@@ -1,6 +1,7 @@
 locals {
-  has_encrypted_password = length(compact(aws_iam_user_login_profile.this[*].encrypted_password)) > 0
-  has_encrypted_secret   = length(compact(aws_iam_access_key.this[*].encrypted_secret)) > 0
+  has_encrypted_password             = length(compact(aws_iam_user_login_profile.this[*].encrypted_password)) > 0
+  has_encrypted_secret               = length(compact(aws_iam_access_key.this[*].encrypted_secret)) > 0
+  has_encrypted_ses_smtp_password_v4 = length(compact(aws_iam_access_key.this[*].encrypted_ses_smtp_password_v4)) > 0
 }
 
 output "iam_user_name" {
@@ -120,7 +121,7 @@ EOF
 
 output "keybase_ses_smtp_password_v4_decrypt_command" {
   description = "Decrypt SES SMTP password command"
-  value       = !local.has_encrypted_secret ? null : <<EOF
+  value       = !local.has_encrypted_ses_smtp_password_v4 ? null : <<EOF
 echo "${try(aws_iam_access_key.this[0].encrypted_ses_smtp_password_v4, "")}" | base64 --decode | keybase pgp decrypt
 EOF
 
@@ -128,7 +129,7 @@ EOF
 
 output "keybase_ses_smtp_password_v4_pgp_message" {
   description = "Encrypted SES SMTP password"
-  value       = !local.has_encrypted_secret ? null : <<EOF
+  value       = !local.has_encrypted_ses_smtp_password_v4 ? null : <<EOF
 -----BEGIN PGP MESSAGE-----
 Version: Keybase OpenPGP v2.0.76
 Comment: https://keybase.io/crypto


### PR DESCRIPTION
Closes https://github.com/terraform-aws-modules/terraform-aws-iam/issues/274