### PR TITLE
feat: Add support for condition role_session_name when assuming a role

### DIFF
--- a/modules/iam-assumable-role/README.md
+++ b/modules/iam-assumable-role/README.md
@@ -62,6 +62,8 @@ No modules.
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role | `string` | `"/"` | no |
 | <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | <a name="input_role_requires_mfa"></a> [role\_requires\_mfa](#input\_role\_requires\_mfa) | Whether role requires MFA | `bool` | `true` | no |
+| <a name="input_role_requires_session_name"></a> [role\_requires\_session\_name](#input\_role\_requires\_session\_name) | Determines if the role-session-name variable is needed when assuming a role(https://aws.amazon.com/blogs/security/easily-control-naming-individual-iam-role-sessions/) | `bool` | `false` | no |
+| <a name="input_role_session_name"></a> [role\_session\_name](#input\_role\_session\_name) | role\_session\_name for roles which require this parameter when being assumed. By default, you need to set your own username as role\_session\_name | `list(string)` | <pre>[<br>  "${aws:username}"<br>]</pre> | no |
 | <a name="input_role_sts_externalid"></a> [role\_sts\_externalid](#input\_role\_sts\_externalid) | STS ExternalId condition values to use with a role (when MFA is not required) | `any` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
 | <a name="input_trusted_role_actions"></a> [trusted\_role\_actions](#input\_trusted\_role\_actions) | Actions of STS | `list(string)` | <pre>[<br>  "sts:AssumeRole"<br>]</pre> | no |

--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -117,6 +117,15 @@ data "aws_iam_policy_document" "assume_role_with_mfa" {
         values   = local.role_sts_externalid
       }
     }
+
+    dynamic "condition" {
+      for_each = var.role_requires_session_name ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "sts:RoleSessionName"
+        values   = var.role_session_name
+      }
+    }
   }
 }
 

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -154,3 +154,15 @@ variable "allow_self_assume_role" {
   type        = bool
   default     = false
 }
+
+variable "role_requires_session_name" {
+  description = "Determines if the role-session-name variable is needed when assuming a role(https://aws.amazon.com/blogs/security/easily-control-naming-individual-iam-role-sessions/)"
+  type        = bool
+  default     = false
+}
+
+variable "role_session_name" {
+  description = "role_session_name for roles which require this parameter when being assumed. By default, you need to set your own username as role_session_name"
+  type        = list(string)
+  default     = ["$${aws:username}"]
+}


### PR DESCRIPTION
## Description
Trying to set as a requirement the parameter role_session_name when a user assumes a role I found that someone created an [issue](https://github.com/terraform-aws-modules/terraform-aws-iam/issues/359) but it has been closed. I need this feature, so I implemented this MR.
I hope this will be useful for the community.


## Motivation and Context
The purpose of this condition is to make easier track the user actions when viewing AWS CloudTrail logs, as described in this [AWS post](https://aws.amazon.com/blogs/security/easily-control-naming-individual-iam-role-sessions/)


## Breaking Changes
Nothing

## How Has This Been Tested?
I tested this locally in my environment and it works great. To test this, you need to set your username as role_session_name when assuming the role. If you don´t set your username as this variable, the assumerole will fail.
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
