### PR TITLE
feat: Add support for other remote PGP keys in iam-user module

### DIFF
--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -2,16 +2,21 @@
 
 Creates IAM user, IAM login profile, IAM access key and uploads IAM SSH user public key. All of these are optional resources.
 
-## Notes for keybase users
-
 **If possible, always use PGP encryption to prevent Terraform from keeping unencrypted password and access secret key in state file.**
 
-### Keybase pre-requisits
+## PGP encryption
 
+To encrypt passwords and access keys, provide a PGP key to `pgp_key` variable in one of three formats. 
+1. Keybase hosted public key: `keybase:username`
+2. Generic HTTP hosted public key: `http://example.com/my_pgp_key.pub`
+3. Explicit public key string: `-----BEGIN PGP PUBLIC KEY BLOCK----- .....`
+
+### Keybase
+
+#### Prerequsites
 When `pgp_key` is specified as `keybase:username`, make sure that that user has already uploaded public key to keybase.io. For example, user with username `test` has done it properly and you can [verify it here](https://keybase.io/test/pgp_keys.asc).
 
-### How to decrypt user's encrypted password and secret key
-
+#### How to decrypt user's encrypted password and secret key
 This module outputs commands and PGP messages which can be decrypted either using [keybase.io web-site](https://keybase.io/decrypt) or using command line to get user's password and user's secret key:
 - `keybase_password_decrypt_command`
 - `keybase_secret_key_decrypt_command`
@@ -19,6 +24,16 @@ This module outputs commands and PGP messages which can be decrypted either usin
 - `keybase_password_pgp_message`
 - `keybase_secret_key_pgp_message`
 - `keybase_ses_smtp_password_v4_pgp_message`
+
+
+### PGP key over Generic HTTP or as explicit string
+When `pgp_key` is a string starting with `http` or `https`, the module will attempt to download the public key over HTTP. Ensure that the key is available over the network, and provide any necessary request headers via `pgp_key_request_headers`.
+
+Note, when using the Generic HTTP URL or as explicit string, the Keybase decryption commands may not work. Instead, use the encrypted outputs directly in any decryption tool:
+- `iam_user_login_profile_encrypted_password`
+- `iam_access_key_encrypted_secret`
+- `iam_access_key_encrypted_ses_smtp_password_v4`
+
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -42,12 +42,14 @@ Note, when using the Generic HTTP URL or as explicit string, the Keybase decrypt
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | >= 3.0 |
 
 ## Modules
 
@@ -62,6 +64,7 @@ No modules.
 | [aws_iam_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_login_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_login_profile) | resource |
 | [aws_iam_user_ssh_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_ssh_key) | resource |
+| [http_http.pgp_key](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 
 ## Inputs
 
@@ -77,7 +80,8 @@ No modules.
 | <a name="input_password_reset_required"></a> [password\_reset\_required](#input\_password\_reset\_required) | Whether the user should be forced to reset the generated password on first login. | `bool` | `true` | no |
 | <a name="input_path"></a> [path](#input\_path) | Desired path for the IAM user | `string` | `"/"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the user. | `string` | `""` | no |
-| <a name="input_pgp_key"></a> [pgp\_key](#input\_pgp\_key) | Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Used to encrypt password and access key. | `string` | `""` | no |
+| <a name="input_pgp_key"></a> [pgp\_key](#input\_pgp\_key) | Either a base-64 encoded PGP public key, a keybase username in the form `keybase:username`, or an HTTP/HTTPS url where the key is hosted. Used to encrypt password and access key. | `string` | `""` | no |
+| <a name="input_pgp_key_request_headers"></a> [pgp\_key\_request\_headers](#input\_pgp\_key\_request\_headers) | Additional headers if fetching the key over HTTP. | `map(string)` | `{}` | no |
 | <a name="input_ssh_key_encoding"></a> [ssh\_key\_encoding](#input\_ssh\_key\_encoding) | Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH. To retrieve the public key in PEM format, use PEM | `string` | `"SSH"` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The SSH public key. The public key must be encoded in ssh-rsa format or PEM format | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |

--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -19,7 +19,7 @@ resource "aws_iam_user_login_profile" "this" {
   count = var.create_user && var.create_iam_user_login_profile ? 1 : 0
 
   user                    = aws_iam_user.this[0].name
-  pgp_key                 = startswith(var.pgp_key, "http") ? data.http.pgp_key.response_body : var.pgp_key
+  pgp_key                 = startswith(var.pgp_key, "http") ? data.http.pgp_key[0].response_body : var.pgp_key
   password_length         = var.password_length
   password_reset_required = var.password_reset_required
 

--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -1,3 +1,9 @@
+data "http" "pgp_key" {
+  count = startswith(var.pgp_key, "http") ? 1 : 0
+  url   = var.pgp_key
+  request_headers = var.pgp_key_request_headers
+}
+
 resource "aws_iam_user" "this" {
   count = var.create_user ? 1 : 0
 
@@ -13,7 +19,7 @@ resource "aws_iam_user_login_profile" "this" {
   count = var.create_user && var.create_iam_user_login_profile ? 1 : 0
 
   user                    = aws_iam_user.this[0].name
-  pgp_key                 = var.pgp_key
+  pgp_key                 = startswith(var.pgp_key, "http") ? data.http.pgp_key.response_body : var.pgp_key
   password_length         = var.password_length
   password_reset_required = var.password_reset_required
 

--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -1,6 +1,6 @@
 data "http" "pgp_key" {
-  count = startswith(var.pgp_key, "http") ? 1 : 0
-  url   = var.pgp_key
+  count           = startswith(var.pgp_key, "http") ? 1 : 0
+  url             = var.pgp_key
   request_headers = var.pgp_key_request_headers
 }
 

--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -20,7 +20,7 @@ resource "aws_iam_user_login_profile" "this" {
   count = var.create_user && var.create_iam_user_login_profile ? 1 : 0
 
   user                    = aws_iam_user.this[0].name
-  pgp_key                 = try(data.http.pgp_key[0].response_body, var.pgp_key)
+  pgp_key                 = try(base64encode(data.http.pgp_key[0].response_body), var.pgp_key)
   password_length         = var.password_length
   password_reset_required = var.password_reset_required
 

--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -1,5 +1,6 @@
 data "http" "pgp_key" {
-  count           = startswith(var.pgp_key, "http") ? 1 : 0
+  count = startswith(var.pgp_key, "http") ? 1 : 0
+
   url             = var.pgp_key
   request_headers = var.pgp_key_request_headers
 }
@@ -19,7 +20,7 @@ resource "aws_iam_user_login_profile" "this" {
   count = var.create_user && var.create_iam_user_login_profile ? 1 : 0
 
   user                    = aws_iam_user.this[0].name
-  pgp_key                 = startswith(var.pgp_key, "http") ? data.http.pgp_key[0].response_body : var.pgp_key
+  pgp_key                 = try(data.http.pgp_key[0].response_body, var.pgp_key)
   password_length         = var.password_length
   password_reset_required = var.password_reset_required
 

--- a/modules/iam-user/variables.tf
+++ b/modules/iam-user/variables.tf
@@ -34,9 +34,15 @@ variable "force_destroy" {
 }
 
 variable "pgp_key" {
-  description = "Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Used to encrypt password and access key."
+  description = "Either a base-64 encoded PGP public key, a keybase username in the form `keybase:username`, or an HTTP/HTTPS url where the key is hosted. Used to encrypt password and access key."
   type        = string
   default     = ""
+}
+
+variable "pgp_key_request_headers" {
+  description = "Additional headers if fetching the key over HTTP."
+  type        = map(string)
+  default     = {}
 }
 
 variable "iam_access_key_status" {

--- a/modules/iam-user/versions.tf
+++ b/modules/iam-user/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0"
     }
+    http = {
+      source = "hashicorp/http"
+      version = ">= 3.0"
+    }
   }
 }

--- a/modules/iam-user/versions.tf
+++ b/modules/iam-user/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 4.0"
     }
     http = {
-      source = "hashicorp/http"
+      source  = "hashicorp/http"
       version = ">= 3.0"
     }
   }


### PR DESCRIPTION
## Description
Use http datasource to retrieve keys from non-keybase urls (like keys.openpgp.org)

## Motivation and Context
Allows alternatives to keybase, without needing to hardcode pgp keys

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
