### PR TITLE
feat(iam-assumable-roles-with-saml): Allow set max_session_duration per role

### DIFF
--- a/examples/iam-assumable-roles-with-saml/README.md
+++ b/examples/iam-assumable-roles-with-saml/README.md
@@ -35,6 +35,7 @@ Run `terraform destroy` when you don't need these resources.
 | <a name="module_iam_assumable_roles_with_saml"></a> [iam\_assumable\_roles\_with\_saml](#module\_iam\_assumable\_roles\_with\_saml) | ../../modules/iam-assumable-roles-with-saml | n/a |
 | <a name="module_iam_assumable_roles_with_saml_custom"></a> [iam\_assumable\_roles\_with\_saml\_custom](#module\_iam\_assumable\_roles\_with\_saml\_custom) | ../../modules/iam-assumable-roles-with-saml | n/a |
 | <a name="module_iam_assumable_roles_with_saml_second_provider"></a> [iam\_assumable\_roles\_with\_saml\_second\_provider](#module\_iam\_assumable\_roles\_with\_saml\_second\_provider) | ../../modules/iam-assumable-roles-with-saml | n/a |
+| <a name="module_iam_assumable_roles_with_saml_with_dedicated_max_session_duration"></a> [iam\_assumable\_roles\_with\_saml\_with\_dedicated\_max\_session\_duration](#module\_iam\_assumable\_roles\_with\_saml\_with\_dedicated\_max\_session\_duration) | ../../modules/iam-assumable-roles-with-saml | n/a |
 | <a name="module_iam_assumable_roles_with_saml_with_self_assume"></a> [iam\_assumable\_roles\_with\_saml\_with\_self\_assume](#module\_iam\_assumable\_roles\_with\_saml\_with\_self\_assume) | ../../modules/iam-assumable-roles-with-saml | n/a |
 
 ## Resources

--- a/examples/iam-assumable-roles-with-saml/main.tf
+++ b/examples/iam-assumable-roles-with-saml/main.tf
@@ -77,3 +77,24 @@ module "iam_assumable_roles_with_saml_with_self_assume" {
 
   provider_id = aws_iam_saml_provider.idp_saml.id
 }
+
+###########################################################################
+# IAM assumable roles with SAML with dedicated max session duration per role
+###########################################################################
+module "iam_assumable_roles_with_saml_with_dedicated_max_session_duration" {
+  source = "../../modules/iam-assumable-roles-with-saml"
+
+  create_admin_role          = true
+  admin_role_name            = "Admin-Role-Custom-Max-Session-Duration"
+  admin_max_session_duration = 7200
+
+  create_poweruser_role          = true
+  poweruser_role_name            = "Poweruser-Role-Custom-Max-Session-Duration"
+  poweruser_max_session_duration = 14400
+
+  create_readonly_role          = true
+  readonly_role_name            = "Readonly-Role-Custom-Max-Session-Duration"
+  readonly_max_session_duration = 43200
+
+  provider_id = aws_iam_saml_provider.idp_saml.id
+}

--- a/modules/iam-assumable-roles-with-saml/README.md
+++ b/modules/iam-assumable-roles-with-saml/README.md
@@ -42,6 +42,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_admin_max_session_duration"></a> [admin\_max\_session\_duration](#input\_admin\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 (admin role). If not set, max\_session\_duration will be used. | `number` | `null` | no |
 | <a name="input_admin_role_name"></a> [admin\_role\_name](#input\_admin\_role\_name) | IAM role with admin access | `string` | `"admin"` | no |
 | <a name="input_admin_role_path"></a> [admin\_role\_path](#input\_admin\_role\_path) | Path of admin IAM role | `string` | `"/"` | no |
 | <a name="input_admin_role_permissions_boundary_arn"></a> [admin\_role\_permissions\_boundary\_arn](#input\_admin\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for admin role | `string` | `""` | no |
@@ -54,6 +55,7 @@ No modules.
 | <a name="input_create_readonly_role"></a> [create\_readonly\_role](#input\_create\_readonly\_role) | Whether to create readonly role | `bool` | `false` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `false` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
+| <a name="input_poweruser_max_session_duration"></a> [poweruser\_max\_session\_duration](#input\_poweruser\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 (poweruser role). If not set, max\_session\_duration will be used. | `number` | `null` | no |
 | <a name="input_poweruser_role_name"></a> [poweruser\_role\_name](#input\_poweruser\_role\_name) | IAM role with poweruser access | `string` | `"poweruser"` | no |
 | <a name="input_poweruser_role_path"></a> [poweruser\_role\_path](#input\_poweruser\_role\_path) | Path of poweruser IAM role | `string` | `"/"` | no |
 | <a name="input_poweruser_role_permissions_boundary_arn"></a> [poweruser\_role\_permissions\_boundary\_arn](#input\_poweruser\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for poweruser role | `string` | `""` | no |
@@ -61,6 +63,7 @@ No modules.
 | <a name="input_poweruser_role_tags"></a> [poweruser\_role\_tags](#input\_poweruser\_role\_tags) | A map of tags to add to poweruser role resource. | `map(string)` | `{}` | no |
 | <a name="input_provider_id"></a> [provider\_id](#input\_provider\_id) | ID of the SAML Provider. Use provider\_ids to specify several IDs. | `string` | `""` | no |
 | <a name="input_provider_ids"></a> [provider\_ids](#input\_provider\_ids) | List of SAML Provider IDs | `list(string)` | `[]` | no |
+| <a name="input_readonly_max_session_duration"></a> [readonly\_max\_session\_duration](#input\_readonly\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 (readonly role). If not set, max\_session\_duration will be used. | `number` | `null` | no |
 | <a name="input_readonly_role_name"></a> [readonly\_role\_name](#input\_readonly\_role\_name) | IAM role with readonly access | `string` | `"readonly"` | no |
 | <a name="input_readonly_role_path"></a> [readonly\_role\_path](#input\_readonly\_role\_path) | Path of readonly IAM role | `string` | `"/"` | no |
 | <a name="input_readonly_role_permissions_boundary_arn"></a> [readonly\_role\_permissions\_boundary\_arn](#input\_readonly\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for readonly role | `string` | `""` | no |

--- a/modules/iam-assumable-roles-with-saml/main.tf
+++ b/modules/iam-assumable-roles-with-saml/main.tf
@@ -2,9 +2,12 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 locals {
-  account_id  = data.aws_caller_identity.current.account_id
-  identifiers = compact(distinct(concat(var.provider_ids, [var.provider_id])))
-  partition   = data.aws_partition.current.partition
+  account_id                     = data.aws_caller_identity.current.account_id
+  identifiers                    = compact(distinct(concat(var.provider_ids, [var.provider_id])))
+  partition                      = data.aws_partition.current.partition
+  admin_max_session_duration     = var.admin_max_session_duration == null ? var.max_session_duration : var.admin_max_session_duration
+  poweruser_max_session_duration = var.poweruser_max_session_duration == null ? var.max_session_duration : var.poweruser_max_session_duration
+  readonly_max_session_duration  = var.readonly_max_session_duration == null ? var.max_session_duration : var.readonly_max_session_duration
 }
 
 data "aws_iam_policy_document" "assume_role_with_saml" {
@@ -99,7 +102,7 @@ resource "aws_iam_role" "admin" {
 
   name                 = var.admin_role_name
   path                 = var.admin_role_path
-  max_session_duration = var.max_session_duration
+  max_session_duration = local.admin_max_session_duration
 
   force_detach_policies = var.force_detach_policies
   permissions_boundary  = var.admin_role_permissions_boundary_arn
@@ -122,7 +125,7 @@ resource "aws_iam_role" "poweruser" {
 
   name                 = var.poweruser_role_name
   path                 = var.poweruser_role_path
-  max_session_duration = var.max_session_duration
+  max_session_duration = local.poweruser_max_session_duration
 
   force_detach_policies = var.force_detach_policies
   permissions_boundary  = var.poweruser_role_permissions_boundary_arn
@@ -145,7 +148,7 @@ resource "aws_iam_role" "readonly" {
 
   name                 = var.readonly_role_name
   path                 = var.readonly_role_path
-  max_session_duration = var.max_session_duration
+  max_session_duration = local.readonly_max_session_duration
 
   force_detach_policies = var.force_detach_policies
   permissions_boundary  = var.readonly_role_permissions_boundary_arn

--- a/modules/iam-assumable-roles-with-saml/variables.tf
+++ b/modules/iam-assumable-roles-with-saml/variables.tf
@@ -59,6 +59,12 @@ variable "admin_role_tags" {
   default     = {}
 }
 
+variable "admin_max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200 (admin role). If not set, max_session_duration will be used."
+  type        = number
+  default     = null
+}
+
 # Poweruser
 variable "create_poweruser_role" {
   description = "Whether to create poweruser role"
@@ -96,6 +102,12 @@ variable "poweruser_role_tags" {
   default     = {}
 }
 
+variable "poweruser_max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200 (poweruser role). If not set, max_session_duration will be used."
+  type        = number
+  default     = null
+}
+
 # Readonly
 variable "create_readonly_role" {
   description = "Whether to create readonly role"
@@ -131,6 +143,12 @@ variable "readonly_role_tags" {
   description = "A map of tags to add to readonly role resource."
   type        = map(string)
   default     = {}
+}
+
+variable "readonly_max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200 (readonly role). If not set, max_session_duration will be used."
+  type        = number
+  default     = null
 }
 
 variable "max_session_duration" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Introduce 3 new variables to control the `max_session_duration` per role (admin, poweruser, readonly)
- Update docs accordingly  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is to close #362 

## Breaking Changes
<!-- Does this break backward compatibility with the current major version? -->
<!-- If so, please explain why it is necessary. -->
None 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, and then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
