### PR TITLE
feat: Added support for Bitbucket OIDC provider and Bitbucket OIDC Role

### DIFF
--- a/examples/iam-bitbucket-oidc/README.md
+++ b/examples/iam-bitbucket-oidc/README.md
@@ -1,0 +1,63 @@
+# IAM GitHub OIDC
+
+- Creates an IAM identity provider for Bitbucket OIDC
+- Creates an IAM role that trust the IAM Bitbucket OIDC provider
+  - Bitbucket reference: https://support.atlassian.com/bitbucket-cloud/docs/integrate-pipelines-with-resource-servers-using-oidc/
+  - AWS IAM role reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html
+
+Note: an IAM provider is 1 per account per given URL. This module would be provisioned once per AWS account, and multiple roles created with this provider as the trusted identity (typically 1 role per Bitbucket workspace).
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_iam_bitbucket_oidc_provider"></a> [iam\_bitbucket\_oidc\_provider](#module\_iam\_bitbucket\_oidc\_provider) | ../../modules/iam-bitbucket-oidc-provider | n/a |
+| <a name="module_iam_bitbucket_oidc_provider_disabled"></a> [iam\_bitbucket\_oidc\_provider\_disabled](#module\_iam\_bitbucket\_oidc\_provider\_disabled) | ../../modules/iam-bitbucket-oidc-provider | n/a |
+| <a name="module_iam_bitbucket_oidc_role"></a> [iam\_bitbucket\_oidc\_role](#module\_iam\_bitbucket\_oidc\_role) | ../../modules/iam-bitbucket-oidc-role | n/a |
+| <a name="module_iam_bitbucket_oidc_role_disabled"></a> [iam\_bitbucket\_oidc\_role\_disabled](#module\_iam\_bitbucket\_oidc\_role\_disabled) | ../../modules/iam-bitbucket-oidc-role | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
+| <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
+| <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_provider_arn"></a> [provider\_arn](#output\_provider\_arn) | The ARN assigned by AWS for this provider |
+| <a name="output_provider_url"></a> [provider\_url](#output\_provider\_url) | The URL of the identity provider. Corresponds to the iss claim |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-bitbucket-oidc/main.tf
+++ b/examples/iam-bitbucket-oidc/main.tf
@@ -1,0 +1,95 @@
+provider "aws" {
+  region = local.region
+}
+
+locals {
+  name   = "ex-iam-bitbucket-oidc"
+  region = "eu-west-1"
+
+  tags = {
+    Example    = local.name
+    GithubRepo = "terraform-aws-iam"
+    GithubOrg  = "terraform-aws-modules"
+  }
+}
+
+################################################################################
+# Bitbucket OIDC Provider
+# Note: This is one per AWS account
+################################################################################
+
+module "iam_bitbucket_oidc_provider" {
+  source = "../../modules/iam-bitbucket-oidc-provider"
+
+  client_id_list = ["ari:cloud:bitbucket::workspace/5df1fe21-3e92-4e32-ad7b-6ab3114afe0b"]
+  tags           = local.tags
+}
+
+module "iam_bitbucket_oidc_provider_disabled" {
+  source = "../../modules/iam-bitbucket-oidc-provider"
+
+  create = false
+}
+
+################################################################################
+# Bitbucket OIDC Role
+################################################################################
+
+module "iam_bitbucket_oidc_role" {
+  source = "../../modules/iam-bitbucket-oidc-role"
+
+  name = local.name
+
+  # These should be updated to suit your workspace, repository, environment, and step UUIDs
+
+  # audience can be defined as "ari:cloud:bitbucket::workspace/WORKSPACE_UUID"
+  audience = "ari:cloud:bitbucket::workspace/922e118c-f34f-4226-a897-0e0afbec553d"
+
+  # subjects can be configured as explained at https://support.atlassian.com/bitbucket-cloud/docs/deploy-on-aws-using-bitbucket-pipelines-openid-connect/
+  # {REPOSITORY_UUID}[:{ENVIRONMENT_UUID}]:{STEP_UUID}
+  # E.g.
+  # {1de489be-ce6a-42a0-a8c8-eadbf1174ac7}:{bd715740-c970-486b-b68a-b421ec2a1f8b}:{759de0c6-eaee-4eaa-b7a6-c507eec759a7}
+  # {1de489be-ce6a-42a0-a8c8-eadbf1174ac7}:{759de0c6-eaee-4eaa-b7a6-c507eec759a7}
+
+  subjects = [
+    "{1de489be-ce6a-42a0-a8c8-eadbf1174ac7}:*",
+    "{1de489be-ce6a-42a0-a8c8-eadbf1174ac7}:{bd715740-c970-486b-b68a-b421ec2a1f8b}:*",
+  ]
+
+  policies = {
+    additional = aws_iam_policy.additional.arn
+    S3ReadOnly = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  }
+
+  tags = local.tags
+}
+
+module "iam_bitbucket_oidc_role_disabled" {
+  source = "../../modules/iam-bitbucket-oidc-role"
+
+  create = false
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+resource "aws_iam_policy" "additional" {
+  name        = "${local.name}-additional"
+  description = "Additional test policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+
+  tags = local.tags
+}

--- a/examples/iam-bitbucket-oidc/outputs.tf
+++ b/examples/iam-bitbucket-oidc/outputs.tf
@@ -1,0 +1,37 @@
+################################################################################
+# Bitbucket OIDC Provider
+################################################################################
+
+output "provider_arn" {
+  description = "The ARN assigned by AWS for this provider"
+  value       = module.iam_bitbucket_oidc_provider.arn
+}
+
+output "provider_url" {
+  description = "The URL of the identity provider. Corresponds to the iss claim"
+  value       = module.iam_bitbucket_oidc_provider.url
+}
+
+################################################################################
+# Bitbucket OIDC Role
+################################################################################
+
+output "iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = module.iam_bitbucket_oidc_role.arn
+}
+
+output "iam_role_name" {
+  description = "Name of IAM role"
+  value       = module.iam_bitbucket_oidc_role.name
+}
+
+output "iam_role_path" {
+  description = "Path of IAM role"
+  value       = module.iam_bitbucket_oidc_role.path
+}
+
+output "iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.iam_bitbucket_oidc_role.unique_id
+}

--- a/examples/iam-bitbucket-oidc/versions.tf
+++ b/examples/iam-bitbucket-oidc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}

--- a/modules/iam-bitbucket-oidc-provider/README.md
+++ b/modules/iam-bitbucket-oidc-provider/README.md
@@ -1,0 +1,62 @@
+# IAM Bitbucket OIDC Provider
+
+Creates an IAM identity provider for Bitbucket OIDC. See more details here https://support.atlassian.com/bitbucket-cloud/docs/integrate-pipelines-with-resource-servers-using-oidc/
+
+Note: an IAM provider is 1 per account per given URL. This module would be provisioned once per AWS account, and multiple roles created with this provider as the trusted identity (typically 1 role per Bitbucket repository).
+
+## Usage
+
+```hcl
+module "iam_bitbucket_oidc_provider" {
+  source    = "terraform-aws-modules/iam/aws//modules/iam-bitbucket-oidc-provider"
+
+  tags = {
+    Environment = "test"
+  }
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [tls_certificate.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_client_id_list"></a> [client\_id\_list](#input\_client\_id\_list) | List of client IDs (also known as audiences) for the IAM OIDC provider. Defaults to STS service if not values are provided | `list(string)` | `[]` | no |
+| <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects all resources) | `bool` | `true` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources created | `map(any)` | `{}` | no |
+| <a name="input_workspace"></a> [workspace](#input\_workspace) | The Bitbucket workspace name | `string` | `"YOUR_WORSPACE_NAME"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN assigned by AWS for this provider |
+| <a name="output_url"></a> [url](#output\_url) | The URL of the identity provider. Corresponds to the iss claim |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-bitbucket-oidc-provider/main.tf
+++ b/modules/iam-bitbucket-oidc-provider/main.tf
@@ -1,0 +1,25 @@
+locals {
+  url = "https://api.bitbucket.org/2.0/workspaces/${var.workspace}/pipelines-config/identity/oidc"
+}
+
+data "aws_partition" "current" {}
+
+################################################################################
+# Bitbucket OIDC Provider
+################################################################################
+
+data "tls_certificate" "this" {
+  count = var.create ? 1 : 0
+
+  url = local.url
+}
+
+resource "aws_iam_openid_connect_provider" "this" {
+  count = var.create ? 1 : 0
+
+  url             = local.url
+  client_id_list  = coalescelist(var.client_id_list, ["sts.${data.aws_partition.current.dns_suffix}"])
+  thumbprint_list = data.tls_certificate.this[0].certificates[*].sha1_fingerprint
+
+  tags = var.tags
+}

--- a/modules/iam-bitbucket-oidc-provider/outputs.tf
+++ b/modules/iam-bitbucket-oidc-provider/outputs.tf
@@ -1,0 +1,13 @@
+################################################################################
+# Bitbucket OIDC Provider
+################################################################################
+
+output "arn" {
+  description = "The ARN assigned by AWS for this provider"
+  value       = try(aws_iam_openid_connect_provider.this[0].arn, null)
+}
+
+output "url" {
+  description = "The URL of the identity provider. Corresponds to the iss claim"
+  value       = try(aws_iam_openid_connect_provider.this[0].url, null)
+}

--- a/modules/iam-bitbucket-oidc-provider/variables.tf
+++ b/modules/iam-bitbucket-oidc-provider/variables.tf
@@ -1,0 +1,23 @@
+variable "create" {
+  description = "Controls if resources should be created (affects all resources)"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "A map of tags to add to the resources created"
+  type        = map(any)
+  default     = {}
+}
+
+variable "client_id_list" {
+  description = "List of client IDs (also known as audiences) for the IAM OIDC provider. Defaults to STS service if not values are provided"
+  type        = list(string)
+  default     = []
+}
+
+variable "workspace" {
+  description = "The Bitbucket workspace name"
+  type        = string
+  default     = "YOUR_WORSPACE_NAME"
+}

--- a/modules/iam-bitbucket-oidc-provider/versions.tf
+++ b/modules/iam-bitbucket-oidc-provider/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/modules/iam-bitbucket-oidc-role/README.md
+++ b/modules/iam-bitbucket-oidc-role/README.md
@@ -1,0 +1,89 @@
+# IAM GitHub OIDC Role
+
+Creates an IAM role that trust the IAM Bitbucket OIDC provider.
+
+- Bitbucket reference: https://support.atlassian.com/bitbucket-cloud/docs/deploy-on-aws-using-bitbucket-pipelines-openid-connect
+- AWS IAM role reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html
+
+## Usage
+
+### [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/deploy-on-aws-using-bitbucket-pipelines-openid-connect)
+
+The defaults provided by the module are suitable for Bitbucket Pipelines.
+
+```hcl
+module "iam_bitbucket_oidc_role" {
+  source    = "terraform-aws-modules/iam/aws//modules/iam-bitbucket-oidc-role"
+
+  audience     = "https://mygithub.com/<GITHUB_ORG>"
+  provider_url = "mygithub.com/_services/token"
+
+  # This should be updated to suit your organization, repository, references/branches, etc.
+  subjects = ["<GITHUB_ORG>/terraform-aws-iam:*"]
+
+  policies = {
+    S3ReadOnly = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  }
+
+  tags = {
+    Environment = "test"
+  }
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_audience"></a> [audience](#input\_audience) | Audience to use for OIDC role. Defaults to `sts.amazonaws.com` | `string` | `"sts.amazonaws.com"` | no |
+| <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects all resources) | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | IAM Role description | `string` | `null` | no |
+| <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `true` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of IAM role | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | IAM role name prefix | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | Path of IAM role | `string` | `"/"` | no |
+| <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `null` | no |
+| <a name="input_policies"></a> [policies](#input\_policies) | Policies to attach to the IAM role in `{'static_name' = 'policy_arn'}` format | `map(string)` | `{}` | no |
+| <a name="input_subjects"></a> [subjects](#input\_subjects) | List of Bitbucket OIDC subjects that are permitted by the trust policy. Example: `['{REPO_UUID}:*', '{REPOSITORY_UUID}:{ENVIRONMENT_UUID}:{STEP_UUID}']` | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources created | `map(any)` | `{}` | no |
+| <a name="input_workspace"></a> [workspace](#input\_workspace) | The Bitbucket workspace name | `string` | `"YOUR_WORSPACE_NAME"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN of IAM role |
+| <a name="output_name"></a> [name](#output\_name) | Name of IAM role |
+| <a name="output_path"></a> [path](#output\_path) | Path of IAM role |
+| <a name="output_unique_id"></a> [unique\_id](#output\_unique\_id) | Unique ID of IAM role |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-bitbucket-oidc-role/main.tf
+++ b/modules/iam-bitbucket-oidc-role/main.tf
@@ -1,0 +1,66 @@
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  provider_url = "api.bitbucket.org/2.0/workspaces/${var.workspace}/pipelines-config/identity/oidc"
+
+  account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
+}
+
+################################################################################
+# Bitbucket OIDC Role
+################################################################################
+
+data "aws_iam_policy_document" "this" {
+  count = var.create ? 1 : 0
+
+  statement {
+    sid    = "BitbucketOidcAuth"
+    effect = "Allow"
+    actions = [
+      "sts:TagSession",
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:${local.partition}:iam::${local.account_id}:oidc-provider/${local.provider_url}"]
+    }
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "${local.provider_url}:aud"
+      values   = [var.audience]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${local.provider_url}:sub"
+      values   = [for subject in var.subjects : subject]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  count = var.create ? 1 : 0
+
+  name        = var.name
+  name_prefix = var.name_prefix
+  path        = var.path
+  description = var.description
+
+  assume_role_policy    = data.aws_iam_policy_document.this[0].json
+  max_session_duration  = var.max_session_duration
+  permissions_boundary  = var.permissions_boundary_arn
+  force_detach_policies = var.force_detach_policies
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each = { for k, v in var.policies : k => v if var.create }
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = each.value
+}

--- a/modules/iam-bitbucket-oidc-role/outputs.tf
+++ b/modules/iam-bitbucket-oidc-role/outputs.tf
@@ -1,0 +1,23 @@
+################################################################################
+# GitHub OIDC Role
+################################################################################
+
+output "arn" {
+  description = "ARN of IAM role"
+  value       = try(aws_iam_role.this[0].arn, null)
+}
+
+output "name" {
+  description = "Name of IAM role"
+  value       = try(aws_iam_role.this[0].name, null)
+}
+
+output "path" {
+  description = "Path of IAM role"
+  value       = try(aws_iam_role.this[0].path, null)
+}
+
+output "unique_id" {
+  description = "Unique ID of IAM role"
+  value       = try(aws_iam_role.this[0].unique_id, null)
+}

--- a/modules/iam-bitbucket-oidc-role/variables.tf
+++ b/modules/iam-bitbucket-oidc-role/variables.tf
@@ -1,0 +1,81 @@
+variable "create" {
+  description = "Controls if resources should be created (affects all resources)"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "A map of tags to add to the resources created"
+  type        = map(any)
+  default     = {}
+}
+
+################################################################################
+# Bitbucket OIDC Role
+################################################################################
+
+variable "name" {
+  description = "Name of IAM role"
+  type        = string
+  default     = null
+}
+
+variable "path" {
+  description = "Path of IAM role"
+  type        = string
+  default     = "/"
+}
+
+variable "permissions_boundary_arn" {
+  description = "Permissions boundary ARN to use for IAM role"
+  type        = string
+  default     = null
+}
+
+variable "description" {
+  description = "IAM Role description"
+  type        = string
+  default     = null
+}
+
+variable "name_prefix" {
+  description = "IAM role name prefix"
+  type        = string
+  default     = null
+}
+
+variable "policies" {
+  description = "Policies to attach to the IAM role in `{'static_name' = 'policy_arn'}` format"
+  type        = map(string)
+  default     = {}
+}
+
+variable "force_detach_policies" {
+  description = "Whether policies should be detached from this role when destroying"
+  type        = bool
+  default     = true
+}
+
+variable "max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200"
+  type        = number
+  default     = null
+}
+
+variable "audience" {
+  description = "Audience to use for OIDC role. Defaults to `sts.amazonaws.com`"
+  type        = string
+  default     = "sts.amazonaws.com"
+}
+
+variable "subjects" {
+  description = "List of Bitbucket OIDC subjects that are permitted by the trust policy. Example: `['{REPO_UUID}:*', '{REPOSITORY_UUID}:{ENVIRONMENT_UUID}:{STEP_UUID}']`"
+  type        = list(string)
+  default     = []
+}
+
+variable "workspace" {
+  description = "The Bitbucket workspace name"
+  type        = string
+  default     = "YOUR_WORSPACE_NAME"
+}

--- a/modules/iam-bitbucket-oidc-role/versions.tf
+++ b/modules/iam-bitbucket-oidc-role/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0"
+    }
+  }
+}


### PR DESCRIPTION
## Description
Added support for Bitbucket OIDC provider and role

## Motivation and Context
Using OIDC instead of long-lived AWS keys is a best practice, but before only GitHub was supported in the module. It would be nice to have it out of the box for other popular repositories.

## Breaking Changes
No

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request

Issue to solve #336 