### PR TITLE
feat: Add `elasticloadbalancing:AddTags` permissions to AWS Load Balancer Controller policy required for version 2.4.7+

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -877,6 +877,32 @@ data "aws_iam_policy_document" "load_balancer_controller" {
 
   statement {
     actions = [
+      "elasticloadbalancing:AddTags"
+    ]
+    resources = [
+      "arn:${local.partition}:elasticloadbalancing:*:*:targetgroup/*/*",
+      "arn:${local.partition}:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+      "arn:${local.partition}:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "elasticloadbalancing:CreateAction"
+      values = [
+        "CreateTargetGroup",
+        "CreateLoadBalancer",
+      ]
+    }
+
+    condition {
+      test     = "Null"
+      variable = "aws:RequestTag/elbv2.k8s.aws/cluster"
+      values   = ["false"]
+    }
+  }
+
+  statement {
+    actions = [
       "elasticloadbalancing:RegisterTargets",
       "elasticloadbalancing:DeregisterTargets",
     ]


### PR DESCRIPTION
Add elasticloadbalancing:AddTags permissions to AWS Load Balancer Controller policy required for version 2.4.7

## Description
Version 2.4.7 of AWS ALB controller has been released with an updated IAM permission https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.4.7.

The permission required is elasticloadbalancing:AddTags. See change here https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3046/files.


## Motivation and Context
Updates AWS ALB Controller policy to match latest on version 2.4.7.


## Breaking Changes
None.

## How Has This Been Tested?
I have applied the IAM policy to AWS using Terraform, then copied the resulting JSON file from AWS, and did a file side-by-side comparison with the official IAM policy JSON confirming it matches.

Fixes #339 
