### PR TITLE
fix: Correct tflint errors for latest version of tflint

### DIFF
--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -74,7 +74,7 @@ resource "aws_iam_role" "this" {
   force_detach_policies = var.force_detach_policies
   permissions_boundary  = var.role_permissions_boundary_arn
 
-  assume_role_policy = join("", data.aws_iam_policy_document.assume_role_with_oidc.*.json)
+  assume_role_policy = data.aws_iam_policy_document.assume_role_with_oidc[0].json
 
   tags = var.tags
 }
@@ -82,6 +82,6 @@ resource "aws_iam_role" "this" {
 resource "aws_iam_role_policy_attachment" "custom" {
   count = var.create_role ? local.number_of_role_policy_arns : 0
 
-  role       = join("", aws_iam_role.this.*.name)
+  role       = aws_iam_role.this[0].name
   policy_arn = var.role_policy_arns[count.index]
 }

--- a/modules/iam-assumable-role-with-saml/main.tf
+++ b/modules/iam-assumable-role-with-saml/main.tf
@@ -43,6 +43,6 @@ resource "aws_iam_role" "this" {
 resource "aws_iam_role_policy_attachment" "custom" {
   count = var.create_role ? local.number_of_role_policy_arns : 0
 
-  role       = join("", aws_iam_role.this.*.name)
+  role       = aws_iam_role.this[0].name
   policy_arn = var.role_policy_arns[count.index]
 }

--- a/modules/iam-group-with-policies/main.tf
+++ b/modules/iam-group-with-policies/main.tf
@@ -1,5 +1,5 @@
 locals {
-  group_name = element(concat(aws_iam_group.this.*.id, [var.name]), 0)
+  group_name = var.create_group ? aws_iam_group.this[0].id : var.name
 }
 
 resource "aws_iam_group" "this" {
@@ -37,7 +37,7 @@ resource "aws_iam_group_policy_attachment" "custom" {
   count = length(var.custom_group_policies)
 
   group      = local.group_name
-  policy_arn = element(aws_iam_policy.custom.*.arn, count.index)
+  policy_arn = element(aws_iam_policy.custom[*].arn, count.index)
 }
 
 ###############

--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -5,13 +5,7 @@ data "aws_caller_identity" "current" {
 data "aws_partition" "current" {}
 
 locals {
-  aws_account_id = element(
-    concat(
-      data.aws_caller_identity.current.*.account_id,
-      [var.aws_account_id],
-    ),
-    0,
-  )
+  aws_account_id = try(data.aws_caller_identity.current[0].account_id, var.aws_account_id)
 }
 
 data "aws_iam_policy_document" "iam_self_management" {

--- a/modules/iam-read-only-policy/main.tf
+++ b/modules/iam-read-only-policy/main.tf
@@ -82,9 +82,9 @@ data "aws_iam_policy_document" "logs_query" {
 data "aws_iam_policy_document" "combined" {
   source_policy_documents = concat(
     [data.aws_iam_policy_document.allowed_services.json],
-    data.aws_iam_policy_document.console_services.*.json,
-    data.aws_iam_policy_document.sts.*.json,
-    data.aws_iam_policy_document.logs_query.*.json,
+    data.aws_iam_policy_document.console_services[*].json,
+    data.aws_iam_policy_document.sts[*].json,
+    data.aws_iam_policy_document.logs_query[*].json,
     [var.additional_policy_json]
   )
 }


### PR DESCRIPTION
## Description
- Correct tflint errors for latest version of tflint

## Motivation and Context
- Resolves tflint `Warning: List items should be accessed using square brackets (terraform_deprecated_index)`

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
