### PR TITLE
docs: Remove the invalid `provider` argument from the `oidc_providers` variable description

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/README.md
+++ b/modules/iam-role-for-service-accounts-eks/README.md
@@ -228,7 +228,7 @@ No modules.
 | <a name="input_load_balancer_controller_targetgroup_arns"></a> [load\_balancer\_controller\_targetgroup\_arns](#input\_load\_balancer\_controller\_targetgroup\_arns) | List of Target groups ARNs using Load Balancer Controller | `list(string)` | <pre>[<br>  "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"<br>]</pre> | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `null` | no |
 | <a name="input_node_termination_handler_sqs_queue_arns"></a> [node\_termination\_handler\_sqs\_queue\_arns](#input\_node\_termination\_handler\_sqs\_queue\_arns) | List of SQS ARNs that contain node termination events | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
-| <a name="input_oidc_providers"></a> [oidc\_providers](#input\_oidc\_providers) | Map of OIDC providers where each provider map should contain the `provider`, `provider_arn`, and `namespace_service_accounts` | `any` | `{}` | no |
+| <a name="input_oidc_providers"></a> [oidc\_providers](#input\_oidc\_providers) | Map of OIDC providers where each provider map should contain the `provider_arn` and `namespace_service_accounts` | `map(any)` | `{}` | no |
 | <a name="input_policy_name_prefix"></a> [policy\_name\_prefix](#input\_policy\_name\_prefix) | IAM policy name prefix | `string` | `"AmazonEKS_"` | no |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | IAM Role description | `string` | `null` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of IAM role | `string` | `null` | no |

--- a/modules/iam-role-for-service-accounts-eks/README.md
+++ b/modules/iam-role-for-service-accounts-eks/README.md
@@ -228,7 +228,7 @@ No modules.
 | <a name="input_load_balancer_controller_targetgroup_arns"></a> [load\_balancer\_controller\_targetgroup\_arns](#input\_load\_balancer\_controller\_targetgroup\_arns) | List of Target groups ARNs using Load Balancer Controller | `list(string)` | <pre>[<br>  "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"<br>]</pre> | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `null` | no |
 | <a name="input_node_termination_handler_sqs_queue_arns"></a> [node\_termination\_handler\_sqs\_queue\_arns](#input\_node\_termination\_handler\_sqs\_queue\_arns) | List of SQS ARNs that contain node termination events | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
-| <a name="input_oidc_providers"></a> [oidc\_providers](#input\_oidc\_providers) | Map of OIDC providers where each provider map should contain the `provider_arn` and `namespace_service_accounts` | `map(any)` | `{}` | no |
+| <a name="input_oidc_providers"></a> [oidc\_providers](#input\_oidc\_providers) | Map of OIDC providers where each provider map should contain the `provider_arn` and `namespace_service_accounts` | `any` | `{}` | no |
 | <a name="input_policy_name_prefix"></a> [policy\_name\_prefix](#input\_policy\_name\_prefix) | IAM policy name prefix | `string` | `"AmazonEKS_"` | no |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | IAM Role description | `string` | `null` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of IAM role | `string` | `null` | no |

--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -39,7 +39,6 @@ data "aws_iam_policy_document" "this" {
     for_each = var.oidc_providers
 
     content {
-      sid     = "OIDCRoleAssumption${index(var.oidc_providers, each.value) + 1}"
       effect  = "Allow"
       actions = ["sts:AssumeRoleWithWebIdentity"]
 

--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -39,6 +39,7 @@ data "aws_iam_policy_document" "this" {
     for_each = var.oidc_providers
 
     content {
+      sid     = "OIDCRoleAssumption${index(var.oidc_providers, each.value) + 1}"
       effect  = "Allow"
       actions = ["sts:AssumeRoleWithWebIdentity"]
 

--- a/modules/iam-role-for-service-accounts-eks/variables.tf
+++ b/modules/iam-role-for-service-accounts-eks/variables.tf
@@ -48,7 +48,7 @@ variable "role_policy_arns" {
 
 variable "oidc_providers" {
   description = "Map of OIDC providers where each provider map should contain the `provider_arn` and `namespace_service_accounts`"
-  type        = map(any)
+  type        = any
   default     = {}
 }
 

--- a/modules/iam-role-for-service-accounts-eks/variables.tf
+++ b/modules/iam-role-for-service-accounts-eks/variables.tf
@@ -47,8 +47,8 @@ variable "role_policy_arns" {
 }
 
 variable "oidc_providers" {
-  description = "Map of OIDC providers where each provider map should contain the `provider`, `provider_arn`, and `namespace_service_accounts`"
-  type        = any
+  description = "Map of OIDC providers where each provider map should contain the `provider_arn` and `namespace_service_accounts`"
+  type        = map(any)
   default     = {}
 }
 


### PR DESCRIPTION
## Description
The `provider` attribute is never accessed and thus shouldn't be listed. It also changes the type of `oidc_providers` from `any` to a `map(any)` because it is a map.

## Motivation and Context
It clutters the requirements for the variable and thus should be removed

## Breaking Changes
If someone used to pass something into `oidc_providers` it will now throw an error at an earlier stage of validation

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
