### PR TITLE
Output IAM Role Assume Role Policy JSON

### DIFF
--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -62,6 +62,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_assume_role_policy_json"></a> [iam\_role\_assume\_role\_policy\_json](#output\_iam\_role\_assume\_role\_policy\_json) | Assume Role Policy JSON document of IAM Role |
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
 | <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
 | <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -14,8 +14,6 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 data "aws_iam_policy_document" "assume_role_with_oidc" {
-  count = var.create_role ? 1 : 0
-
   dynamic "statement" {
     # https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/
     for_each = var.allow_self_assume_role ? [1] : []
@@ -96,7 +94,7 @@ resource "aws_iam_role" "this" {
   force_detach_policies = var.force_detach_policies
   permissions_boundary  = var.role_permissions_boundary_arn
 
-  assume_role_policy = data.aws_iam_policy_document.assume_role_with_oidc[0].json
+  assume_role_policy = data.aws_iam_policy_document.assume_role_with_oidc.json
 
   tags = var.tags
 }

--- a/modules/iam-assumable-role-with-oidc/outputs.tf
+++ b/modules/iam-assumable-role-with-oidc/outputs.tf
@@ -17,3 +17,8 @@ output "iam_role_unique_id" {
   description = "Unique ID of IAM role"
   value       = try(aws_iam_role.this[0].unique_id, "")
 }
+
+output "iam_role_assume_role_policy_json" {
+  description = "Assume Role Policy JSON document of IAM Role"
+  value       = data.aws_iam_policy_document.assume_role_with_oidc.json
+}

--- a/modules/iam-assumable-role-with-saml/README.md
+++ b/modules/iam-assumable-role-with-saml/README.md
@@ -59,6 +59,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_assume_role_policy_json"></a> [iam\_role\_assume\_role\_policy\_json](#output\_iam\_role\_assume\_role\_policy\_json) | Assume Role Policy JSON document of IAM Role |
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
 | <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
 | <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |

--- a/modules/iam-assumable-role-with-saml/outputs.tf
+++ b/modules/iam-assumable-role-with-saml/outputs.tf
@@ -17,3 +17,8 @@ output "iam_role_unique_id" {
   description = "Unique ID of IAM role"
   value       = try(aws_iam_role.this[0].unique_id, "")
 }
+
+output "iam_role_assume_role_policy_json" {
+  description = "Assume Role Policy JSON document of IAM Role"
+  value       = data.aws_iam_policy_document.assume_role_with_saml.json
+}

--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -77,6 +77,7 @@ No modules.
 | <a name="output_iam_instance_profile_name"></a> [iam\_instance\_profile\_name](#output\_iam\_instance\_profile\_name) | Name of IAM instance profile |
 | <a name="output_iam_instance_profile_path"></a> [iam\_instance\_profile\_path](#output\_iam\_instance\_profile\_path) | Path of IAM instance profile |
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_assume_role_policy_json"></a> [iam\_role\_assume\_role\_policy\_json](#output\_iam\_role\_assume\_role\_policy\_json) | Assume Role Policy JSON document of IAM Role |
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
 | <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
 | <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |

--- a/modules/iam-assumable-role/outputs.tf
+++ b/modules/iam-assumable-role/outputs.tf
@@ -47,3 +47,8 @@ output "role_sts_externalid" {
   description = "STS ExternalId condition value to use with a role"
   value       = var.role_sts_externalid
 }
+
+output "iam_role_assume_role_policy_json" {
+  description = "Assume Role Policy JSON document of IAM Role"
+  value       = local.assume_role_policy_json
+}

--- a/modules/iam-eks-role/README.md
+++ b/modules/iam-eks-role/README.md
@@ -125,6 +125,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_assume_role_policy_json"></a> [iam\_role\_assume\_role\_policy\_json](#output\_iam\_role\_assume\_role\_policy\_json) | Assume Role Policy JSON document of IAM Role |
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
 | <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
 | <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |

--- a/modules/iam-eks-role/outputs.tf
+++ b/modules/iam-eks-role/outputs.tf
@@ -17,3 +17,8 @@ output "iam_role_unique_id" {
   description = "Unique ID of IAM role"
   value       = try(aws_iam_role.this[0].unique_id, "")
 }
+
+output "iam_role_assume_role_policy_json" {
+  description = "Assume Role Policy JSON document of IAM Role"
+  value       = data.aws_iam_policy_document.assume_role_with_oidc.json
+}

--- a/modules/iam-github-oidc-role/README.md
+++ b/modules/iam-github-oidc-role/README.md
@@ -102,6 +102,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of IAM role |
+| <a name="output_assume_role_policy_json"></a> [assume\_role\_policy\_json](#output\_assume\_role\_policy\_json) | Assume Role Policy JSON document of IAM Role |
 | <a name="output_name"></a> [name](#output\_name) | Name of IAM role |
 | <a name="output_path"></a> [path](#output\_path) | Path of IAM role |
 | <a name="output_unique_id"></a> [unique\_id](#output\_unique\_id) | Unique ID of IAM role |

--- a/modules/iam-github-oidc-role/main.tf
+++ b/modules/iam-github-oidc-role/main.tf
@@ -14,8 +14,6 @@ locals {
 ################################################################################
 
 data "aws_iam_policy_document" "this" {
-  count = var.create ? 1 : 0
-
   statement {
     sid    = "GithubOidcAuth"
     effect = "Allow"
@@ -58,7 +56,7 @@ resource "aws_iam_role" "this" {
   path        = var.path
   description = var.description
 
-  assume_role_policy    = data.aws_iam_policy_document.this[0].json
+  assume_role_policy    = data.aws_iam_policy_document.this.json
   max_session_duration  = var.max_session_duration
   permissions_boundary  = var.permissions_boundary_arn
   force_detach_policies = var.force_detach_policies

--- a/modules/iam-github-oidc-role/outputs.tf
+++ b/modules/iam-github-oidc-role/outputs.tf
@@ -21,3 +21,8 @@ output "unique_id" {
   description = "Unique ID of IAM role"
   value       = try(aws_iam_role.this[0].unique_id, null)
 }
+
+output "assume_role_policy_json" {
+  description = "Assume Role Policy JSON document of IAM Role"
+  value       = data.aws_iam_policy_document.this.json
+}

--- a/modules/iam-role-for-service-accounts-eks/README.md
+++ b/modules/iam-role-for-service-accounts-eks/README.md
@@ -234,6 +234,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_assume_role_policy_json"></a> [iam\_role\_assume\_role\_policy\_json](#output\_iam\_role\_assume\_role\_policy\_json) | Assume Role Policy JSON document of IAM Role |
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
 | <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
 | <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |

--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -11,8 +11,6 @@ locals {
 }
 
 data "aws_iam_policy_document" "this" {
-  count = var.create_role ? 1 : 0
-
   dynamic "statement" {
     # https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/
     for_each = var.allow_self_assume_role ? [1] : []
@@ -72,7 +70,7 @@ resource "aws_iam_role" "this" {
   path        = var.role_path
   description = var.role_description
 
-  assume_role_policy    = data.aws_iam_policy_document.this[0].json
+  assume_role_policy    = data.aws_iam_policy_document.this.json
   max_session_duration  = var.max_session_duration
   permissions_boundary  = var.role_permissions_boundary_arn
   force_detach_policies = var.force_detach_policies

--- a/modules/iam-role-for-service-accounts-eks/outputs.tf
+++ b/modules/iam-role-for-service-accounts-eks/outputs.tf
@@ -17,3 +17,8 @@ output "iam_role_unique_id" {
   description = "Unique ID of IAM role"
   value       = try(aws_iam_role.this[0].unique_id, "")
 }
+
+output "iam_role_assume_role_policy_json" {
+  description = "Assume Role Policy JSON document of IAM Role"
+  value       = data.aws_iam_policy_document.this.json
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
For each submodule that creates a single IAM Role, I added a Terraform output containing the Assume Role Policy JSON.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will allow users to combine the Assume Role Policy from multiple instances of these Terraform modules, then attach the combined policy to a single role.

My use case is to create an IAM Role that can be used by Kubernetes Pods (EKS IRSA) as well as be assumed by another IAM Role. [This Terraform documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#example-of-merging-source-documents) shows how to merge multiple policies together.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
