### PR TITLE
feat(iam-eks-role): Add the ability to provide additional principal ARNs which could assume the role

### DIFF
--- a/modules/iam-eks-role/README.md
+++ b/modules/iam-eks-role/README.md
@@ -74,6 +74,29 @@ module "iam_eks_role" {
 }
 ```
 
+## Provide additional principal ARNs which could assume the managed role
+
+In some cases you might need to provide additional custom principal ARNs which should be able to assume the role.
+This kind of principal ARNs must be provided only in the `assume_role_policy` of the `aws_iam_role` resource.
+The example below shows the case when the existing role of the `my-service-b` is able to assume the `my-service-a`
+role.
+
+```hcl
+module "iam_eks_role" {
+  source = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
+
+  role_name = "my-service-a"
+
+  cluster_service_accounts = {
+    "cluster1" = ["default:my-serviceaccount"]
+  }
+
+  assume_role_additional_principals = [
+    "arn:aws:iam::123456789012:role/my-service-b"
+  ]
+}
+```
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -120,6 +143,7 @@ No modules.
 | <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | ARNs of any policies to attach to the IAM role | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add the the IAM role | `map(any)` | `{}` | no |
+| <a name="input_assume_role_additional_principals"></a> [assume\_role\_additional\_principals](#input\_assume\_role\_additional\_principals) | ARNs of additional AWS principals which should be allowed to assume the managed role | `list(string)` | `null` | no |
 
 ## Outputs
 

--- a/modules/iam-eks-role/main.tf
+++ b/modules/iam-eks-role/main.tf
@@ -58,6 +58,21 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       }
     }
   }
+
+  dynamic "statement" {
+    for_each = length(var.assume_role_additional_principals) > 0 ? [1] : []
+
+    content {
+      sid     = "AdditionalAssumptionPrincipals"
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+
+      principals {
+        type        = "AWS"
+        identifiers = var.assume_role_additional_principals
+      }
+    }
+  }
 }
 
 resource "aws_iam_role" "this" {

--- a/modules/iam-eks-role/variables.tf
+++ b/modules/iam-eks-role/variables.tf
@@ -75,3 +75,9 @@ variable "assume_role_condition_test" {
   type        = string
   default     = "StringEquals"
 }
+
+variable "assume_role_additional_principals" {
+  description = "Additional AWS principal ARNs which should be allowed to assume the managed role"
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
## Description

Add the ability to provide additional principal ARNs which could assume the role.

## Motivation and Context

Please check the additions to the README.md file. I've tested this one with my private project with the real AWS setup and Kubernetes cluster, and it works correctly. I tried to come up with some solution without modifying the upstream module and do all the changes in my private Git repository, but I don't really have any ideas how could I override the `assume_role_policy` value (of the `aws_iam_role` resource) in a nice way without copy'n'pasting half of this module. If you have better ideas, please let me know. Thank you!

## Breaking Changes

There are no breaking changes. The proposed code and changes should be backward compatible with any kind of existing Terraform code that uses this module.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
