### PR TITLE
fix: Update `role_name` default to `null`

### DIFF
--- a/examples/iam-assumable-role/main.tf
+++ b/examples/iam-assumable-role/main.tf
@@ -23,7 +23,7 @@ module "iam_assumable_role_admin" {
   create_role             = true
   create_instance_profile = true
 
-  role_name         = "admin"
+  role_name         = "adminTest"
   role_requires_mfa = true
 
   attach_admin_policy = true
@@ -49,7 +49,7 @@ module "iam_assumable_role_custom" {
 
   create_role = true
 
-  role_name         = "custom"
+  role_name_prefix  = "custom-"
   role_requires_mfa = false
 
   role_sts_externalid = "some-id-goes-here"

--- a/examples/iam-assumable-role/main.tf
+++ b/examples/iam-assumable-role/main.tf
@@ -23,7 +23,7 @@ module "iam_assumable_role_admin" {
   create_role             = true
   create_instance_profile = true
 
-  role_name         = "adminTest"
+  role_name         = "admin"
   role_requires_mfa = true
 
   attach_admin_policy = true

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -57,7 +57,7 @@ No modules.
 | <a name="input_poweruser_role_policy_arn"></a> [poweruser\_role\_policy\_arn](#input\_poweruser\_role\_policy\_arn) | Policy ARN to use for poweruser role | `string` | `"arn:aws:iam::aws:policy/PowerUserAccess"` | no |
 | <a name="input_readonly_role_policy_arn"></a> [readonly\_role\_policy\_arn](#input\_readonly\_role\_policy\_arn) | Policy ARN to use for readonly role | `string` | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | IAM Role description | `string` | `""` | no |
-| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | IAM role name | `string` | `""` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | IAM role name | `string` | `null` | no |
 | <a name="input_role_name_prefix"></a> [role\_name\_prefix](#input\_role\_name\_prefix) | IAM role name prefix | `string` | `null` | no |
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role | `string` | `"/"` | no |
 | <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `""` | no |

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -43,7 +43,7 @@ variable "create_instance_profile" {
 variable "role_name" {
   description = "IAM role name"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "role_name_prefix" {


### PR DESCRIPTION
## Description
`role_name` conflicts with `role_name_prefix` in the `iam-assumable-role` module. 

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-iam/issues/318

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
