### PR TITLE
fix: Remove `"autoscaling:UpdateAutoScalingGroup"` permission from cluster-autoscaler IRSA

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -74,8 +74,7 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
     content {
       actions = [
         "autoscaling:SetDesiredCapacity",
-        "autoscaling:TerminateInstanceInAutoScalingGroup",
-        "autoscaling:UpdateAutoScalingGroup",
+        "autoscaling:TerminateInstanceInAutoScalingGroup"
       ]
 
       resources = ["*"]


### PR DESCRIPTION
## Description
Remove unnecessary action ("autoscaling:UpdateAutoScalingGroup") from the IAM policy of the Cluster Autoscaler.
Update the order of the IAM actions as in the [documentation,](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#full-cluster-autoscaler-features-policy-recommended) so that it is easier for future comparison.

## Motivation and Context
Reduces the IAM permissions to the required actions.

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
