### PR TITLE
feat: Add support for wildcards to service account defs for iam-eks-role

### DIFF
--- a/modules/iam-eks-role/README.md
+++ b/modules/iam-eks-role/README.md
@@ -108,6 +108,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_self_assume_role"></a> [allow\_self\_assume\_role](#input\_allow\_self\_assume\_role) | Determines whether to allow the role to be [assume itself](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/) | `bool` | `false` | no |
 | <a name="input_cluster_service_accounts"></a> [cluster\_service\_accounts](#input\_cluster\_service\_accounts) | EKS cluster and k8s ServiceAccount pairs. Each EKS cluster can have multiple k8s ServiceAccount. See README for details | `map(list(string))` | `{}` | no |
+| <a name="input_cluster_service_accounts_with_wildcards"></a> [cluster\_service\_accounts\_with\_wildcards](#input\_cluster\_service\_accounts\_with\_wildcards) | EKS cluster and k8s ServiceAccount pairs. Each EKS cluster can have multiple k8s ServiceAccount. See README for details | `map(list(string))` | `{}` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Whether to create a role | `bool` | `true` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `false` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `43200` | no |

--- a/modules/iam-eks-role/variables.tf
+++ b/modules/iam-eks-role/variables.tf
@@ -46,6 +46,12 @@ variable "cluster_service_accounts" {
   default     = {}
 }
 
+variable "cluster_service_accounts_with_wildcards" {
+  description = "EKS cluster and k8s ServiceAccount pairs. Each EKS cluster can have multiple k8s ServiceAccount. See README for details"
+  type        = map(list(string))
+  default     = {}
+}
+
 variable "tags" {
   description = "A map of tags to add the the IAM role"
   type        = map(any)


### PR DESCRIPTION
## Description
Added support for wildcards in service account conditions, to more closely align with similar support on `iam-assumable-role-with-oidc` submodule. I've also updated the documentation with `terraform-docs` as noted in the pre-commit hooks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows people to enable many service accounts in an EKS cluster to assume this role without explicitly adding each service account name to the trust policy. This is also backwards compatible and follows a similar variable conventions which exists in another submodule in this repository.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None. Recommending a minor version bump due to an additional variable, but has an empty default.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
