### PR TITLE
feat: Allow users to change own password in iam-group-with-policies module

### DIFF
--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -32,7 +32,9 @@ data "aws_iam_policy_document" "iam_self_management" {
 
     actions = [
       "iam:ChangePassword",
-      "iam:GetUser"
+      "iam:GetLoginProfile",
+      "iam:GetUser",
+      "iam:UpdateLoginProfile"
     ]
 
     resources = [
@@ -153,10 +155,10 @@ data "aws_iam_policy_document" "iam_self_management" {
       sid    = "DenyAllExceptListedIfNoMFA"
       effect = "Deny"
       not_actions = [
-        "iam:ChangePassword",
         "iam:CreateVirtualMFADevice",
         "iam:EnableMFADevice",
         "iam:GetUser",
+        "iam:GetMFADevice",
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",


### PR DESCRIPTION
## Description
This PR corrects IAM Self-manage policy according to example from [AWS: Allows MFA-authenticated IAM users to manage their own credentials on the My security credentials page ](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html):
1. Previously, it did not allow users to change their password on their own user page. To allow this, now the `iam:GetLoginProfile` and `iam:UpdateLoginProfile` actions to be added to the `AllowManageOwnPasswords` statement.
2. The `DenyAllExceptListedIfNoMFA` statement has been corrected to include missing ` iam:GetMFADevice` permission for own MFA management.
3. Also, in the same statement `iam:ChangePassword` action should not be allowed without MFA authorization if it was enforced. This does not allow a user to create a password at sign-in, the MFA must be created and user must authenticate using it before attempting to change administrator provided password.

## Motivation and Context
Stay up to date with AWS recommendations for access policies, grant permissions necessary for IAM user selfie-management via AWS Web Console.
Make sure if MFA is enforced, it disallows unauthorized password change for IAM user in case of credentials leak.

## Breaking Changes
None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
