### PR TITLE
fix: Expand Permissions for external-secrets IRSA Policy towards AWS Secrets Manager

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -501,9 +501,7 @@ data "aws_iam_policy_document" "external_secrets" {
   }
 
   statement {
-    actions = [
-      "kms:Decrypt"
-    ]
+    actions   = ["kms:Decrypt"]
     resources = var.external_secrets_kms_key_arns
   }
 

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -511,9 +511,24 @@ data "aws_iam_policy_document" "external_secrets" {
     for_each = var.external_secrets_secrets_manager_create_permission ? [1] : []
     content {
       actions = [
-        "secretsmanager:CreateSecret"
+        "secretsmanager:CreateSecret",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:TagResource",
       ]
       resources = var.external_secrets_secrets_manager_arns
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.external_secrets_secrets_manager_create_permission ? [1] : []
+    content {
+      actions   = ["secretsmanager:DeleteSecret"]
+      resources = var.external_secrets_secrets_manager_arns
+      condition {
+        test     = "StringEquals"
+        variable = "secretsmanager:ResourceTag/managed-by"
+        values   = ["external-secrets"]
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
Initial set of permissions (#414) was not sufficient. Checked the [source code](https://github.com/external-secrets/external-secrets/blob/main/pkg/provider/aws/secretsmanager/secretsmanager.go) of the secrets manager implementation of external-secrets and added remaining permissions.

## Motivation and Context
There were errors on certain use cases, such as a secret changes and needs to be pushed again.

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
- [x] our setup