### PR TITLE
fix: Hardcode known intermediary thumbprints in github oidc provider

### DIFF
--- a/modules/iam-github-oidc-provider/README.md
+++ b/modules/iam-github-oidc-provider/README.md
@@ -30,7 +30,6 @@ module "iam_github_oidc_provider" {
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0 |
 
 ## Modules
 
@@ -42,7 +41,6 @@ No modules.
 |------|------|
 | [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-| [tls_certificate.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
 
 ## Inputs
 
@@ -50,6 +48,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_client_id_list"></a> [client\_id\_list](#input\_client\_id\_list) | List of client IDs (also known as audiences) for the IAM OIDC provider. Defaults to STS service if not values are provided | `list(string)` | `[]` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects all resources) | `bool` | `true` | no |
+| <a name="input_github_intermediary_thumbprints"></a> [github\_intermediary\_thumbprints](#input\_github\_intermediary\_thumbprints) | GitHub actions SSL intermeidary thumbprints | `set(string)` | <pre>[<br>  "6938fd4d98bab03faadb97b34396831e3780aea1",<br>  "1c58a3a8518e8759bf075b76b750d4f2df264fcd"<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources created | `map(any)` | `{}` | no |
 | <a name="input_url"></a> [url](#input\_url) | The URL of the identity provider. Corresponds to the iss claim | `string` | `"https://token.actions.githubusercontent.com"` | no |
 

--- a/modules/iam-github-oidc-provider/main.tf
+++ b/modules/iam-github-oidc-provider/main.tf
@@ -4,18 +4,12 @@ data "aws_partition" "current" {}
 # GitHub OIDC Provider
 ################################################################################
 
-data "tls_certificate" "this" {
-  count = var.create ? 1 : 0
-
-  url = var.url
-}
-
 resource "aws_iam_openid_connect_provider" "this" {
   count = var.create ? 1 : 0
 
   url             = var.url
   client_id_list  = coalescelist(var.client_id_list, ["sts.${data.aws_partition.current.dns_suffix}"])
-  thumbprint_list = data.tls_certificate.this[0].certificates[*].sha1_fingerprint
+  thumbprint_list = var.github_intermediary_thumbprints
 
   tags = var.tags
 }

--- a/modules/iam-github-oidc-provider/variables.tf
+++ b/modules/iam-github-oidc-provider/variables.tf
@@ -21,3 +21,12 @@ variable "url" {
   type        = string
   default     = "https://token.actions.githubusercontent.com"
 }
+
+variable "github_intermediary_thumbprints" {
+  description = "GitHub actions SSL intermeidary thumbprints"
+  type        = set(string)
+  default = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
+  ]
+}

--- a/wrappers/iam-github-oidc-provider/main.tf
+++ b/wrappers/iam-github-oidc-provider/main.tf
@@ -7,4 +7,8 @@ module "wrapper" {
   tags           = try(each.value.tags, var.defaults.tags, {})
   client_id_list = try(each.value.client_id_list, var.defaults.client_id_list, [])
   url            = try(each.value.url, var.defaults.url, "https://token.actions.githubusercontent.com")
+  github_intermediary_thumbprints = try(each.value.github_intermediary_thumbprints, var.defaults.github_intermediary_thumbprints, [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
+  ])
 }


### PR DESCRIPTION
## Description
Following GitHub's announcement that can be found on their [blog](https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/) there are now multiple thumbprints that are required to integrate AWS with GitHub actions.

We have been running with this change for some time now and wanted to submit upstream in case others are having issues with their GitHub actions workflows assuming AWS roles.

## Motivation and Context
Solves errors where GitHub actions workflows are unable to assume an IAM role due to an invalid thumbprint.

## Breaking Changes
N/A - this change is additive and won't interfere with the current implementation.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s) (N/A)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request

As previously mentioned, we have been testing this change for a while. We vendored this change into our own Terraform workspace and have been running without issue for a while now. During the last couple of weeks, GitHub has changed thumbprints twice and our change detected when this occurred and showed up in a Terraform plan.