### PR TITLE
fix: Added additional policies required for targetgroup binding only to work 

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -863,12 +863,14 @@ data "aws_iam_policy_document" "load_balancer_controller_targetgroup_only" {
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeInstances",
       "ec2:DescribeVpcs",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:RevokeSecurityGroupIngress",
       "elasticloadbalancing:DescribeTargetGroups",
       "elasticloadbalancing:DescribeTargetHealth",
       "elasticloadbalancing:ModifyTargetGroup",
       "elasticloadbalancing:ModifyTargetGroupAttributes",
       "elasticloadbalancing:RegisterTargets",
-      "elasticloadbalancing:DeregisterTargets"
+      "elasticloadbalancing:DeregisterTargets",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
Added additional policies required for targetgroup binding only to work with AWS LBC

## Description
Adds two additional policies to the subset of policies that are in effect when only using TargetGroupBinding policies with the AWS Load Balancer Controller.

## Motivation and Context
The policies applied when using only `var.attach_load_balancer_controller_targetgroup_binding_only_policy = true`
is not sufficient for target group binding to work in latest version of AWS LBC. Not sure when the issue arose, and it may be related to how I define inline ingresses. Nonetheless I am only using TargetGroupBinding resources and the policy fails for that use case. More details described here: [issue](https://github.com/terraform-aws-modules/terraform-aws-iam/issues/291)

## Breaking Changes
This doesn't break backwards compatibility

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
