### PR TITLE
feat: Add support for `path` in `iam-group-with-assumable-roles-policy`

### DIFF
--- a/modules/iam-group-with-assumable-roles-policy/README.md
+++ b/modules/iam-group-with-assumable-roles-policy/README.md
@@ -37,6 +37,7 @@ No modules.
 | <a name="input_assumable_roles"></a> [assumable\_roles](#input\_assumable\_roles) | List of IAM roles ARNs which can be assumed by the group | `list(string)` | `[]` | no |
 | <a name="input_group_users"></a> [group\_users](#input\_group\_users) | List of IAM users to have in an IAM group which can assume the role | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of IAM policy and IAM group | `string` | n/a | yes |
+| <a name="input_path"></a> [path](#input\_path) | Path of IAM policy and IAM group | `string` | `"/"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/iam-group-with-assumable-roles-policy/main.tf
+++ b/modules/iam-group-with-assumable-roles-policy/main.tf
@@ -8,6 +8,7 @@ data "aws_iam_policy_document" "assume_role" {
 
 resource "aws_iam_policy" "this" {
   name        = var.name
+  path        = var.path
   description = "Allows to assume role in another AWS account"
   policy      = data.aws_iam_policy_document.assume_role.json
 
@@ -16,6 +17,7 @@ resource "aws_iam_policy" "this" {
 
 resource "aws_iam_group" "this" {
   name = var.name
+  path = var.path
 }
 
 resource "aws_iam_group_policy_attachment" "this" {

--- a/modules/iam-group-with-assumable-roles-policy/variables.tf
+++ b/modules/iam-group-with-assumable-roles-policy/variables.tf
@@ -3,6 +3,19 @@ variable "name" {
   type        = string
 }
 
+variable "path" {
+  description = "Path of IAM policy and IAM group"
+  type        = string
+  default     = "/"
+  validation {
+    condition = alltrue([
+      startswith(var.path, "/"),
+      endswith(var.path, "/"),
+    ])
+    error_message = "IAM path must include leading and trailing slashes"
+  }
+}
+
 variable "assumable_roles" {
   description = "List of IAM roles ARNs which can be assumed by the group"
   type        = list(string)

--- a/modules/iam-group-with-assumable-roles-policy/variables.tf
+++ b/modules/iam-group-with-assumable-roles-policy/variables.tf
@@ -7,13 +7,6 @@ variable "path" {
   description = "Path of IAM policy and IAM group"
   type        = string
   default     = "/"
-  validation {
-    condition = alltrue([
-      startswith(var.path, "/"),
-      endswith(var.path, "/"),
-    ])
-    error_message = "IAM path must include leading and trailing slashes"
-  }
 }
 
 variable "assumable_roles" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add a new input variable to specify IAM path in `iam-group-with-assumable-roles-policy`, fixing #344 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adds the feature requested in #344 while keeping full backwards compatibility

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
