### PR TITLE
feat: Explicitly grant `elasticloadbalancing:AddTags` permission 

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -795,6 +795,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
 
   statement {
     actions = [
+      "elasticloadbalancing:AddTags",
       "elasticloadbalancing:CreateLoadBalancer",
       "elasticloadbalancing:CreateTargetGroup",
     ]
@@ -809,6 +810,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
 
   statement {
     actions = [
+      "elasticloadbalancing:AddTags",
       "elasticloadbalancing:CreateListener",
       "elasticloadbalancing:DeleteListener",
       "elasticloadbalancing:CreateRule",


### PR DESCRIPTION
As per AWS customer notifications, the `elasticloadbalancing:AddTags` permission will be required soon for anyone calling `CreateLoadBalancer` with tags:

> On June 1, 2023, we will be adding an additional layer of security to ELB ‘Create*' API calls where API callers must have explicit access to add tags in their Identity and Access Management (IAM) policy [1]. Currently, access to attach tags was implicitly granted with access to 'Create*' APIs. … We will be allowing 'Create*' API calls with the current policy to be accepted until August 30, 2023. After this date, the 'Create*' API call will fail and return an error if the the attribute is specified and permission is not granted.