### PR TITLE
feat: Add `eks:DescribeCluster` for Karpenter cluster endpoint auto discovery

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/README.md
+++ b/modules/iam-role-for-service-accounts-eks/README.md
@@ -170,6 +170,7 @@ No modules.
 | [aws_iam_policy_document.velero](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -1,10 +1,12 @@
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
 
 locals {
   account_id          = data.aws_caller_identity.current.account_id
   partition           = data.aws_partition.current.partition
   dns_suffix          = data.aws_partition.current.dns_suffix
+  region              = data.aws_region.current.name
   role_name_condition = var.role_name != null ? var.role_name : "${var.role_name_prefix}*"
 }
 

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -601,7 +601,7 @@ data "aws_iam_policy_document" "karpenter_controller" {
 
   statement {
     actions   = ["eks:DescribeCluster"]
-    resources = ["arn:aws:eks:${local.region}:${local.account_id}:cluster/${var.karpenter_controller_cluster_id}"]
+    resources = ["arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.karpenter_controller_cluster_id}"]
   }
 
   dynamic "statement" {

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -599,6 +599,11 @@ data "aws_iam_policy_document" "karpenter_controller" {
     resources = var.karpenter_controller_node_iam_role_arns
   }
 
+  statement {
+    actions   = ["eks:DescribeCluster"]
+    resources = "arn:aws:eks:${local.region}:${local.account_id}:cluster/${var.karpenter_controller_cluster_id}"
+  }
+
   dynamic "statement" {
     for_each = var.karpenter_sqs_queue_arn != null ? [1] : []
 

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -601,7 +601,7 @@ data "aws_iam_policy_document" "karpenter_controller" {
 
   statement {
     actions   = ["eks:DescribeCluster"]
-    resources = "arn:aws:eks:${local.region}:${local.account_id}:cluster/${var.karpenter_controller_cluster_id}"
+    resources = ["arn:aws:eks:${local.region}:${local.account_id}:cluster/${var.karpenter_controller_cluster_id}"]
   }
 
   dynamic "statement" {


### PR DESCRIPTION
## Description

Add `eks:DescribeCluster` for Karpenter IRSA role

## Motivation and Context
This is needed as of Karpenter 0.25: https://github.com/aws/karpenter/issues/3462
- Closes #341 

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

I tested on my local setup.

- [ ] I have executed `pre-commit run -a` on my pull request
