### PR TITLE
feat: Allow setting additional role arns to trust policy in iam-role-for-service-accounts-eks

### DIFF
--- a/examples/iam-role-for-service-accounts-eks/main.tf
+++ b/examples/iam-role-for-service-accounts-eks/main.tf
@@ -51,6 +51,11 @@ module "irsa_role" {
     additional           = aws_iam_policy.additional.arn
   }
 
+  allow_additional_role_assume = [
+    "arn:aws:iam::012345678901:role/role1",
+    "arn:aws:iam::012345678901:role/role2",
+  ]
+
   tags = local.tags
 }
 

--- a/examples/iam-role-for-service-accounts-eks/main.tf
+++ b/examples/iam-role-for-service-accounts-eks/main.tf
@@ -52,8 +52,7 @@ module "irsa_role" {
   }
 
   allow_additional_role_assume = [
-    "arn:aws:iam::012345678901:role/role1",
-    "arn:aws:iam::012345678901:role/role2",
+    module.aws_gateway_controller_irsa_role.iam_role_arn,
   ]
 
   tags = local.tags

--- a/modules/iam-role-for-service-accounts-eks/README.md
+++ b/modules/iam-role-for-service-accounts-eks/README.md
@@ -184,6 +184,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allow_additional_role_assume"></a> [allow\_additional\_role\_assume](#input\_allow\_additional\_role\_assume) | A list of additional roles to allow assuming this role | `list(string)` | `[]` | no |
 | <a name="input_allow_self_assume_role"></a> [allow\_self\_assume\_role](#input\_allow\_self\_assume\_role) | Determines whether to allow the role to be [assume itself](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/) | `bool` | `false` | no |
 | <a name="input_amazon_managed_service_prometheus_workspace_arns"></a> [amazon\_managed\_service\_prometheus\_workspace\_arns](#input\_amazon\_managed\_service\_prometheus\_workspace\_arns) | List of AMP Workspace ARNs to read and write metrics | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_assume_role_condition_test"></a> [assume\_role\_condition\_test](#input\_assume\_role\_condition\_test) | Name of the [IAM condition operator](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html) to evaluate when assuming the role | `string` | `"StringEquals"` | no |

--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -14,6 +14,20 @@ data "aws_iam_policy_document" "this" {
   count = var.create_role ? 1 : 0
 
   dynamic "statement" {
+    for_each = var.allow_additional_role_assume
+
+    content {
+      effect = "Allow"
+      actions = ["sts:AssumeRole"]
+
+      principals {
+        identifiers = [statement.value]
+        type        = "AWS"
+      }
+    }
+  }
+
+  dynamic "statement" {
     # https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/
     for_each = var.allow_self_assume_role ? [1] : []
 
@@ -59,7 +73,6 @@ data "aws_iam_policy_document" "this" {
         variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:aud"
         values   = ["sts.amazonaws.com"]
       }
-
     }
   }
 }

--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "this" {
     for_each = var.allow_additional_role_assume
 
     content {
-      effect = "Allow"
+      effect  = "Allow"
       actions = ["sts:AssumeRole"]
 
       principals {

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -17,7 +17,6 @@ data "aws_iam_policy_document" "aws_gateway_controller" {
   }
 }
 
-
 resource "aws_iam_policy" "aws_gateway_controller" {
   count = var.create_role && var.attach_aws_gateway_controller_policy ? 1 : 0
 

--- a/modules/iam-role-for-service-accounts-eks/variables.tf
+++ b/modules/iam-role-for-service-accounts-eks/variables.tf
@@ -82,6 +82,12 @@ variable "allow_self_assume_role" {
   default     = false
 }
 
+variable "allow_additional_role_assume" {
+  description = "A list of additional roles to allow assuming this role"
+  type        = list(string)
+  default     = []
+}
+
 ################################################################################
 # Policies
 ################################################################################

--- a/wrappers/iam-read-only-policy/main.tf
+++ b/wrappers/iam-read-only-policy/main.tf
@@ -5,9 +5,9 @@ module "wrapper" {
 
   additional_policy_json       = try(each.value.additional_policy_json, var.defaults.additional_policy_json, "{}")
   allow_cloudwatch_logs_query  = try(each.value.allow_cloudwatch_logs_query, var.defaults.allow_cloudwatch_logs_query, true)
+  allowed_services             = try(each.value.allowed_services, var.defaults.allowed_services)
   allow_predefined_sts_actions = try(each.value.allow_predefined_sts_actions, var.defaults.allow_predefined_sts_actions, true)
   allow_web_console_services   = try(each.value.allow_web_console_services, var.defaults.allow_web_console_services, true)
-  allowed_services             = try(each.value.allowed_services, var.defaults.allowed_services)
   create_policy                = try(each.value.create_policy, var.defaults.create_policy, true)
   description                  = try(each.value.description, var.defaults.description, "IAM Policy")
   name                         = try(each.value.name, var.defaults.name, null)

--- a/wrappers/iam-read-only-policy/main.tf
+++ b/wrappers/iam-read-only-policy/main.tf
@@ -5,9 +5,9 @@ module "wrapper" {
 
   additional_policy_json       = try(each.value.additional_policy_json, var.defaults.additional_policy_json, "{}")
   allow_cloudwatch_logs_query  = try(each.value.allow_cloudwatch_logs_query, var.defaults.allow_cloudwatch_logs_query, true)
-  allowed_services             = try(each.value.allowed_services, var.defaults.allowed_services)
   allow_predefined_sts_actions = try(each.value.allow_predefined_sts_actions, var.defaults.allow_predefined_sts_actions, true)
   allow_web_console_services   = try(each.value.allow_web_console_services, var.defaults.allow_web_console_services, true)
+  allowed_services             = try(each.value.allowed_services, var.defaults.allowed_services)
   create_policy                = try(each.value.create_policy, var.defaults.create_policy, true)
   description                  = try(each.value.description, var.defaults.description, "IAM Policy")
   name                         = try(each.value.name, var.defaults.name, null)

--- a/wrappers/iam-role-for-service-accounts-eks/main.tf
+++ b/wrappers/iam-role-for-service-accounts-eks/main.tf
@@ -3,6 +3,7 @@ module "wrapper" {
 
   for_each = var.items
 
+  allow_additional_role_assume                                    = try(each.value.allow_additional_role_assume, var.defaults.allow_additional_role_assume, [])
   allow_self_assume_role                                          = try(each.value.allow_self_assume_role, var.defaults.allow_self_assume_role, false)
   amazon_managed_service_prometheus_workspace_arns                = try(each.value.amazon_managed_service_prometheus_workspace_arns, var.defaults.amazon_managed_service_prometheus_workspace_arns, ["*"])
   assume_role_condition_test                                      = try(each.value.assume_role_condition_test, var.defaults.assume_role_condition_test, "StringEquals")


### PR DESCRIPTION
## Description

This changes allows the user to pass role ARN's into the `iam-role-for-service-accounts-eks` module for allowing additional IAM roles to assume the created role.

## Motivation and Context

This change helps to facilitate some more complex setups in EKS where other roles need to access the IRSA enabled role.

For example: Keda autoscaler with pod identity authentication, where the Keda operator Pod (with IRSA enabled) will access the target (ScaledObject) Pod's attached role.

## Breaking Changes

None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request