### PR TITLE
feat(iam-user): Fixed direct policy attachment in iam-user module

### DIFF
--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -47,8 +47,8 @@ resource "aws_iam_user_ssh_key" "this" {
 }
 
 resource "aws_iam_user_policy_attachment" "this" {
-  for_each = var.create_user ? toset(var.policy_arns) : []
+  count = var.create_user ? length(var.policy_arns) : 0
 
   user       = aws_iam_user.this[0].name
-  policy_arn = each.value
+  policy_arn = element(var.policy_arns, count.index)
 }


### PR DESCRIPTION
## Description
When creating the `iam-user` module, it throws error as `for_each` is expecting a map or a set of string however the module defines the `policy_arns` variable as a `list(string)`.

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-iam/issues/408

There are two options to fix this issue. Option 1 is to cast the `policy_arns` into a map of string in runtime (like how it is done in https://github.com/terraform-aws-modules/terraform-aws-iam/blob/master/modules/iam-eks-role/main.tf#L78). Or option 2 is to replace `for_each` with `count`. For simplicity reason, I chose option 2.

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
example remains the same as there is no change to the caller inputs
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
