### PR TITLE
fix: Update AllowManageOwnAccessKeys statement

### DIFF
--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -50,7 +50,8 @@ data "aws_iam_policy_document" "iam_self_management" {
       "iam:CreateAccessKey",
       "iam:DeleteAccessKey",
       "iam:ListAccessKeys",
-      "iam:UpdateAccessKey"
+      "iam:UpdateAccessKey",
+      "iam:GetAccessKeyLastUsed"
     ]
 
     resources = [


### PR DESCRIPTION

## Description
The "AWS: Self-manage credentials with MFA (My security credentials)" reference policy got updated by AWS in the docs[1] and this implements the following correction:

The AllowManageOwnAccessKeys statement allows the user to create, update, and delete their own access keys.
**The user can also retrieve information about when the specified access key was last used.**

1. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html

<!--- Describe your changes in detail -->

## Motivation and Context
Having the self-management policy up to date with AWS recommendations. 

## Breaking Changes
None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
