### PR TITLE
fix: Reflect the changes in the ebs_csi driver

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -226,6 +226,17 @@ data "aws_iam_policy_document" "ebs_csi" {
   }
 
   statement {
+    actions   = ["ec2:DeleteVolume"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/kubernetes.io/created-for/pvc/name"
+      values   = ["*"]
+    }
+  }
+
+  statement {
     actions   = ["ec2:DeleteSnapshot"]
     resources = ["*"]
 


### PR DESCRIPTION
## Description

modules/iam-role-for-service-accounts-eks -
EBS-CSI driver policy - fix condition string for DeleteVolume action to reflect the changes in the upstream

## Motivation and Context
Issue - https://github.com/terraform-aws-modules/terraform-aws-iam/issues/325
The change in the upstream - https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1450

## Breaking Changes
There are no breaking changes

## How Has This Been Tested?
- [x] I have executed `pre-commit run -a` on my pull request
- tested on the EKS 1.23, Chart: aws-ebs-csi-driver-2.11.1, the driver version: 1.11.3
