### PR TITLE
feat: Adding eks:DescribeCluster permission required by Karpenter v0.25.0

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -1,8 +1,10 @@
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
 
 locals {
   account_id          = data.aws_caller_identity.current.account_id
+  region              = data.aws_region.current.name
   partition           = data.aws_partition.current.partition
   dns_suffix          = data.aws_partition.current.dns_suffix
   role_name_condition = var.role_name != null ? var.role_name : "${var.role_name_prefix}*"

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -533,7 +533,7 @@ data "aws_iam_policy_document" "karpenter_controller" {
     ]
 
     resources = [
-      "arn:aws:eks:${local.partition}:${local.account_id}:cluster/${var.karpenter_controller_cluster_id}"
+      "arn:aws:eks:${local.region}:${local.account_id}:cluster/${var.karpenter_controller_cluster_id}"
     ]
   }
   

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -529,6 +529,16 @@ data "aws_iam_policy_document" "karpenter_controller" {
 
   statement {
     actions = [
+      "eks:DescribeCluster",
+    ]
+
+    resources = [
+      "arn:aws:eks:${local.partition}:${local.account_id}:cluster/${var.karpenter_controller_cluster_id}"
+    ]
+  }
+  
+  statement {
+    actions = [
       "ec2:CreateFleet",
       "ec2:CreateLaunchTemplate",
       "ec2:CreateTags",


### PR DESCRIPTION
Karpenter v0.25.0 is capable of detecting the EKS endpoint automatically but it requires the `eks:DescribeCluster` IAM permission.

https://karpenter.sh/v0.25.0/upgrade-guide/#upgrading-to-v0250

Plan output with an existing Karpenter IAM role:

```hcl
Terraform will perform the following actions:

  # aws_iam_policy.karpenter_controller[0] will be updated in-place
  ~ resource "aws_iam_policy" "karpenter_controller" {
        id          = "arn:aws:iam::XXXXXXXXXXX:policy/AmazonEKS_Karpenter_Controller_Policy-XXXXXXXXXXX"
        name        = "AmazonEKS_Karpenter_Controller_Policy-XXXXXXXXXXX"
      ~ policy      = jsonencode(
          ~ {
              ~ Statement = [
                  + {
                      + Action   = "eks:DescribeCluster"
                      + Effect   = "Allow"
                      + Resource = "arn:aws:eks:eu-central-1:XXXXXXXXXXX:cluster/my-cluster"
                      + Sid      = ""
                    },
                    {
                        Action   = [
                            "pricing:GetProducts",
                            "ec2:DescribeSubnets",
                            "ec2:DescribeSpotPriceHistory",
                            "ec2:DescribeSecurityGroups",
                            "ec2:DescribeLaunchTemplates",
                            "ec2:DescribeInstances",
                            "ec2:DescribeInstanceTypes",
                            "ec2:DescribeInstanceTypeOfferings",
                            "ec2:DescribeImages",
                            "ec2:DescribeAvailabilityZones",
                            "ec2:CreateTags",
                            "ec2:CreateLaunchTemplate",
                            "ec2:CreateFleet",
                        ]
                        Effect   = "Allow"
                        Resource = "*"
                        Sid      = ""
                    },
                    # (6 unchanged elements hidden)
                ]
                # (1 unchanged element hidden)
            }
        )
        tags        = {}
        # (6 unchanged attributes hidden)
    }
```
