### PR TITLE
Patch 1

### DIFF
--- a/examples/iam-assumable-role-with-oidc/main.tf
+++ b/examples/iam-assumable-role-with-oidc/main.tf
@@ -50,3 +50,22 @@ module "iam_assumable_role_self_assume" {
 
   oidc_fully_qualified_subjects = ["system:serviceaccount:default:sa1", "system:serviceaccount:default:sa2"]
 }
+
+#####################################
+# IAM assumable role with audience
+#####################################
+module "iam_iam-assumable-role-with-oidc" {
+  source = "../../modules/iam-assumable-role-with-oidc"
+
+  create_role = true
+
+  role_name = "role-with-oidc-github-actions"
+
+  provider_url = "token.actions.githubusercontent.com"
+
+  role_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+  ]
+
+  oidc_fully_qualified_audiences = ["sts.amazonaws.com"]
+}

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
         for_each = length(var.oidc_fully_qualified_audiences) > 0 ? local.urls : []
 
         content {
-          test     = "StringLike"
+          test     = "StringEquals"
           variable = "${statement.value}:aud"
           values   = var.oidc_fully_qualified_audiences
         }


### PR DESCRIPTION
Fix: fully qualified audiences should generate StringEquals but is generating StringLike

## Description
<!--- Describe your changes in detail -->
There is a bug that causes oidc_fully_qualified_audiences to create StringLike condition instead of StringEquals condition. This is simply because the content is created with StringLike instead of StringEquals

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves bug
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
I don't know
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
