### PR TITLE
fix: Add missing condition role_session_name when assuming a role

### DIFF
--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -55,6 +55,15 @@ data "aws_iam_policy_document" "assume_role" {
         values   = local.role_sts_externalid
       }
     }
+
+    dynamic "condition" {
+      for_each = var.role_requires_session_name ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "sts:RoleSessionName"
+        values   = var.role_session_name
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
For `iam-assumable-role` the setting `role_requires_session_name = true` is ignored when `role_requires_mfa = false`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For the case when MFA is not enforced, the option to set the condition `role_session_name` when assuming a role is missing. This was probably due to the confusion caused by unnecessary code duplication (two separate policies whether MFA is enabled or not) when the feature was implemented.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
