### PR TITLE
feat: Allow multiple MFA devices and users to manage MFA devices

### DIFF
--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -141,7 +141,7 @@ data "aws_iam_policy_document" "iam_self_management" {
       "iam:ListVirtualMFADevices",
       "iam:ResyncMFADevice",
       "sts:GetSessionToken"
-]
+    ]
 
     resources = ["*"]
 

--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -14,17 +14,17 @@ locals {
 data "aws_iam_policy_document" "iam_self_management" {
   statement {
     sid = "AllowViewAccountInfo"
-    
+
     effect = "Allow"
-    
+
     actions = [
       "iam:GetAccountPasswordPolicy",
-      "iam:ListVirtualMFADevices"     
+      "iam:ListVirtualMFADevices"
     ]
 
     resources = ["*"]
   }
-  
+
   statement {
     sid = "AllowManageOwnPasswords"
 
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "iam_self_management" {
     ]
 
     resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
-  }  
+  }
 
   statement {
     sid = "AllowManageOwnAccessKeys"
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "iam_self_management" {
     ]
 
     resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
-  }    
+  }
 
   statement {
     sid = "AllowManageOwnSigningCertificates"
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "iam_self_management" {
 
     resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
   }
-  
+
   statement {
     sid = "AllowManageOwnGitCredentials"
 
@@ -150,5 +150,5 @@ data "aws_iam_policy_document" "iam_self_management" {
       variable = "aws:MultiFactorAuthPresent"
       values   = ["false"]
     }
-  }  
+  }
 }

--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -9,124 +9,146 @@ locals {
   partition      = data.aws_partition.current.partition
 }
 
