### PR TITLE
feat: Added Extra STS actions param in assumable role with SAML

### DIFF
--- a/modules/iam-assumable-role-with-saml/README.md
+++ b/modules/iam-assumable-role-with-saml/README.md
@@ -52,8 +52,7 @@ No modules.
 | <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of ARNs of IAM policies to attach to IAM role | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
-| <a name="input_trusted_role_actions"></a> [trusted\_role\_actions](#input\_trusted\_role\_actions) | Extra Actions of STS appended to AssumeRoleWithSAML | `list(string)` | `[]` | no |
-
+| <a name="input_trusted_role_actions"></a> [trusted\_role\_actions](#input\_trusted\_role\_actions) | Extra Actions of STS | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 
 ## Outputs
 

--- a/modules/iam-assumable-role-with-saml/README.md
+++ b/modules/iam-assumable-role-with-saml/README.md
@@ -52,6 +52,8 @@ No modules.
 | <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of ARNs of IAM policies to attach to IAM role | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
+| <a name="input_trusted_role_actions"></a> [trusted\_role\_actions](#input\_trusted\_role\_actions) | Extra Actions of STS appended to AssumeRoleWithSAML | `list(string)` | `[]` | no |
+
 
 ## Outputs
 

--- a/modules/iam-assumable-role-with-saml/main.tf
+++ b/modules/iam-assumable-role-with-saml/main.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "assume_role_with_saml" {
 
   statement {
     effect  = "Allow"
-    actions = ["sts:AssumeRoleWithSAML"]
+    actions = distinct((concat(["sts:AssumeRoleWithSAML"], var.trusted_role_actions)))
 
     principals {
       type = "Federated"

--- a/modules/iam-assumable-role-with-saml/main.tf
+++ b/modules/iam-assumable-role-with-saml/main.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "assume_role_with_saml" {
 
   statement {
     effect  = "Allow"
-    actions = distinct((concat(["sts:AssumeRoleWithSAML"], var.trusted_role_actions)))
+    actions = compact(distinct(concat(["sts:AssumeRoleWithSAML"], var.trusted_role_actions)))
 
     principals {
       type = "Federated"

--- a/modules/iam-assumable-role-with-saml/variables.tf
+++ b/modules/iam-assumable-role-with-saml/variables.tf
@@ -87,3 +87,9 @@ variable "allow_self_assume_role" {
   type        = bool
   default     = false
 }
+
+variable "trusted_role_actions" {
+  description = "Extra Actions of STS"
+  type        = list(string)
+  default     = [""]
+}


### PR DESCRIPTION
## Description
Added the abbility to append optional extra trusted roles actions appart from the default "AssumeRoleWithSAML" in the iam-assumable-role-with-saml module

## Motivation and Context
Wanted the to utilize the module to avoid rewiting all the logic from scratch but also have the ability to add some extra actions that apply to our use cases.

## Breaking Changes
None as far as I know.

## How Has This Been Tested?
Internally in our organisation in many deployments. Unable to showcase.