### PR TITLE
:wrench: Fix local role_name_condition to avoid null result

### DIFF
--- a/examples/iam-role-for-service-accounts-eks/main.tf
+++ b/examples/iam-role-for-service-accounts-eks/main.tf
@@ -85,6 +85,24 @@ module "cert_manager_irsa_role" {
   tags = local.tags
 }
 
+module "cert_manager_irsa_role_self_assume" {
+  source = "../../modules/iam-role-for-service-accounts-eks"
+
+  role_name                     = "cert-manager"
+  attach_cert_manager_policy    = true
+  cert_manager_hosted_zone_arns = ["arn:aws:route53:::hostedzone/IClearlyMadeThisUp"]
+  allow_self_assume_role        = true
+
+  oidc_providers = {
+    ex = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:cert-manager"]
+    }
+  }
+
+  tags = local.tags
+}
+
 module "cluster_autoscaler_irsa_role" {
   source = "../../modules/iam-role-for-service-accounts-eks"
 

--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -7,7 +7,7 @@ locals {
   partition           = data.aws_partition.current.partition
   dns_suffix          = data.aws_partition.current.dns_suffix
   region              = data.aws_region.current.name
-  role_name_condition = try(coalesce(var.role_name, "${var.role_name_prefix}*"), null)
+  role_name_condition = var.role_name != null ? var.role_name : "${var.role_name_prefix}*"
 }
 
 data "aws_iam_policy_document" "this" {


### PR DESCRIPTION
## Description

When using the `iam-role-for-service-accounts-eks` module with the `allow_self_assume_role` set to `true` a dynamic statement is generated for the policy. This policy uses a local role_name_condition computed using the coalesce function as follows:
`coalesce(var.role_name, "${var.role_name_prefix}*")`
The issue comes from the fact that the `var.role_name_prefix` is `null` by default, and cannot be included in a string template. The error generated is:
`The expression result is null. Cannot include a null value in a string template.`


<!--- Describe your changes in detail -->

## Motivation and Context
This change solves the issue generated when the `allow_self_assume_role` set to `true`. It is a fix to handle the different cases properly
The PR also fixes this open issue: #383 


## Breaking Changes
The PR does not introduce any breaking changes. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
Changes have been tested by creating a new example taking the `module.cert_manager_irsa_role` as a base and setting `allow_self_assume_role` to `true`. The new example is included in the PR to make sure this case is always properly handled, it is under `module.cert_manager_irsa_role_self_assume`
The original example has been tested with the new changes to make sure nothing is broken. 

- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
