### PR TITLE
Update self manage policy to support users with path

### DIFF
--- a/examples/iam-group-with-policies/main.tf
+++ b/examples/iam-group-with-policies/main.tf
@@ -14,6 +14,7 @@ module "iam_user2" {
   source = "../../modules/iam-user"
 
   name = "user2"
+  path = "/developers/"
 
   create_iam_user_login_profile = false
   create_iam_access_key         = false

--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -35,7 +35,10 @@ data "aws_iam_policy_document" "iam_self_management" {
       "iam:GetUser"
     ]
 
-    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
+    resources = [
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}",
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/*/$${aws:username}"
+    ]
   }
 
   statement {
@@ -50,7 +53,10 @@ data "aws_iam_policy_document" "iam_self_management" {
       "iam:UpdateAccessKey"
     ]
 
-    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
+    resources = [
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}",
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/*/$${aws:username}"
+    ]
   }
 
   statement {
@@ -65,7 +71,10 @@ data "aws_iam_policy_document" "iam_self_management" {
       "iam:UploadSigningCertificate"
     ]
 
-    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
+    resources = [
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}",
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/*/$${aws:username}"
+    ]
   }
 
   statement {
@@ -81,7 +90,10 @@ data "aws_iam_policy_document" "iam_self_management" {
       "iam:UploadSSHPublicKey"
     ]
 
-    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
+    resources = [
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}",
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/*/$${aws:username}"
+    ]
   }
 
   statement {
@@ -97,7 +109,10 @@ data "aws_iam_policy_document" "iam_self_management" {
       "iam:UpdateServiceSpecificCredential"
     ]
 
-    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
+    resources = [
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}",
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/*/$${aws:username}"
+    ]
   }
 
   statement {
@@ -124,8 +139,10 @@ data "aws_iam_policy_document" "iam_self_management" {
       "iam:ResyncMFADevice"
     ]
 
-    resources = ["arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}"]
-
+    resources = [
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/$${aws:username}",
+      "arn:${local.partition}:iam::${local.aws_account_id}:user/*/$${aws:username}"
+    ]
   }
 
   statement {


### PR DESCRIPTION
## Description
Update self-manage policy to support users with path, regressed in 5.11.0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Changes introduced in #313 removed support for users with path. 

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #334

## Breaking Changes
None

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
