### PR TITLE
fix(iam-github-oidc-provider): Add Github OIDC thumbprints sorting

### DIFF
--- a/modules/iam-github-oidc-provider/main.tf
+++ b/modules/iam-github-oidc-provider/main.tf
@@ -15,7 +15,7 @@ resource "aws_iam_openid_connect_provider" "this" {
 
   url             = var.url
   client_id_list  = coalescelist(var.client_id_list, ["sts.${data.aws_partition.current.dns_suffix}"])
-  thumbprint_list = distinct(concat(data.tls_certificate.this[0].certificates[*].sha1_fingerprint, var.additional_thumbprints))
+  thumbprint_list = sort(distinct(concat(data.tls_certificate.this[0].certificates[*].sha1_fingerprint, var.additional_thumbprints)))
 
   tags = var.tags
 }


### PR DESCRIPTION
## Description
Add github oidc provider thumbprints list sorting

## Motivation and Context
After the introduction of https://github.com/terraform-aws-modules/terraform-aws-iam/pull/403 we started facing terraform drift changes in our nightly workflow runs. 
It tries to store the same thumbprints in a different order because [distinct](https://developer.hashicorp.com/terraform/language/functions/distinct) function preserves ordering:
```
Terraform will perform the following actions:

  # aws_iam_openid_connect_provider.this[0] will be updated in-place
  ~ resource "aws_iam_openid_connect_provider" "this" {
        id              = "arn:aws:iam::***:oidc-provider/token.actions.githubusercontent.com"
        tags            = {
            "managedBy"      = "terragrunt"
        }
      ~ thumbprint_list = [
          - "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
          - "f879abce0008e4eb126e0097e46620f5aaae26ad",
            "6938fd4d98bab03faadb97b34396831e3780aea1",
          + "f879abce0008e4eb126e0097e46620f5aaae26ad",
          + "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
        ]
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
Storing the list in a sorted way should prevent this behavior.
## Breaking Changes
no

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
