### PR TITLE
fix(iam-group-with-policies): Typo "enforcment" to "enforcement"

### DIFF
--- a/modules/iam-group-with-policies/README.md
+++ b/modules/iam-group-with-policies/README.md
@@ -44,7 +44,7 @@ No modules.
 | <a name="input_create_group"></a> [create\_group](#input\_create\_group) | Whether to create IAM group | `bool` | `true` | no |
 | <a name="input_custom_group_policies"></a> [custom\_group\_policies](#input\_custom\_group\_policies) | List of maps of inline IAM policies to attach to IAM group. Should have `name` and `policy` keys in each element. | `list(map(string))` | `[]` | no |
 | <a name="input_custom_group_policy_arns"></a> [custom\_group\_policy\_arns](#input\_custom\_group\_policy\_arns) | List of IAM policies ARNs to attach to IAM group | `list(string)` | `[]` | no |
-| <a name="input_enable_mfa_enforcment"></a> [enable\_mfa\_enforcment](#input\_enable\_mfa\_enforcment) | Determines whether permissions are added to the policy which requires the groups IAM users to use MFA | `bool` | `true` | no |
+| <a name="input_enable_mfa_enforcement"></a> [enable\_mfa\_enforcement](#input\_enable\_mfa\_enforcement) | Determines whether permissions are added to the policy which requires the groups IAM users to use MFA | `bool` | `true` | no |
 | <a name="input_group_users"></a> [group\_users](#input\_group\_users) | List of IAM users to have in an IAM group which can assume the role | `list(string)` | `[]` | no |
 | <a name="input_iam_self_management_policy_name_prefix"></a> [iam\_self\_management\_policy\_name\_prefix](#input\_iam\_self\_management\_policy\_name\_prefix) | Name prefix for IAM policy to create with IAM self-management permissions | `string` | `"IAMSelfManagement-"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of IAM group | `string` | `""` | no |

--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -146,7 +146,7 @@ data "aws_iam_policy_document" "iam_self_management" {
   }
 
   dynamic "statement" {
-    for_each = var.enable_mfa_enforcment ? [1] : []
+    for_each = var.enable_mfa_enforcement ? [1] : []
 
     content {
       sid    = "DenyAllExceptListedIfNoMFA"

--- a/modules/iam-group-with-policies/variables.tf
+++ b/modules/iam-group-with-policies/variables.tf
@@ -34,7 +34,7 @@ variable "custom_group_policies" {
   default     = []
 }
 
-variable "enable_mfa_enforcment" {
+variable "enable_mfa_enforcement" {
   description = "Determines whether permissions are added to the policy which requires the groups IAM users to use MFA"
   type        = bool
   default     = true

--- a/wrappers/iam-group-with-policies/main.tf
+++ b/wrappers/iam-group-with-policies/main.tf
@@ -9,7 +9,7 @@ module "wrapper" {
   group_users                            = try(each.value.group_users, var.defaults.group_users, [])
   custom_group_policy_arns               = try(each.value.custom_group_policy_arns, var.defaults.custom_group_policy_arns, [])
   custom_group_policies                  = try(each.value.custom_group_policies, var.defaults.custom_group_policies, [])
-  enable_mfa_enforcment                  = try(each.value.enable_mfa_enforcment, var.defaults.enable_mfa_enforcment, true)
+  enable_mfa_enforcement                  = try(each.value.enable_mfa_enforcement, var.defaults.enable_mfa_enforcement, true)
   attach_iam_self_management_policy      = try(each.value.attach_iam_self_management_policy, var.defaults.attach_iam_self_management_policy, true)
   iam_self_management_policy_name_prefix = try(each.value.iam_self_management_policy_name_prefix, var.defaults.iam_self_management_policy_name_prefix, "IAMSelfManagement-")
   aws_account_id                         = try(each.value.aws_account_id, var.defaults.aws_account_id, "")


### PR DESCRIPTION
`enable_mfa_enforcment` should be `enable_mfa_enforcement`

https://github.com/terraform-aws-modules/terraform-aws-iam/blob/f537b20bb4d31f014c1c63a5b4151177aed694e0/modules/iam-group-with-policies/variables.tf#L37

## Description

As far as I know, the word "enforcment" does not exist.

## Motivation and Context

 It offends the editor's spell checker, etc., so I fixed it.

It is a minor correction and has not been issued.

## Breaking Changes

If any user is already using this argument in this module, it may need to be modified.

## How Has This Been Tested?

- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
