### PR TITLE
fix: Add missing locals in iam-assumable-role-with-oidc

### DIFF
--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -7,6 +7,7 @@ locals {
   ]
   number_of_role_policy_arns = coalesce(var.number_of_role_policy_arns, length(var.role_policy_arns))
   role_name_condition        = var.role_name != null ? var.role_name : "${var.role_name_prefix}*"
+  partition                  = data.aws_partition.current
 }
 
 data "aws_caller_identity" "current" {}
@@ -32,7 +33,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       condition {
         test     = "ArnLike"
         variable = "aws:PrincipalArn"
-        values   = ["arn:${local.partition}:iam::${local.account_id}:role${var.role_path}${local.role_name_condition}"]
+        values   = ["arn:${local.partition}:iam::${local.aws_account_id}:role${var.role_path}${local.role_name_condition}"]
       }
     }
   }
@@ -47,7 +48,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       principals {
         type = "Federated"
 
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:oidc-provider/${statement.value}"]
+        identifiers = ["arn:${local.partition}:iam::${local.aws_account_id}:oidc-provider/${statement.value}"]
       }
 
       dynamic "condition" {


### PR DESCRIPTION
Bug fix: Self assume role condition

## Description
Add missing locals in [iam-assumable-role-with-oidc](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-assumable-role-with-oidc).  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