+# Allows MFA-authenticated IAM users to manage their own credentials on the My security credentials page
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html
 data "aws_iam_policy_document" "iam_self_management" {
   statement {
-    sid = "AllowSelfManagement"
+    sid = "AllowViewAccountInfo"
+    
+    effect = "Allow"
+    
+    actions = [
+      "iam:GetAccountPasswordPolicy",
+      "iam:ListVirtualMFADevices"     
+    ]
+
+    resources = ["*"]
+  }
+  
+  statement {
+    sid = "AllowManageOwnPasswords"
 
     effect = "Allow"
 
     actions = [
       "iam:ChangePassword",
-      "iam:CreateAccessKey",
-      "iam:CreateLoginProfile",
-      "iam:CreateVirtualMFADevice",
-      "iam:DeleteAccessKey",
-      "iam:DeleteLoginProfile",
-      "iam:DeleteVirtualMFADevice",
-      "iam:EnableMFADevice",
-      "iam:GenerateCredentialReport",
-      "iam:GenerateServiceLastAccessedDetails",
-      "iam:Get*",
-      "iam:List*",
-      "iam:ResyncMFADevice",
-      "iam:UpdateAccessKey",
-      "iam:UpdateLoginProfile",
-      "iam:UpdateUser",
-      "iam:UploadSigningCertificate",
-      "iam:UploadSSHPublicKey",
-      "iam:TagUser",
-      "iam:ListUserTags",
-      "iam:UntagUser",
+      "iam:GetUser"
     ]
 
-    # Allow for both users with "path" and without it
-    resources = [
-      "arn:${local.partition}:iam::${local.aws_account_id}:user/*/$${aws:username}",
-      "arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}",
-      "arn:${local.partition}:iam::${local.aws_account_id}:mfa/$${aws:username}",
+    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
+  }  
+
+  statement {
+    sid = "AllowManageOwnAccessKeys"
+
+    effect = "Allow"
+
+    actions = [
+      "iam:CreateAccessKey",
+      "iam:DeleteAccessKey",
+      "iam:ListAccessKeys",
+      "iam:UpdateAccessKey"
     ]
+
+    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
+  }    
+
+  statement {
+    sid = "AllowManageOwnSigningCertificates"
+
+    effect = "Allow"
+
+    actions = [
+      "iam:DeleteSigningCertificate",
+      "iam:ListSigningCertificates",
+      "iam:UpdateSigningCertificate",
+      "iam:UploadSigningCertificate"
+    ]
+
+    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
   }
 
   statement {
-    sid = "AllowIAMReadOnly"
+    sid = "AllowManageOwnSSHPublicKeys"
+
+    effect = "Allow"
 
     actions = [
-      "iam:Get*",
-      "iam:List*",
+      "iam:DeleteSSHPublicKey",
+      "iam:GetSSHPublicKey",
+      "iam:ListSSHPublicKeys",
+      "iam:UpdateSSHPublicKey",
+      "iam:UploadSSHPublicKey"
     ]
 
-    resources = ["*"]
-    effect    = "Allow"
+    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
+  }
+  
+  statement {
+    sid = "AllowManageOwnGitCredentials"
+
+    effect = "Allow"
+
+    actions = [
+      "iam:CreateServiceSpecificCredential",
+      "iam:DeleteServiceSpecificCredential",
+      "iam:ListServiceSpecificCredentials",
+      "iam:ResetServiceSpecificCredential",
+      "iam:UpdateServiceSpecificCredential"
+    ]
+
+    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
   }
 
   statement {
     sid = "AllowManageOwnVirtualMFADevice"
 
-    actions = [
-      "iam:CreateVirtualMFADevice",
-    ]
-
-    resources = [
-      "arn:${local.partition}:iam::${local.aws_account_id}:mfa/*",
-    ]
-
     effect = "Allow"
+
+    actions = [
+      "iam:CreateVirtualMFADevice"
+    ]
+
+    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:mfa/*"]
   }
 
-  # Allow to deactivate MFA only when logging in with MFA
   statement {
-    sid = "AllowDeactivateMFADevice"
+    sid = "AllowManageOwnUserMFA"
 
     effect = "Allow"
 
     actions = [
       "iam:DeactivateMFADevice",
+      "iam:EnableMFADevice",
+      "iam:ListMFADevices",
+      "iam:ResyncMFADevice"
     ]
 
-    # Allow for both users with "path" and without it
-    resources = [
-      "arn:${local.partition}:iam::${local.aws_account_id}:user/*/$${aws:username}",
-      "arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}",
-      "arn:${local.partition}:iam::${local.aws_account_id}:mfa/$${aws:username}",
-    ]
+    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
 
-    condition {
-      test     = "Bool"
-      variable = "aws:MultiFactorAuthPresent"
-      values   = ["true"]
-    }
-
-    condition {
-      test     = "NumericLessThan"
-      variable = "aws:MultiFactorAuthAge"
-      values   = ["3600"]
-    }
   }
 
-  # Allow to delete MFA only when logging in with MFA
   statement {
-    sid = "AllowDeleteVirtualMFADevice"
+    sid = "DenyAllExceptListedIfNoMFA"
 
-    effect = "Allow"
+    effect = "Deny"
 
-    actions = [
-      "iam:DeleteVirtualMFADevice",
-    ]
+    not_actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:EnableMFADevice",
+      "iam:GetUser",
+      "iam:ListMFADevices",
+      "iam:ListVirtualMFADevices",
+      "iam:ResyncMFADevice",
+      "sts:GetSessionToken"
+]
 
-    resources = [
-      "arn:${local.partition}:iam::${local.aws_account_id}:mfa/*",
-    ]
+    resources = ["*"]
 
     condition {
-      test     = "Bool"
+      test     = "BoolIfExists"
       variable = "aws:MultiFactorAuthPresent"
-      values   = ["true"]
+      values   = ["false"]
     }
-
-    condition {
-      test     = "NumericLessThan"
-      variable = "aws:MultiFactorAuthAge"
-      values   = ["3600"]
-    }
-  }
+  }  
 }

--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "iam_self_management" {
     resources = [
       "arn:${local.partition}:iam::${local.aws_account_id}:user/*/$${aws:username}",
       "arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}",
-      "arn:${local.partition}:iam::${local.aws_account_id}:mfa/$${aws:username}",
+      "arn:${local.partition}:iam::${local.aws_account_id}:mfa/*",
     ]
   }
 
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "iam_self_management" {
     resources = [
       "arn:${local.partition}:iam::${local.aws_account_id}:user/*/$${aws:username}",
       "arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}",
-      "arn:${local.partition}:iam::${local.aws_account_id}:mfa/$${aws:username}",
+      "arn:${local.partition}:iam::${local.aws_account_id}:mfa/*",
     ]
 
     condition {


### PR DESCRIPTION
## Description

Fix the `IAMSelfManagement` policy to allow virtual MFA devices creation.

Due to [this new feature](https://aws.amazon.com/blogs/security/you-can-now-assign-multiple-mfa-devices-in-iam/), the resource name of virtual MFA devices change and the policy doesn't work anymore. 

The wildcard in the MFA resource name is required now, because the user must specify a name for his virtual MFA device, and this is a part of the resource name.

## Motivation and Context
- Resolves #312 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
- [x] I have directly edited the `IAMSelfManagement` policy and added successfully a new virtual MFA device.
