### PR TITLE
fix(iam-group-with-policies): Related resources shouldn't be created when group creation is disabled

### DIFF
--- a/examples/iam-group-with-policies/README.md
+++ b/examples/iam-group-with-policies/README.md
@@ -34,6 +34,7 @@ Run `terraform destroy` when you don't need these resources.
 |------|--------|---------|
 | <a name="module_iam_group_superadmins"></a> [iam\_group\_superadmins](#module\_iam\_group\_superadmins) | ../../modules/iam-group-with-policies | n/a |
 | <a name="module_iam_group_with_custom_policies"></a> [iam\_group\_with\_custom\_policies](#module\_iam\_group\_with\_custom\_policies) | ../../modules/iam-group-with-policies | n/a |
+| <a name="module_iam_group_with_custom_policies_disabled"></a> [iam\_group\_with\_custom\_policies\_disabled](#module\_iam\_group\_with\_custom\_policies\_disabled) | ../../modules/iam-group-with-policies | n/a |
 | <a name="module_iam_user1"></a> [iam\_user1](#module\_iam\_user1) | ../../modules/iam-user | n/a |
 | <a name="module_iam_user2"></a> [iam\_user2](#module\_iam\_user2) | ../../modules/iam-user | n/a |
 

--- a/examples/iam-group-with-policies/main.tf
+++ b/examples/iam-group-with-policies/main.tf
@@ -65,6 +65,35 @@ module "iam_group_with_custom_policies" {
   ]
 }
 
+#####################################################################################
+# IAM group to test the `create_group = false` option
+#####################################################################################
+module "iam_group_with_custom_policies_disabled" {
+  source = "../../modules/iam-group-with-policies"
+
+  create_group = false
+
+  name = "custom-disabled"
+  path = "/custom/"
+
+  group_users = [
+    module.iam_user1.iam_user_name,
+    module.iam_user2.iam_user_name,
+  ]
+
+  custom_group_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonCognitoReadOnly",
+    "arn:aws:iam::aws:policy/AlexaForBusinessFullAccess",
+  ]
+
+  custom_group_policies = [
+    {
+      name   = "AllowS3Listing"
+      policy = data.aws_iam_policy_document.sample.json
+    },
+  ]
+}
+
 ######################
 # IAM policy (sample)
 ######################

--- a/modules/iam-group-with-policies/main.tf
+++ b/modules/iam-group-with-policies/main.tf
@@ -21,21 +21,21 @@ resource "aws_iam_group_membership" "this" {
 # IAM group policy attachements
 ################################
 resource "aws_iam_group_policy_attachment" "iam_self_management" {
-  count = var.attach_iam_self_management_policy ? 1 : 0
+  count = var.create_group && var.attach_iam_self_management_policy ? 1 : 0
 
   group      = local.group_name
   policy_arn = aws_iam_policy.iam_self_management[0].arn
 }
 
 resource "aws_iam_group_policy_attachment" "custom_arns" {
-  count = length(var.custom_group_policy_arns)
+  count = var.create_group ? length(var.custom_group_policy_arns) : 0
 
   group      = local.group_name
   policy_arn = element(var.custom_group_policy_arns, count.index)
 }
 
 resource "aws_iam_group_policy_attachment" "custom" {
-  count = length(var.custom_group_policies)
+  count = var.create_group ? length(var.custom_group_policies) : 0
 
   group      = local.group_name
   policy_arn = element(aws_iam_policy.custom[*].arn, count.index)
@@ -45,7 +45,7 @@ resource "aws_iam_group_policy_attachment" "custom" {
 # IAM policies
 ###############
 resource "aws_iam_policy" "iam_self_management" {
-  count = var.attach_iam_self_management_policy ? 1 : 0
+  count = var.create_group && var.attach_iam_self_management_policy ? 1 : 0
 
   name_prefix = var.iam_self_management_policy_name_prefix
   policy      = data.aws_iam_policy_document.iam_self_management.json
@@ -54,7 +54,7 @@ resource "aws_iam_policy" "iam_self_management" {
 }
 
 resource "aws_iam_policy" "custom" {
-  count = length(var.custom_group_policies)
+  count = var.create_group ? length(var.custom_group_policies) : 0
 
   name        = var.custom_group_policies[count.index]["name"]
   policy      = var.custom_group_policies[count.index]["policy"]


### PR DESCRIPTION
## Description
Related resources shouldn't be created when group creation is disabled

## Motivation and Context
In some scenarios the `iam-group-with-policies` submodule attempts to create `aws_iam_group_membership`, `aws_iam_policy` and `aws_iam_group_policy_attachment` resources even though the `create_group` variable is set to `false`. Workarounds do exist, but ultimately this behaviour is undesired.

## Breaking Changes
None.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
