### PR TITLE
feat(iam-assumable-role-with-oidc): Add assume role policies

### DIFF
--- a/examples/iam-assumable-role-with-oidc/main.tf
+++ b/examples/iam-assumable-role-with-oidc/main.tf
@@ -37,14 +37,14 @@ module "iam_assumable_role_self_assume" {
 
   role_name = "role-with-oidc-self-assume"
 
-  assume_role_source_policies = jsonencode({
+  assume_role_source_policies = [jsonencode({
     Version = "2012-10-17"
     Statement = [{
       Effect    = "Allow"
       Action    = ["sts:AssumeRole"]
       Principal = { AWS = ["arn:aws:iam::012345678901:role/Admin"] }
     }]
-  })
+  })]
 
   tags = {
     Role = "role-with-oidc-self-assume"
@@ -59,4 +59,3 @@ module "iam_assumable_role_self_assume" {
 
   oidc_fully_qualified_subjects = ["system:serviceaccount:default:sa1", "system:serviceaccount:default:sa2"]
 }
-

--- a/examples/iam-assumable-role-with-oidc/main.tf
+++ b/examples/iam-assumable-role-with-oidc/main.tf
@@ -26,9 +26,9 @@ module "iam_assumable_role_admin" {
   oidc_fully_qualified_subjects = ["system:serviceaccount:default:sa1", "system:serviceaccount:default:sa2"]
 }
 
-#####################################
-# IAM assumable role with self assume
-#####################################
+################################################################
+# IAM assumable role with self assume and assume from Admin role
+################################################################
 module "iam_assumable_role_self_assume" {
   source = "../../modules/iam-assumable-role-with-oidc"
 
@@ -36,6 +36,15 @@ module "iam_assumable_role_self_assume" {
   allow_self_assume_role = true
 
   role_name = "role-with-oidc-self-assume"
+
+  assume_role_source_policies = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = ["sts:AssumeRole"]
+      Principal = { AWS = ["arn:aws:iam::012345678901:role/Admin"] }
+    }]
+  })
 
   tags = {
     Role = "role-with-oidc-self-assume"
@@ -50,3 +59,4 @@ module "iam_assumable_role_self_assume" {
 
   oidc_fully_qualified_subjects = ["system:serviceaccount:default:sa1", "system:serviceaccount:default:sa2"]
 }
+

--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -39,6 +39,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_self_assume_role"></a> [allow\_self\_assume\_role](#input\_allow\_self\_assume\_role) | Determines whether to allow the role to be [assume itself](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/) | `bool` | `false` | no |
+| <a name="input_assume_role_source_policies"></a> [assume\_role\_source\_policies](#input\_assume\_role\_source\_policies) | JSON blobs to use as source\_policy\_documents for the assume role policy | `list(string)` | `[]` | no |
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | The AWS account ID where the OIDC provider lives, leave empty to use the account for the AWS provider | `string` | `""` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Whether to create a role | `bool` | `false` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `false` | no |

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -16,6 +16,8 @@ data "aws_partition" "current" {}
 data "aws_iam_policy_document" "assume_role_with_oidc" {
   count = var.create_role ? 1 : 0
 
+  source_policy_documents = var.assume_role_source_policies
+
   dynamic "statement" {
     # https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/
     for_each = var.allow_self_assume_role ? [1] : []

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -105,3 +105,9 @@ variable "allow_self_assume_role" {
   type        = bool
   default     = false
 }
+
+variable "assume_role_source_policies" {
+  description = "JSON blobs to use as source_policy_documents for the assume role policy"
+  type        = list(string)
+  default     = []
+}

--- a/wrappers/iam-assumable-role-with-oidc/main.tf
+++ b/wrappers/iam-assumable-role-with-oidc/main.tf
@@ -21,4 +21,5 @@ module "wrapper" {
   oidc_fully_qualified_audiences = try(each.value.oidc_fully_qualified_audiences, var.defaults.oidc_fully_qualified_audiences, [])
   force_detach_policies          = try(each.value.force_detach_policies, var.defaults.force_detach_policies, false)
   allow_self_assume_role         = try(each.value.allow_self_assume_role, var.defaults.allow_self_assume_role, false)
+  assume_role_source_policies    = try(each.value.assume_role_source_policies, var.defaults.assume_role_source_policies, [])
 }


### PR DESCRIPTION
## Description
Enable users to set `source_policy_documents` on the assume role policy.


## Motivation and Context
Fixes #361.

As I'm creating IAM OIDC roles, I need to be able to test them by assuming them. Using `source_policies` is the most generic implem, so other use cases might also benefit this.

## Breaking Changes
None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
