### PR TITLE
add iam-goolge-oidc-role (no provider arn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,181 +1,21 @@
-# AWS Identity and Access Management (IAM) Terraform module
+# IAM GitHub OIDC Role
 
-[![SWUbanner](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md)
-
-## Features
-
-1. **Cross-account access.** Define IAM roles using `iam_assumable_role` or `iam_assumable_roles` submodules in "resource AWS accounts (prod, staging, dev)" and IAM groups and users using `iam-group-with-assumable-roles-policy` submodule in "IAM AWS Account" to setup access controls between accounts. See [iam-group-with-assumable-roles-policy example](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-group-with-assumable-roles-policy) for more details.
-2. **Individual IAM resources (users, roles, policies).** See usage snippets and [examples](https://github.com/terraform-aws-modules/terraform-aws-iam#examples) listed below.
+Creates an IAM role that trust the IAM Google OIDC built in provider.
+- AWS IAM role reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html#idp_oidc_Create
 
 ## Usage
 
-`iam-account`:
+### Google
+
+The defaults provided by the module are suitable for testing with any Google service account.
 
 ```hcl
-module "iam_account" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-account"
-
-  account_alias = "awesome-company"
-
-  minimum_password_length = 37
-  require_numbers         = false
-}
-```
-
-`iam-assumable-role`:
-
-```hcl
-module "iam_assumable_role" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-
-  trusted_role_arns = [
-    "arn:aws:iam::307990089504:root",
-    "arn:aws:iam::835367859851:user/anton",
-  ]
-
-  create_role = true
-
-  role_name         = "custom"
-  role_requires_mfa = true
-
-  custom_role_policy_arns = [
-    "arn:aws:iam::aws:policy/AmazonCognitoReadOnly",
-    "arn:aws:iam::aws:policy/AlexaForBusinessFullAccess",
-  ]
-  number_of_custom_role_policy_arns = 2
-}
-```
-
-`iam-assumable-role-with-oidc`:
-
-```hcl
-module "iam_assumable_role_with_oidc" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-
-  create_role = true
-
-  role_name = "role-with-oidc"
-
-  tags = {
-    Role = "role-with-oidc"
-  }
-
-  provider_url = "oidc.eks.eu-west-1.amazonaws.com/id/BA9E170D464AF7B92084EF72A69B9DC8"
-
-  role_policy_arns = [
-    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
-  ]
-  number_of_role_policy_arns = 1
-}
-```
-
-`iam-assumable-role-with-saml`:
-
-```hcl
-module "iam_assumable_role_with_saml" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-saml"
-
-  create_role = true
-
-  role_name = "role-with-saml"
-
-  tags = {
-    Role = "role-with-saml"
-  }
-
-  provider_id = "arn:aws:iam::235367859851:saml-provider/idp_saml"
-
-  role_policy_arns = [
-    "arn:aws:iam::aws:policy/ReadOnlyAccess"
-  ]
-  number_of_role_policy_arns = 1
-}
-```
-
-`iam-assumable-roles`:
-
-```hcl
-module "iam_assumable_roles" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-roles"
-
-  trusted_role_arns = [
-    "arn:aws:iam::307990089504:root",
-    "arn:aws:iam::835367859851:user/anton",
-  ]
-
-  create_admin_role = true
-
-  create_poweruser_role = true
-  poweruser_role_name   = "developer"
-
-  create_readonly_role       = true
-  readonly_role_requires_mfa = false
-}
-```
-
-`iam-assumable-roles-with-saml`:
-
-```hcl
-module "iam_assumable_roles_with_saml" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-roles-with-saml"
-
-  create_admin_role = true
-
-  create_poweruser_role = true
-  poweruser_role_name   = "developer"
-
-  create_readonly_role = true
-
-  provider_id   = "arn:aws:iam::235367859851:saml-provider/idp_saml"
-}
-```
-
-`iam-eks-role`:
-
-```hcl
-module "iam_eks_role" {
-  source      = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
-
-  role_name   = "my-app"
-
-  cluster_service_accounts = {
-    "cluster1" = ["default:my-app"]
-    "cluster2" = [
-      "default:my-app",
-      "canary:my-app",
-    ]
-  }
-
-  tags = {
-    Name = "eks-role"
-  }
-
-  role_policy_arns = {
-    AmazonEKS_CNI_Policy = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-  }
-}
-```
-
-`iam-github-oidc-provider`:
-
-```hcl
-module "iam_github_oidc_provider" {
-  source    = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-provider"
-
-  tags = {
-    Environment = "test"
-  }
-}
-```
-
-`iam-github-oidc-role`:
-
-```hcl
-module "iam_github_oidc_role" {
-  source    = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
+module "iam_google_oidc_role" {
+  source    = "terraform-aws-modules/iam/aws//modules/iam-google-oidc-role"
 
   # This should be updated to suit your organization, repository, references/branches, etc.
-  subjects = ["terraform-aws-modules/terraform-aws-iam:*"]
+  google_service_account_ids = ["123456789101112131415"]
+  google_service_account_emails = ["aws-role-access@project-acme.iam.gserviceaccount.com"]
 
   policies = {
     S3ReadOnly = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
@@ -187,198 +27,118 @@ module "iam_github_oidc_role" {
 }
 ```
 
-`iam-group-with-assumable-roles-policy`:
+```
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_audience"></a> [audience](#input\_audience) | Audience to use for OIDC role. Defaults to `sts.amazonaws.com` for use with the [official AWS GitHub action](https://github.com/aws-actions/configure-aws-credentials) | `string` | `"sts.amazonaws.com"` | no |
+| <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects all resources) | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | IAM Role description | `string` | `null` | no |
+| <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `true` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of IAM role | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | IAM role name prefix | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | Path of IAM role | `string` | `"/"` | no |
+| <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `null` | no |
+| <a name="input_policies"></a> [policies](#input\_policies) | Policies to attach to the IAM role in `{'static_name' = 'policy_arn'}` format | `map(string)` | `{}` | no |
+| <a name="input_provider_url"></a> [provider\_url](#input\_provider\_url) | The URL of the identity provider. Corresponds to the iss claim | `string` | `"token.actions.githubusercontent.com"` | no |
+| <a name="input_subjects"></a> [subjects](#input\_subjects) | List of GitHub OIDC subjects that are permitted by the trust policy. You do not need to prefix with `repo:` as this is provided. Example: `['my-org/my-repo:*', 'octo-org/octo-repo:ref:refs/heads/octo-branch']` | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources created | `map(any)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN of IAM role |
+| <a name="output_name"></a> [name](#output\_name) | Name of IAM role |
+| <a name="output_path"></a> [path](#output\_path) | Path of IAM role |
+| <a name="output_unique_id"></a> [unique\_id](#output\_unique\_id) | Unique ID of IAM role |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+<!-- BEGIN_TF_DOCS -->
+# IAM Google OIDC Role
+
+Creates an IAM role that trust the IAM Google OIDC built in provider.
+- AWS IAM role reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html#idp_oidc_Create
+
+## Usage
+
+### Google
+
+The defaults provided by the module are suitable for testing with any Google service account.
 
 ```hcl
-module "iam_group_with_assumable_roles_policy" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-group-with-assumable-roles-policy"
+module "iam_google_oidc_role" {
+source    = "terraform-aws-modules/iam/aws//modules/iam-google-oidc-role"
 
-  name = "production-readonly"
+# This should be updated to suit your organization, repository, references/branches, etc.
+google_service_account_ids = ["123456789101112131415"]
+google_service_account_emails = ["aws-role-access@project-acme.iam.gserviceaccount.com"]
 
-  assumable_roles = [
-    "arn:aws:iam::835367859855:role/readonly"  # these roles can be created using `iam_assumable_roles` submodule
-  ]
+policies = {
+S3ReadOnly = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
 
-  group_users = [
-    "user1",
-    "user2"
-  ]
+tags = {
+Environment = "test"
+}
 }
 ```
 
-`iam-group-with-policies`:
+## Inputs
 
-```hcl
-module "iam_group_with_policies" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-group-with-policies"
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects all resources) | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | IAM Role description | `string` | `null` | no |
+| <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `true` | no |
+| <a name="input_google_service_account_emails"></a> [google\_service\_account\_emails](#input\_google\_service\_account\_emails) | Must be the google service account email address. | `list(string)` | `[]` | no |
+| <a name="input_google_service_account_ids"></a> [google\_service\_account\_ids](#input\_google\_service\_account\_ids) | Must be the google service account IDs (not email address). This is used for both subjects | `list(string)` | `[]` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of IAM role | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | IAM role name prefix | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | Path of IAM role | `string` | `"/"` | no |
+| <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `null` | no |
+| <a name="input_policies"></a> [policies](#input\_policies) | Policies to attach to the IAM role in `{'static_name' = 'policy_arn'}` format | `map(string)` | `{}` | no |
+| <a name="input_provider_url"></a> [provider\_url](#input\_provider\_url) | The URL of the identity provider. Corresponds to the iss claim | `string` | `"accounts.google.com"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources created | `map(any)` | `{}` | no |
 
-  name = "superadmins"
+## Outputs
 
-  group_users = [
-    "user1",
-    "user2"
-  ]
-
-  attach_iam_self_management_policy = true
-
-  custom_group_policy_arns = [
-    "arn:aws:iam::aws:policy/AdministratorAccess",
-  ]
-
-  custom_group_policies = [
-    {
-      name   = "AllowS3Listing"
-      policy = data.aws_iam_policy_document.sample.json
-    }
-  ]
-}
-```
-
-`iam-policy`:
-
-```hcl
-module "iam_policy" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-
-  name        = "example"
-  path        = "/"
-  description = "My example policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:Describe*"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-```
-
-`iam-read-only-policy`:
-
-```hcl
-module "iam_read_only_policy" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-read-only-policy"
-
-  name        = "example"
-  path        = "/"
-  description = "My example read-only policy"
-
-  allowed_services = ["rds", "dynamo", "health"]
-}
-```
-
-`iam-role-for-service-accounts-eks`:
-
-```hcl
-module "vpc_cni_irsa" {
-  source      = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-
-  role_name   = "vpc-cni"
-
-  attach_vpc_cni_policy = true
-  vpc_cni_enable_ipv4   = true
-
-  oidc_providers = {
-    main = {
-      provider_arn               = "arn:aws:iam::012345678901:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/5C54DDF35ER19312844C7333374CC09D"
-      namespace_service_accounts = ["kube-system:aws-node"]
-    }
-  }
-
-  tags = {
-    Name = "vpc-cni-irsa"
-  }
-}
-```
-
-`iam-user`:
-
-```hcl
-module "iam_user" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-
-  name          = "vasya.pupkin"
-  force_destroy = true
-
-  pgp_key = "keybase:test"
-
-  password_reset_required = false
-}
-```
-
-## IAM Best Practices
-
-AWS published [IAM Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html) and this Terraform module was created to help with some of points listed there:
-
-1. Create Individual IAM Users
-
-Use [iam-user module](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-user) module to manage IAM users.
-
-2. Use AWS Defined Policies to Assign Permissions Whenever Possible
-
-Use [iam-assumable-roles module](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-assumable-roles) to create IAM roles with managed policies to support common tasks (admin, poweruser or readonly).
-
-3. Use Groups to Assign Permissions to IAM Users
-
-Use [iam-group-with-assumable-roles-policy module](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-group-with-assumable-roles-policy) to manage IAM groups of users who can assume roles.
-Use [iam-group-with-policies module](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-group-with-policies) to manage IAM groups of users where specified IAM policies are allowed.
-
-4. Configure a Strong Password Policy for Your Users
-
-Use [iam-account module](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-account) to set password policy for your IAM users.
-
-5. Enable MFA for Privileged Users
-
-Use [iam-assumable-roles module](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-assumable-roles) to create IAM roles that require MFA.
-
-6. Delegate by Using Roles Instead of by Sharing Credentials
-
-[iam-assumable-role](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-assumable-role), [iam-assumable-roles](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-assumable-roles), [iam-assumable-roles-with-saml](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-assumable-roles-with-saml) and [iam-group-with-assumable-roles-policy](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-group-with-assumable-roles-policy) modules provide complete set of functionality required for this.
-
-7. Use Policy Conditions for Extra Security
-
-[iam-assumable-roles module](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-assumable-roles) can be configured to require valid MFA token when different roles are assumed (for example, admin role requires MFA, but readonly - does not).
-
-8. Create IAM Policies
-
-Use [iam-policy module](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-policy) module to manage IAM policy.
-Use [iam-read-only-policy module](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-read-only-policy) module to manage IAM read-only policies.
-
-## Examples
-
-- [iam-account](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-account) - Set AWS account alias and password policy
-- [iam-assumable-role-with-oidc](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-assumable-role-with-oidc) - Create individual IAM role which can be assumed from specified subjects federated with a OIDC Identity Provider
-- [iam-assumable-role-with-saml](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-assumable-role-with-saml) - Create individual IAM role which can be assumed by users with a SAML Identity Provider
-- [iam-assumable-role](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-assumable-role) - Create individual IAM role which can be assumed from specified ARNs (AWS accounts, IAM users, etc)
-- [iam-assumable-roles-with-saml](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-assumable-roles-with-saml) - Create several IAM roles which can be assumed by users with a SAML Identity Provider
-- [iam-assumable-roles](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-assumable-roles) - Create several IAM roles which can be assumed from specified ARNs (AWS accounts, IAM users, etc)
-- [iam-eks-role](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-eks-role) - Create an IAM role that can be assumed by one or more EKS `ServiceAccount`
-- [iam-group-complete](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-group-complete) - IAM group with users who are allowed to assume IAM roles in another AWS account and have access to specified IAM policies
-- [iam-group-with-assumable-roles-policy](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-group-with-assumable-roles-policy) - IAM group with users who are allowed to assume IAM roles in the same or in separate AWS account
-- [iam-group-with-policies](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-group-with-policies) - IAM group with users who are allowed specified IAM policies (eg, "manage their own IAM user")
-- [iam-policy](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-policy) - Create IAM policy
-- [iam-read-only-policy](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-read-only-policy) - Create IAM read-only policy
-- [iam-role-for-service-accounts-eks](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-role-for-service-accounts-eks) - Create IAM role for service accounts (IRSA) for use within EKS clusters
-- [iam-user](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/examples/iam-user) - Add IAM user, login profile and access keys (with PGP enabled or disabled)
-
-## Authors
-
-Module is maintained by [Anton Babenko](https://github.com/antonbabenko) with help from [these awesome contributors](https://github.com/terraform-aws-modules/terraform-aws-iam/graphs/contributors).
-
-## License
-
-Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/LICENSE) for full details.
-
-## Additional information for users from Russia and Belarus
-
-* Russia has [illegally annexed Crimea in 2014](https://en.wikipedia.org/wiki/Annexation_of_Crimea_by_the_Russian_Federation) and [brought the war in Donbas](https://en.wikipedia.org/wiki/War_in_Donbas) followed by [full-scale invasion of Ukraine in 2022](https://en.wikipedia.org/wiki/2022_Russian_invasion_of_Ukraine).
-* Russia has brought sorrow and devastations to millions of Ukrainians, killed hundreds of innocent people, damaged thousands of buildings, and forced several million people to flee.
-* [Putin khuylo!](https://en.wikipedia.org/wiki/Putin_khuylo!)
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN of IAM role |
+| <a name="output_name"></a> [name](#output\_name) | Name of IAM role |
+| <a name="output_path"></a> [path](#output\_path) | Path of IAM role |
+| <a name="output_unique_id"></a> [unique\_id](#output\_unique\_id) | Unique ID of IAM role |
+<!-- END_TF_DOCS -->

--- a/modules/iam-google-oidc-role/README.md
+++ b/modules/iam-google-oidc-role/README.md
@@ -1,0 +1,86 @@
+# IAM GitHub OIDC Role
+
+Creates an IAM role that trust the IAM Google OIDC built in provider.
+- AWS IAM role reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html#idp_oidc_Create
+
+## Usage
+
+### Google
+
+The defaults provided by the module are suitable for testing with any Google service account.
+
+```hcl
+module "iam_google_oidc_role" {
+  source    = "terraform-aws-modules/iam/aws//modules/iam-google-oidc-role"
+
+  # This should be updated to suit your organization, repository, references/branches, etc.
+  google_service_account_ids = ["123456789101112131415"]
+  google_service_account_emails = ["aws-role-access@project-acme.iam.gserviceaccount.com"]
+
+  policies = {
+    S3ReadOnly = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  }
+
+  tags = {
+    Environment = "test"
+  }
+}
+```
+
+```
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_audience"></a> [audience](#input\_audience) | Audience to use for OIDC role. Defaults to `sts.amazonaws.com` for use with the [official AWS GitHub action](https://github.com/aws-actions/configure-aws-credentials) | `string` | `"sts.amazonaws.com"` | no |
+| <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects all resources) | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | IAM Role description | `string` | `null` | no |
+| <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `true` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of IAM role | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | IAM role name prefix | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | Path of IAM role | `string` | `"/"` | no |
+| <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `null` | no |
+| <a name="input_policies"></a> [policies](#input\_policies) | Policies to attach to the IAM role in `{'static_name' = 'policy_arn'}` format | `map(string)` | `{}` | no |
+| <a name="input_provider_url"></a> [provider\_url](#input\_provider\_url) | The URL of the identity provider. Corresponds to the iss claim | `string` | `"token.actions.githubusercontent.com"` | no |
+| <a name="input_subjects"></a> [subjects](#input\_subjects) | List of GitHub OIDC subjects that are permitted by the trust policy. You do not need to prefix with `repo:` as this is provided. Example: `['my-org/my-repo:*', 'octo-org/octo-repo:ref:refs/heads/octo-branch']` | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources created | `map(any)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN of IAM role |
+| <a name="output_name"></a> [name](#output\_name) | Name of IAM role |
+| <a name="output_path"></a> [path](#output\_path) | Path of IAM role |
+| <a name="output_unique_id"></a> [unique\_id](#output\_unique\_id) | Unique ID of IAM role |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam-google-oidc-role/main.tf
+++ b/modules/iam-google-oidc-role/main.tf
@@ -7,6 +7,7 @@ locals {
 
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition
+  number_of_role_policy_arns = length(var.role_policy_arns)
 }
 
 ################################################################################
@@ -63,9 +64,9 @@ resource "aws_iam_role" "this" {
   tags = var.tags
 }
 
-resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in var.policies : k => v if var.create }
+resource "aws_iam_role_policy_attachment" "custom" {
+  count = var.create ? local.number_of_role_policy_arns : 0
 
   role       = aws_iam_role.this[0].name
-  policy_arn = each.value
+  policy_arn = var.role_policy_arns[count.index]
 }

--- a/modules/iam-google-oidc-role/main.tf
+++ b/modules/iam-google-oidc-role/main.tf
@@ -1,0 +1,71 @@
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Just extra safety incase someone passes in a url with `https://`
+  provider_url = replace(var.provider_url, "https://", "")
+
+  account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
+}
+
+################################################################################
+# Google OIDC Role
+################################################################################
+
+data "aws_iam_policy_document" "this" {
+  count = var.create ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.provider_url]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.provider_url}:iss"
+      values   = "https://${local.provider_url}"
+    }
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "${local.provider_url}:sub"
+      values   = var.google_service_account_ids
+    }
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "${local.provider_url}:email"
+      values   = var.google_service_account_emails
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  count = var.create ? 1 : 0
+
+  name        = var.name
+  name_prefix = var.name_prefix
+  path        = var.path
+  description = var.description
+
+  assume_role_policy    = data.aws_iam_policy_document.this[0].json
+  max_session_duration  = var.max_session_duration
+  permissions_boundary  = var.permissions_boundary_arn
+  force_detach_policies = var.force_detach_policies
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each = { for k, v in var.policies : k => v if var.create }
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = each.value
+}

--- a/modules/iam-google-oidc-role/main.tf
+++ b/modules/iam-google-oidc-role/main.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "this" {
     condition {
       test     = "StringEquals"
       variable = "${local.provider_url}:iss"
-      values   = "https://${local.provider_url}"
+      values   = ["https://${local.provider_url}"]
     }
 
     condition {

--- a/modules/iam-google-oidc-role/outputs.tf
+++ b/modules/iam-google-oidc-role/outputs.tf
@@ -1,0 +1,23 @@
+################################################################################
+# GitHub OIDC Role
+################################################################################
+
+output "arn" {
+  description = "ARN of IAM role"
+  value       = try(aws_iam_role.this[0].arn, null)
+}
+
+output "name" {
+  description = "Name of IAM role"
+  value       = try(aws_iam_role.this[0].name, null)
+}
+
+output "path" {
+  description = "Path of IAM role"
+  value       = try(aws_iam_role.this[0].path, null)
+}
+
+output "unique_id" {
+  description = "Unique ID of IAM role"
+  value       = try(aws_iam_role.this[0].unique_id, null)
+}

--- a/modules/iam-google-oidc-role/variables.tf
+++ b/modules/iam-google-oidc-role/variables.tf
@@ -1,0 +1,81 @@
+variable "create" {
+  description = "Controls if resources should be created (affects all resources)"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "A map of tags to add to the resources created"
+  type        = map(any)
+  default     = {}
+}
+
+################################################################################
+# Google OIDC Role
+################################################################################
+
+variable "name" {
+  description = "Name of IAM role"
+  type        = string
+  default     = null
+}
+
+variable "path" {
+  description = "Path of IAM role"
+  type        = string
+  default     = "/"
+}
+
+variable "permissions_boundary_arn" {
+  description = "Permissions boundary ARN to use for IAM role"
+  type        = string
+  default     = null
+}
+
+variable "description" {
+  description = "IAM Role description"
+  type        = string
+  default     = null
+}
+
+variable "name_prefix" {
+  description = "IAM role name prefix"
+  type        = string
+  default     = null
+}
+
+variable "policies" {
+  description = "Policies to attach to the IAM role in `{'static_name' = 'policy_arn'}` format"
+  type        = map(string)
+  default     = {}
+}
+
+variable "force_detach_policies" {
+  description = "Whether policies should be detached from this role when destroying"
+  type        = bool
+  default     = true
+}
+
+variable "max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200"
+  type        = number
+  default     = null
+}
+
+variable "google_service_account_ids" {
+  description = "Must be the google service account IDs (not email address). This is used for both subjects"
+  type        = list(string)
+  default     = []
+}
+
+variable "google_service_account_emails" {
+  description = "Must be the google service account email address."
+  type        = list(string)
+  default     = []
+}
+
+variable "provider_url" {
+  description = "The URL of the identity provider. Corresponds to the iss claim"
+  type        = string
+  default     = "accounts.google.com"
+}

--- a/modules/iam-google-oidc-role/variables.tf
+++ b/modules/iam-google-oidc-role/variables.tf
@@ -44,12 +44,6 @@ variable "name_prefix" {
   default     = null
 }
 
-variable "policies" {
-  description = "Policies to attach to the IAM role in `{'static_name' = 'policy_arn'}` format"
-  type        = map(string)
-  default     = {}
-}
-
 variable "force_detach_policies" {
   description = "Whether policies should be detached from this role when destroying"
   type        = bool
@@ -60,6 +54,12 @@ variable "max_session_duration" {
   description = "Maximum CLI/API session duration in seconds between 3600 and 43200"
   type        = number
   default     = null
+}
+
+variable "role_policy_arns" {
+  description = "List of ARNs of IAM policies to attach to IAM role"
+  type        = list(string)
+  default     = []
 }
 
 variable "google_service_account_ids" {

--- a/modules/iam-google-oidc-role/versions.tf
+++ b/modules/iam-google-oidc-role/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0"
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adds support for a OIDC that trusts a Google service Account **WITHOUT** an IAM provider in AWS.

Not sure I'll get to this in a hurry but raising this a POC as using this from our fork for now.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This adds support for Google service accounts and `google.accounts.com` as a provider url as Google is pre-trusted by AWS and does NOT require an AWS iam oidc provider arn to be referenced.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
