### PR TITLE
feat(iam-role-for-service-accounts-eks): Add AWS China support

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -3,6 +3,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
+  audience            = data.aws_partition.current.partition == "aws-cn" ? "sts.amazonaws.com.cn" : "sts.amazonaws.com"
   account_id          = data.aws_caller_identity.current.account_id
   partition           = data.aws_partition.current.partition
   dns_suffix          = data.aws_partition.current.dns_suffix
@@ -57,7 +58,7 @@ data "aws_iam_policy_document" "this" {
       condition {
         test     = var.assume_role_condition_test
         variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:aud"
-        values   = ["sts.amazonaws.com"]
+        values   = [local.audience]
       }
 
     }


### PR DESCRIPTION
## Description
Enabling AWS China support for the EKS Service Accounts OIDC role.
Instead of using a hardcoded audience for the `iam-role-for-service-accounts-eks` trust policy, a calculated and based on `data.aws_partition` value will be applyed.

## Motivation and Context
Since STS service ID differs from Global AWS to China, the policy audience condition should be different as well:
`sts.amazonaws.com` => `sts.amazonaws.com.cn`

## Breaking Changes
No

## How Has This Been Tested?
- [x] ~I have updated at least one of the `examples/*` to demonstrate and validate my change(s)~ Not affected
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
