### PR TITLE
feat: Add `name_prefix` to iam-policy and iam-read-only-policy modules

### DIFF
--- a/examples/iam-policy/main.tf
+++ b/examples/iam-policy/main.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 module "iam_policy" {
   source = "../../modules/iam-policy"
 
-  name        = "example"
+  name_prefix = "example-"
   path        = "/"
   description = "My example policy"
 

--- a/modules/iam-policy/README.md
+++ b/modules/iam-policy/README.md
@@ -32,7 +32,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | Whether to create the IAM policy | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the policy | `string` | `"IAM Policy"` | no |
-| <a name="input_name"></a> [name](#input\_name) | The name of the policy | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the policy | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | IAM policy name prefix | `string` | `null` | no |
 | <a name="input_path"></a> [path](#input\_path) | The path of the policy in IAM | `string` | `"/"` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | The path of the policy in IAM (tpl file) | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |

--- a/modules/iam-policy/main.tf
+++ b/modules/iam-policy/main.tf
@@ -2,6 +2,7 @@ resource "aws_iam_policy" "policy" {
   count = var.create_policy ? 1 : 0
 
   name        = var.name
+  name_prefix = var.name_prefix
   path        = var.path
   description = var.description
 

--- a/modules/iam-policy/variables.tf
+++ b/modules/iam-policy/variables.tf
@@ -7,7 +7,13 @@ variable "create_policy" {
 variable "name" {
   description = "The name of the policy"
   type        = string
-  default     = ""
+  default     = null
+}
+
+variable "name_prefix" {
+  description = "IAM policy name prefix"
+  type        = string
+  default     = null
 }
 
 variable "path" {

--- a/modules/iam-read-only-policy/README.md
+++ b/modules/iam-read-only-policy/README.md
@@ -43,7 +43,8 @@ No modules.
 | <a name="input_allowed_services"></a> [allowed\_services](#input\_allowed\_services) | List of services to allow Get/List/Describe/View options. Service name should be the same as corresponding service IAM prefix. See what it is for each service here https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html | `list(string)` | n/a | yes |
 | <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | Whether to create the IAM policy | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the policy | `string` | `"IAM Policy"` | no |
-| <a name="input_name"></a> [name](#input\_name) | The name of the policy | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the policy | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | IAM policy name prefix | `string` | `null` | no |
 | <a name="input_path"></a> [path](#input\_path) | The path of the policy in IAM | `string` | `"/"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | <a name="input_web_console_services"></a> [web\_console\_services](#input\_web\_console\_services) | List of web console services to allow | `list(string)` | <pre>[<br>  "resource-groups",<br>  "tag",<br>  "health",<br>  "ce"<br>]</pre> | no |

--- a/modules/iam-read-only-policy/main.tf
+++ b/modules/iam-read-only-policy/main.tf
@@ -2,6 +2,7 @@ resource "aws_iam_policy" "policy" {
   count = var.create_policy ? 1 : 0
 
   name        = var.name
+  name_prefix = var.name_prefix
   path        = var.path
   description = var.description
 

--- a/modules/iam-read-only-policy/variables.tf
+++ b/modules/iam-read-only-policy/variables.tf
@@ -7,7 +7,13 @@ variable "create_policy" {
 variable "name" {
   description = "The name of the policy"
   type        = string
-  default     = ""
+  default     = null
+}
+
+variable "name_prefix" {
+  description = "IAM policy name prefix"
+  type        = string
+  default     = null
 }
 
 variable "path" {


### PR DESCRIPTION
## Description
Fixes https://github.com/terraform-aws-modules/terraform-aws-iam/issues/365

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-iam/issues/365

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
