### PR TITLE
fix: Do not attach force MFA statement for iam-groups-with-policies by default

### DIFF
--- a/examples/iam-group-with-policies/README.md
+++ b/examples/iam-group-with-policies/README.md
@@ -32,6 +32,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_iam_group_force_mfa"></a> [iam\_group\_force\_mfa](#module\_iam\_group\_force\_mfa) | ../../modules/iam-group-with-policies | n/a |
 | <a name="module_iam_group_superadmins"></a> [iam\_group\_superadmins](#module\_iam\_group\_superadmins) | ../../modules/iam-group-with-policies | n/a |
 | <a name="module_iam_group_with_custom_policies"></a> [iam\_group\_with\_custom\_policies](#module\_iam\_group\_with\_custom\_policies) | ../../modules/iam-group-with-policies | n/a |
 | <a name="module_iam_user1"></a> [iam\_user1](#module\_iam\_user1) | ../../modules/iam-user | n/a |

--- a/examples/iam-group-with-policies/main.tf
+++ b/examples/iam-group-with-policies/main.tf
@@ -38,6 +38,25 @@ module "iam_group_superadmins" {
 }
 
 #####################################################################################
+# IAM group for billing with full Administrator access
+#####################################################################################
+module "iam_group_force_mfa" {
+  source = "../../modules/iam-group-with-policies"
+
+  name = "billing"
+
+  group_users = [
+    module.iam_user1.iam_user_name,
+    module.iam_user2.iam_user_name,
+  ]
+
+  custom_group_policy_arns = [
+    "arn:aws:iam::aws:policy/job-function/Billing",
+  ]
+  attach_force_mfa_policy = true
+}
+
+#####################################################################################
 # IAM group for users with custom access
 #####################################################################################
 module "iam_group_with_custom_policies" {

--- a/modules/iam-group-with-policies/README.md
+++ b/modules/iam-group-with-policies/README.md
@@ -28,10 +28,13 @@ No modules.
 | [aws_iam_group_membership.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_membership) | resource |
 | [aws_iam_group_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
 | [aws_iam_group_policy_attachment.custom_arns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
+| [aws_iam_group_policy_attachment.force_mfa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
 | [aws_iam_group_policy_attachment.iam_self_management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
 | [aws_iam_policy.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.force_mfa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.iam_self_management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.force_mfa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.iam_self_management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
@@ -39,11 +42,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_attach_force_mfa_policy"></a> [attach\_force\_mfa\_policy](#input\_attach\_force\_mfa\_policy) | Whether to attach IAM policy which users to use MFA for console and API requests | `bool` | `false` | no |
 | <a name="input_attach_iam_self_management_policy"></a> [attach\_iam\_self\_management\_policy](#input\_attach\_iam\_self\_management\_policy) | Whether to attach IAM policy which allows IAM users to manage their credentials and MFA | `bool` | `true` | no |
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS account id to use inside IAM policies. If empty, current AWS account ID will be used. | `string` | `""` | no |
 | <a name="input_create_group"></a> [create\_group](#input\_create\_group) | Whether to create IAM group | `bool` | `true` | no |
 | <a name="input_custom_group_policies"></a> [custom\_group\_policies](#input\_custom\_group\_policies) | List of maps of inline IAM policies to attach to IAM group. Should have `name` and `policy` keys in each element. | `list(map(string))` | `[]` | no |
 | <a name="input_custom_group_policy_arns"></a> [custom\_group\_policy\_arns](#input\_custom\_group\_policy\_arns) | List of IAM policies ARNs to attach to IAM group | `list(string)` | `[]` | no |
+| <a name="input_force_mfa_policy_name_prefix"></a> [force\_mfa\_policy\_name\_prefix](#input\_force\_mfa\_policy\_name\_prefix) | Name prefix for IAM policy to create with Force MFA statements | `string` | `"ForceMFA-"` | no |
 | <a name="input_group_users"></a> [group\_users](#input\_group\_users) | List of IAM users to have in an IAM group which can assume the role | `list(string)` | `[]` | no |
 | <a name="input_iam_self_management_policy_name_prefix"></a> [iam\_self\_management\_policy\_name\_prefix](#input\_iam\_self\_management\_policy\_name\_prefix) | Name prefix for IAM policy to create with IAM self-management permissions | `string` | `"IAMSelfManagement-"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of IAM group | `string` | `""` | no |

--- a/modules/iam-group-with-policies/main.tf
+++ b/modules/iam-group-with-policies/main.tf
@@ -26,6 +26,13 @@ resource "aws_iam_group_policy_attachment" "iam_self_management" {
   policy_arn = aws_iam_policy.iam_self_management[0].arn
 }
 
+resource "aws_iam_group_policy_attachment" "force_mfa" {
+  count = var.attach_force_mfa_policy ? 1 : 0
+
+  group      = local.group_name
+  policy_arn = aws_iam_policy.force_mfa[0].arn
+}
+
 resource "aws_iam_group_policy_attachment" "custom_arns" {
   count = length(var.custom_group_policy_arns)
 

--- a/modules/iam-group-with-policies/main.tf
+++ b/modules/iam-group-with-policies/main.tf
@@ -52,6 +52,15 @@ resource "aws_iam_policy" "iam_self_management" {
   tags = var.tags
 }
 
+resource "aws_iam_policy" "force_mfa" {
+  count = var.attach_force_mfa_policy ? 1 : 0
+
+  name_prefix = var.force_mfa_policy_name_prefix
+  policy      = data.aws_iam_policy_document.force_mfa.json
+
+  tags = var.tags
+}
+
 resource "aws_iam_policy" "custom" {
   count = length(var.custom_group_policies)
 

--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -125,9 +125,10 @@ data "aws_iam_policy_document" "iam_self_management" {
     ]
 
     resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
-
   }
+}
 
+data "aws_iam_policy_document" "force_mfa" {
   statement {
     sid = "DenyAllExceptListedIfNoMFA"
 

--- a/modules/iam-group-with-policies/variables.tf
+++ b/modules/iam-group-with-policies/variables.tf
@@ -28,6 +28,18 @@ variable "custom_group_policies" {
   default     = []
 }
 
+variable "attach_force_mfa_policy" {
+  description = "Whether to attach IAM policy which users to use MFA for console and API requests"
+  type        = bool
+  default     = false
+}
+
+variable "force_mfa_policy_name_prefix" {
+  description = "Name prefix for IAM policy to create with Force MFA statements"
+  type        = string
+  default     = "ForceMFA-"
+}
+
 variable "attach_iam_self_management_policy" {
   description = "Whether to attach IAM policy which allows IAM users to manage their credentials and MFA"
   type        = bool


### PR DESCRIPTION
## Description
Disable MFA enforcement for created groups added in 5.11.0. This change was undocumented, therefore it should be reverted and added as opt-in feature.

## Motivation and Context
Keep the module backward compatible with versions prior to 5.11.0

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #332 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
