### PR TITLE
feat: Explicit self-assume permission for IAM assumable role with OIDC

### DIFF
--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -41,7 +41,7 @@ No modules.
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | The AWS account ID where the OIDC provider lives, leave empty to use the account for the AWS provider | `string` | `""` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Whether to create a role | `bool` | `false` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `false` | no |
-| <a name="explicit_permission_to_assume_self"></a> [explicit\_permission\_to\_assume\_self](#input\_explicit\_permission\_to\_assume\_self) | "Whether the role Trusted Policy should allow the role to assume itself | `bool` | `false` | no |
+| <a name="explicit_permission_to_assume_self"></a> [explicit\_permission\_to\_assume\_self](#input\_explicit\_permission\_to\_assume\_self) | Whether the role Trusted Policy should allow the role to assume itself | `bool` | `false` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
 | <a name="input_number_of_role_policy_arns"></a> [number\_of\_role\_policy\_arns](#input\_number\_of\_role\_policy\_arns) | Number of IAM policies to attach to IAM role | `number` | `null` | no |
 | <a name="input_oidc_fully_qualified_audiences"></a> [oidc\_fully\_qualified\_audiences](#input\_oidc\_fully\_qualified\_audiences) | The audience to be added to the role policy. Set to sts.amazonaws.com for cross-account assumable role. Leave empty otherwise. | `set(string)` | `[]` | no |

--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -41,6 +41,7 @@ No modules.
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | The AWS account ID where the OIDC provider lives, leave empty to use the account for the AWS provider | `string` | `""` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Whether to create a role | `bool` | `false` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `false` | no |
+| <a name="explicit_permission_to_assume_self"></a> [explicit\_permission\_to\_assume\_self](#input\_explicit\_permission\_to\_assume\_self) | "Whether the role Trusted Policy should allow the role to assume itself | `bool` | `false` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
 | <a name="input_number_of_role_policy_arns"></a> [number\_of\_role\_policy\_arns](#input\_number\_of\_role\_policy\_arns) | Number of IAM policies to attach to IAM role | `number` | `null` | no |
 | <a name="input_oidc_fully_qualified_audiences"></a> [oidc\_fully\_qualified\_audiences](#input\_oidc\_fully\_qualified\_audiences) | The audience to be added to the role policy. Set to sts.amazonaws.com for cross-account assumable role. Leave empty otherwise. | `set(string)` | `[]` | no |

--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -32,6 +32,8 @@ No modules.
 | [aws_iam_role_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_with_oidc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "assume_self" {
 
 data "aws_iam_policy_document" "combined" {
   source_policy_documents = concat(
-    join("", data.aws_iam_policy_document.assume_role_with_oidc.*.json),
+    var.create_role ? [data.aws_iam_policy_document.assume_role_with_oidc[0].json] :[],
     var.explicit_permission_to_assume_self ? [data.aws_iam_policy_document.assume_self[0].json] : []
   )
 }

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -79,8 +79,8 @@ data "aws_iam_policy_document" "assume_self" {
 
 data "aws_iam_policy_document" "combined" {
   source_policy_documents = concat(
-    var.create_role ? [data.aws_iam_policy_document.assume_role_with_oidc[0].json] : [],
-    var.explicit_permission_to_assume_self ? [data.aws_iam_policy_document.assume_self[0].json] : []
+    try([data.aws_iam_policy_document.assume_role_with_oidc[0].json, [])
+    try([data.aws_iam_policy_document.assume_self[0].json], [])
   )
 }
 

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "assume_self" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"]
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.role_path}${var.role_name}"]
     }
   }
 }

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "assume_self" {
 
 data "aws_iam_policy_document" "combined" {
   source_policy_documents = concat(
-    try([data.aws_iam_policy_document.assume_role_with_oidc[0].json, [])
+    try([data.aws_iam_policy_document.assume_role_with_oidc[0].json], []),
     try([data.aws_iam_policy_document.assume_self[0].json], [])
   )
 }

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "assume_self" {
 
 data "aws_iam_policy_document" "combined" {
   source_policy_documents = concat(
-    var.create_role ? [data.aws_iam_policy_document.assume_role_with_oidc[0].json] :[],
+    var.create_role ? [data.aws_iam_policy_document.assume_role_with_oidc[0].json] : [],
     var.explicit_permission_to_assume_self ? [data.aws_iam_policy_document.assume_self[0].json] : []
   )
 }

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "assume_self" {
 data "aws_iam_policy_document" "combined" {
   source_policy_documents = concat(
     join("", data.aws_iam_policy_document.assume_role_with_oidc.*.json),
-    var.explicit_permission_to_assume_self ? [data.aws_iam_policy_document.assume_self.json] : []
+    var.explicit_permission_to_assume_self ? [data.aws_iam_policy_document.assume_self[0].json] : []
   )
 }
 

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "assume_self" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.role_path}${var.role_name}"]
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role${var.role_path}${var.role_name}"]
     }
   }
 }

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -99,3 +99,9 @@ variable "force_detach_policies" {
   type        = bool
   default     = false
 }
+
+variable "explicit_permission_to_assume_self" {
+  description = "Whether the role Trusted Policy should allow the role to assume itself"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Description
Adds the ability to implement self-assume permission for IAM assumable role with OIDC.

## Motivation and Context
AWS is [changing the way IAM role trust policies work](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/). Before, they implicitly allowed the role to assume itself. After the change, an explicit permission is needed.

## Breaking Changes
No.

## How Has This Been Tested?
Tested via Terraform Enterprise on multiple environments, with prior config (without the new variable input) and with `explicit_permission_to_assume_self = true`.
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
