### PR TITLE
fix: Add `secretsmanager:ListSecrets` to `external-secrets` policy

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -416,7 +416,7 @@ data "aws_iam_policy_document" "external_secrets" {
 
   statement {
     actions   = ["secretsmanager:ListSecrets"]
-    resources = "*"
+    resources = ["*"]
   }
 
   statement {

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -415,6 +415,11 @@ data "aws_iam_policy_document" "external_secrets" {
   }
 
   statement {
+    actions   = ["secretsmanager:ListSecrets"]
+    resources = "*"
+  }
+
+  statement {
     actions = [
       "secretsmanager:GetResourcePolicy",
       "secretsmanager:GetSecretValue",


### PR DESCRIPTION
External secrets uses ListSecrets when searching for secrets by tag.

https://github.com/external-secrets/external-secrets/issues/1443

## Description
Add `secretsmanager:ListSecrets` to external-secrets policy.

## Motivation and Context
Allows external secrets controller list all secrets when searching for secrets by tag.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

I tested it by manually updating the policy in AWS.

Before updating it:

```
{"level":"error","ts":1667943642.1480799,"logger":"controllers.ExternalSecret","msg":"could not get secret data from provider","ExternalSecret":"test/linkinbio-api","SecretStore":"test/later-test-store","error":"AccessDeniedException: User: arn:aws:sts::795986403160:assumed-role/ExternalSecretStore20221107234613050800000003/external-secrets-provider-aws is not authorized to perform: secretsmanager:ListSecrets because no identity-based policy allows the secretsmanager:ListSecrets action\n\tstatus code: 400, request id: 31a64aaf-8436-4008-9faf-cd27a56122b2","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:227"}
```

After updating:

```
{"level":"info","ts":1667943672.3597736,"logger":"controllers.ExternalSecret","msg":"reconciled secret","ExternalSecret":"test/linkinbio-api","SecretStore":"test/later-test-store"}
```
