### PR TITLE
fix: Insufficient permissions for karpenter policy when not using karpenter discovery tags on security group

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -547,7 +547,6 @@ data "aws_iam_policy_document" "karpenter_controller" {
     actions = ["ec2:RunInstances"]
     resources = [
       "arn:${local.partition}:ec2:*:${local.account_id}:launch-template/*",
-      "arn:${local.partition}:ec2:*:${local.account_id}:security-group/*",
     ]
 
     condition {
@@ -563,6 +562,7 @@ data "aws_iam_policy_document" "karpenter_controller" {
       "arn:${local.partition}:ec2:*::image/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:instance/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:spot-instances-request/*",
+      "arn:${local.partition}:ec2:*:${local.account_id}:security-group/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:volume/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:network-interface/*",
       "arn:${local.partition}:ec2:*:${coalesce(var.karpenter_subnet_account_id, local.account_id)}:subnet/*",


### PR DESCRIPTION
Fixes an issue where the policy was not sufficient if you use security group ids in the Karpenter `AWSNodeTemplate` instead of relying on discovery tags. Then the security groups weren't tagged, which led to insufficient permissions for Karpenter to launch the node.

## Description
Removes the need for the security group to be tagged with the Karpenter discovery tag
for Karpenter to be able to use it when launching an instance.

## Motivation and Context

- Resolves #295 

If we create an AWSNodeTemplate like this:
```yaml
apiVersion: karpenter.k8s.aws/v1alpha1
kind: AWSNodeTemplate
metadata:
  name: default
spec:
  subnetSelector:
    aws-ids: subnet-abc,subnet-xyz
  securityGroupSelector:
    aws-ids: sg-abc,sg-xyz
  tags:
    karpenter.sh/discovery/foo-cluster: foo-cluster
```
which is perfectly valid according to Karpenter docs, we will not
be able to use the module policy as is, since the security group we are referring to doesn't have the correct discovery tag (since we don't want to use discovery tags).

The change here changes the policy such that this constraint is relaxed. This makes the security group part of the policy behave like the subnet part, which wasn't dependent on the tag being present.

## Breaking Changes
No breaking changes, just a little bit more permissive policy.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have updated the policy manually and verified in karpenter 
