### PR TITLE
fix: Allow TagUser to SelfManagement policy

### DIFF
--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -39,6 +39,9 @@ data "aws_iam_policy_document" "iam_self_management" {
       "iam:UpdateUser",
       "iam:UploadSigningCertificate",
       "iam:UploadSSHPublicKey",
+      "iam:TagUser",
+      "iam:ListUserTags",
+      "iam:UntagUser",
     ]
 
     # Allow for both users with "path" and without it


### PR DESCRIPTION
## Description
Adding the following permissions to IAM users created from the iam-group-with-policies module. 
```
"iam:ListUserTags"
"iam:TagUser"
"iam:UntagUser"
```
For instance, user will now be able to label their own access keys.

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-iam/issues/286

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
