### PR TITLE
chore(iam-assume-role-with-oidc): Update audience dynamic block to StringEquals

### DIFF
--- a/examples/iam-assumable-role-with-oidc/main.tf
+++ b/examples/iam-assumable-role-with-oidc/main.tf
@@ -57,7 +57,7 @@ module "iam_assumable_role_self_assume" {
 module "iam_assumable_role_cross_account" {
   source = "../../modules/iam-assumable-role-with-oidc"
 
-  create_role            = true
+  create_role = true
 
   role_name = "role-with-oidc-cross-account"
 
@@ -73,5 +73,5 @@ module "iam_assumable_role_cross_account" {
   ]
 
   oidc_fully_qualified_audiences = ["sts.amazonaws.com"]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:default:sa1", "system:serviceaccount:default:sa2"]
+  oidc_fully_qualified_subjects  = ["system:serviceaccount:default:sa1", "system:serviceaccount:default:sa2"]
 }

--- a/examples/iam-assumable-role-with-oidc/main.tf
+++ b/examples/iam-assumable-role-with-oidc/main.tf
@@ -50,3 +50,28 @@ module "iam_assumable_role_self_assume" {
 
   oidc_fully_qualified_subjects = ["system:serviceaccount:default:sa1", "system:serviceaccount:default:sa2"]
 }
+
+##############################################
+# IAM assumable role with cross-account assume
+##############################################
+module "iam_assumable_role_cross_account" {
+  source = "../../modules/iam-assumable-role-with-oidc"
+
+  create_role            = true
+
+  role_name = "role-with-oidc-cross-account"
+
+  tags = {
+    Role = "role-with-oidc-cross-account"
+  }
+
+  provider_url  = "oidc.eks.eu-west-1.amazonaws.com/id/BA9E170D464AF7B92084EF72A69B9DC8"
+  provider_urls = ["oidc.eks.eu-west-1.amazonaws.com/id/AA9E170D464AF7B92084EF72A69B9DC8"]
+
+  role_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+  ]
+
+  oidc_fully_qualified_audiences = ["sts.amazonaws.com"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:default:sa1", "system:serviceaccount:default:sa2"]
+}

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
         for_each = length(var.oidc_fully_qualified_audiences) > 0 ? local.urls : []
 
         content {
-          test     = "StringLike"
+          test     = "StringEquals"
           variable = "${statement.value}:aud"
           values   = var.oidc_fully_qualified_audiences
         }


### PR DESCRIPTION
## Description
Minor update to change the dynamic block for fully_qualified_audiences to StringEquals instead of StringLike

## Motivation and Context
Coming from the documentations for adding assume roles for Github Actions:
- [Github documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#configuring-the-role-and-trust-policy)
- [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html#idp_oidc_Create_GitHub)

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request