### PR TITLE
feat(iam-assumable-role-with-oidc): Add condition for role session name

### DIFF
--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -55,6 +55,8 @@ No modules.
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role | `string` | `"/"` | no |
 | <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of ARNs of IAM policies to attach to IAM role | `list(string)` | `[]` | no |
+| <a name="input_role_requires_session_name"></a> [role\_requires\_session\_name](#input\_role\_requires\_session\_name) | Determines if the role-session-name variable is needed when assuming a role(https://aws.amazon.com/blogs/security/easily-control-naming-individual-iam-role-sessions/) | `bool` | `false` | no |
+| <a name="input_role_session_name"></a> [role\_session\_name](#input\_role\_session\_name) | role\_session\_name for roles which require this parameter when being assumed. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -80,6 +80,16 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
           values   = var.oidc_fully_qualified_audiences
         }
       }
+
+      dynamic "condition" {
+        for_each = var.role_requires_session_name ? [1] : []
+      
+        content {
+          test     = "StringEquals"
+          variable = "sts:RoleSessionName"
+          values   = var.role_session_name
+        }
+      }
     }
   }
 }

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
 
       dynamic "condition" {
         for_each = var.role_requires_session_name ? [1] : []
-      
+
         content {
           test     = "StringEquals"
           variable = "sts:RoleSessionName"

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -105,3 +105,15 @@ variable "allow_self_assume_role" {
   type        = bool
   default     = false
 }
+
+variable "role_requires_session_name" {
+  description = "Determines if the role-session-name variable is needed when assuming a role(https://aws.amazon.com/blogs/security/easily-control-naming-individual-iam-role-sessions/)"
+  type        = bool
+  default     = false
+}
+
+variable "role_session_name" {
+  description = "role_session_name for roles which require this parameter when being assumed."
+  type        = list(string)
+  default     = [""]
+}


### PR DESCRIPTION
## Description
Adding the ability for role session name condition on assumable role with oidc module.
Used as a dependency the PR that added this functionality to assumable role - #379.

## Motivation and Context
I am using this module and this condition is missing for my use case.

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
