### PR TITLE
feat: Ensure that GitHub OIDC subject prefixes are normalied for `repo:`

### DIFF
--- a/examples/iam-github-oidc/main.tf
+++ b/examples/iam-github-oidc/main.tf
@@ -37,8 +37,14 @@ module "iam_github_oidc_provider_disabled" {
 module "iam_github_oidc_role" {
   source = "../../modules/iam-github-oidc-role"
 
+  name = local.name
+
   # This should be updated to suit your organization, repository, references/branches, etc.
-  subjects = ["terraform-aws-modules/terraform-aws-iam:*"]
+  subjects = [
+    # You can prepend with `repo:` but it is not required
+    "repo:terraform-aws-modules/terraform-aws-iam:pull_request",
+    "terraform-aws-modules/terraform-aws-iam:ref:refs/heads/master",
+  ]
 
   policies = {
     additional = aws_iam_policy.additional.arn

--- a/modules/iam-github-oidc-role/main.tf
+++ b/modules/iam-github-oidc-role/main.tf
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "this" {
       test     = "StringLike"
       variable = "${local.provider_url}:sub"
       # Strip `repo:` to normalize for cases where users may prepend it
-      values = [for subject in var.subjects : "repo:${replace(subject, "/^repo:/", "")}"]
+      values = [for subject in var.subjects : "repo:${trimprefix(subject, "repo:")}"]
     }
   }
 }

--- a/modules/iam-github-oidc-role/main.tf
+++ b/modules/iam-github-oidc-role/main.tf
@@ -44,7 +44,8 @@ data "aws_iam_policy_document" "this" {
     condition {
       test     = "StringLike"
       variable = "${local.provider_url}:sub"
-      values   = [for subject in var.subjects : "repo:${subject}"]
+      # Strip `repo:` to normalize for cases where users may prepend it
+      values = [for subject in var.subjects : "repo:${replace(subject, "/^repo:/", "")}"]
     }
   }
 }


### PR DESCRIPTION
## Description
- Ensure that GitHub OIDC subject prefixes are normalied for `repo:`

## Motivation and Context
- All of the `subjects` used in the `iam-github-oidc-role` will need to start with `repo:` so the code originally added that for users. However, nearly all documentation shows the subject with `repo:...` and users add this text into their subjects. This results in subjects that then look like `repo:repo:...` which is incorrect. This change normalizes the text to ensure that subjects only start with `repo:...` regardless of whether the user adds it or not in their provided subjects

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
