### PR TITLE
feat: Added permissions to list zone tags in iam-role-for-service-accounts-eks module

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -439,6 +439,7 @@ data "aws_iam_policy_document" "external_dns" {
     actions = [
       "route53:ListHostedZones",
       "route53:ListResourceRecordSets",
+      "route53:ListTagsForResource",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
## Description

When using the `--aws-zone-tags` filter feature of external-dns, `route53:ListTagsForResource` permissions are required.

Without it, external-dns will fail to start.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change adds the necessary permissions required for external-dns to start when using the `--aws-zone-tags` filter.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have applied the changes from my fork and confirmed external-dns starts successfully
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
