### PR TITLE
fix: Add `ssm:GetParameters` permission to `external-secrets` policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+    rev: v1.77.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -410,7 +410,10 @@ data "aws_iam_policy_document" "external_secrets" {
   count = var.create_role && var.attach_external_secrets_policy ? 1 : 0
 
   statement {
-    actions   = ["ssm:GetParameter"]
+    actions   = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
     resources = var.external_secrets_ssm_parameter_arns
   }
 

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -410,7 +410,7 @@ data "aws_iam_policy_document" "external_secrets" {
   count = var.create_role && var.attach_external_secrets_policy ? 1 : 0
 
   statement {
-    actions   = [
+    actions = [
       "ssm:GetParameter",
       "ssm:GetParameters",
     ]


### PR DESCRIPTION
https://docs.aws.amazon.com/systems-manager/latest/userguide/integrating_csi_driver.html#integrating_csi_driver_access

## Description
according to documentation ssm:GetParameters permission is required

## Motivation and Context
atm AWS CSI Secret Store Driver failed to get parameter with error
`MountVolume.SetUp failed for volume "volume_name" : rpc error: code = Unknown desc = failed to mount secrets store objects for pod namespace/pod-647dbc98b4-h8kl4, err: rpc error: code = Unknown desc = Failed fetching parameters: WebIdentityErr: failed to retrieve credentials caused by: AccessDenied: Not authorized to perform sts:AssumeRoleWithWebIdentity status code: 403, request id: request-uuid`

## Breaking Changes
-

## How Has This Been Tested?
- use https://github.com/aws/secrets-store-csi-driver-provider-aws
- `attach_external_secrets_policy  = true`; `external_secrets_ssm_parameter_arns = ["cluster-oidc-provider-arn"]`
- Deployment spec: specify serviceAccountName with
```
    annotations = {
      "eks.amazonaws.com/role-arn" = module.secrets-store-csi-irsa-role.iam_role_arn
    }
```
- mount SecretProviderClass with `provider: aws`