### PR TITLE
feat(iam_account): Make aws_iam_account_alias optional

### DIFF
--- a/examples/iam-account/main.tf
+++ b/examples/iam-account/main.tf
@@ -13,3 +13,13 @@ module "iam_account" {
   minimum_password_length = 6
   require_numbers         = false
 }
+
+module "iam_account_no_alias" {
+  source = "../../modules/iam-account"
+
+  account_alias        = ""
+  create_account_alias = false
+
+  minimum_password_length = 6
+  require_numbers         = false
+}

--- a/modules/iam-account/main.tf
+++ b/modules/iam-account/main.tf
@@ -3,6 +3,7 @@ data "aws_caller_identity" "this" {
 }
 
 resource "aws_iam_account_alias" "this" {
+  count         = var.create_account_alias ? 1 : 0
   account_alias = var.account_alias
 }
 

--- a/modules/iam-account/variables.tf
+++ b/modules/iam-account/variables.tf
@@ -15,6 +15,11 @@ variable "create_account_password_policy" {
   default     = true
 }
 
+variable "create_account_alias" {
+  description = "Whether to create AWS IAM account alias"
+  type        = bool
+  default     = true
+}
 variable "max_password_age" {
   description = "The number of days that an user password is valid."
   type        = number


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I would like to make optional the creation of the alias
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If someone does not want to enable alias, we dont have an option yet.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
no breaking change. I keep the default behavior.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
