### PR TITLE
docs: Inform multiple region support not an option for iam-role-eks

### DIFF
--- a/modules/iam-eks-role/README.md
+++ b/modules/iam-eks-role/README.md
@@ -7,6 +7,7 @@ Creates an IAM role that can be assumed by one or more EKS `ServiceAccount` in o
 - Support multiple `ServiceAccount` in the same cluster, for example when a workload runs in multiple namespaces
 - More suitable for non-cluster admins as implementation is simpler
 - More suitable for when the IAM role and cluster resources are in separate Terraform configurations
+- Does not support multiple regions, consider using [iam-assumable-role-with-oidc](https://github.com/terraform-aws-modules/terraform-aws-iam/blob/master/modules/iam-assumable-role-with-oidc/) if role needs to support clusters in multiple regions
 
 This module is for use with AWS EKS. For details of how a `ServiceAccount` in EKS can assume an IAM role, see the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
 

--- a/modules/iam-eks-role/README.md
+++ b/modules/iam-eks-role/README.md
@@ -7,7 +7,7 @@ Creates an IAM role that can be assumed by one or more EKS `ServiceAccount` in o
 - Support multiple `ServiceAccount` in the same cluster, for example when a workload runs in multiple namespaces
 - More suitable for non-cluster admins as implementation is simpler
 - More suitable for when the IAM role and cluster resources are in separate Terraform configurations
-- Does not support multiple regions, consider using [iam-assumable-role-with-oidc](https://github.com/terraform-aws-modules/terraform-aws-iam/blob/master/modules/iam-assumable-role-with-oidc/) if role needs to support clusters in multiple regions
+- Does not support multiple regions, consider using [iam-role-for-service-accounts-eks](https://github.com/terraform-aws-modules/terraform-aws-iam/blob/master/modules/iam-role-for-service-accounts-eks/) if role needs to support clusters in multiple regions
 
 This module is for use with AWS EKS. For details of how a `ServiceAccount` in EKS can assume an IAM role, see the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
 


### PR DESCRIPTION
## Description
Improve docs for iam-eks-role - inform user that this sub module will not work for multiple regions

## Motivation and Context
Will help save time if the end user has a multi region setup. This module doesn't support creating a role for multiple EKS clusters in more than 1 region.

## Breaking Changes
None

## How Has This Been Tested?
Docs change for clarity

projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
