### PR TITLE
feat(iam-eks-role): Add variable to allow change of IAM assume role condition test operator

### DIFF
--- a/examples/iam-eks-role/README.md
+++ b/examples/iam-eks-role/README.md
@@ -36,6 +36,7 @@ Run `terraform destroy` when you don't need these resources.
 |------|--------|---------|
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 18.0 |
 | <a name="module_iam_eks_role"></a> [iam\_eks\_role](#module\_iam\_eks\_role) | ../../modules/iam-eks-role | n/a |
+| <a name="module_iam_eks_role_with_assume_wildcard"></a> [iam\_eks\_role\_with\_assume\_wildcard](#module\_iam\_eks\_role\_with\_assume\_wildcard) | ../../modules/iam-eks-role | n/a |
 | <a name="module_iam_eks_role_with_self_assume"></a> [iam\_eks\_role\_with\_self\_assume](#module\_iam\_eks\_role\_with\_self\_assume) | ../../modules/iam-eks-role | n/a |
 
 ## Resources

--- a/examples/iam-eks-role/main.tf
+++ b/examples/iam-eks-role/main.tf
@@ -40,6 +40,27 @@ module "iam_eks_role_with_self_assume" {
   }
 }
 
+#############################################
+# IAM EKS role with wildcard assume condition
+#############################################
+module "iam_eks_role_with_assume_wildcard" {
+  source    = "../../modules/iam-eks-role"
+  role_name = "my-app-assume-wildcard"
+
+  cluster_service_accounts = {
+    (random_pet.this.id) = ["default:my-app-prefix-*"]
+  }
+  assume_role_condition_test = "StringLike"
+
+  tags = {
+    Name = "my-app-assume-wildcard"
+  }
+
+  role_policy_arns = {
+    AmazonEKS_CNI_Policy = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  }
+}
+
 ##################
 # Extra resources
 ##################

--- a/modules/iam-eks-role/README.md
+++ b/modules/iam-eks-role/README.md
@@ -108,6 +108,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_self_assume_role"></a> [allow\_self\_assume\_role](#input\_allow\_self\_assume\_role) | Determines whether to allow the role to be [assume itself](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/) | `bool` | `false` | no |
+| <a name="input_assume_role_condition_test"></a> [assume\_role\_condition\_test](#input\_assume\_role\_condition\_test) | Name of the [IAM condition operator](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html) to evaluate when assuming the role | `string` | `"StringEquals"` | no |
 | <a name="input_cluster_service_accounts"></a> [cluster\_service\_accounts](#input\_cluster\_service\_accounts) | EKS cluster and k8s ServiceAccount pairs. Each EKS cluster can have multiple k8s ServiceAccount. See README for details | `map(list(string))` | `{}` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Whether to create a role | `bool` | `true` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `false` | no |

--- a/modules/iam-eks-role/main.tf
+++ b/modules/iam-eks-role/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       }
 
       condition {
-        test     = "StringEquals"
+        test     = var.assume_role_condition_test
         variable = "${replace(data.aws_eks_cluster.main[statement.key].identity[0].oidc[0].issuer, "https://", "")}:sub"
         values   = [for s in statement.value : "system:serviceaccount:${s}"]
       }

--- a/modules/iam-eks-role/variables.tf
+++ b/modules/iam-eks-role/variables.tf
@@ -69,3 +69,9 @@ variable "allow_self_assume_role" {
   type        = bool
   default     = false
 }
+
+variable "assume_role_condition_test" {
+  description = "Name of the [IAM condition operator](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html) to evaluate when assuming the role"
+  type        = string
+  default     = "StringEquals"
+}


### PR DESCRIPTION
## Description
Fixes #366 

## Motivation and Context
Sometimes we need to assign a single role to multiple service accounts or service account names are created dynamically so we might not know them in advance. It allows us to override the default `StringEquals` condition with `StringLike` and use wildcards to allow multiple service accounts to assume the same role.

## Breaking Changes
No, the new variable defaults to previously hard-coded value. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request