### PR TITLE
fix: DescribeParameter always needs full access

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -432,10 +432,14 @@ data "aws_iam_policy_document" "external_secrets" {
   count = var.create_role && var.attach_external_secrets_policy ? 1 : 0
 
   statement {
+    actions   = ["ssm:DescribeParameters"]
+    resources = ["*"]
+  }
+
+  statement {
     actions = [
       "ssm:GetParameter",
       "ssm:GetParameters",
-      "ssm:DescribeParameters",
     ]
     resources = var.external_secrets_ssm_parameter_arns
   }


### PR DESCRIPTION
## Description
Just like ListSecrets from Secrets Manager the DecribeParameter action is always required to allow full access

## Motivation and Context
With out this the policy will not work when using the external_secrets_ssm_parameter_arns variable

## Breaking Changes
no

## How Has This Been Tested?
- [x] I have tested and validated these changes using my fork as a module
- [x] I have executed `pre-commit run -a` on my pull request

