### PR TITLE
feat: add default role description

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -8,6 +8,25 @@ locals {
   dns_suffix          = data.aws_partition.current.dns_suffix
   region              = data.aws_region.current.name
   role_name_condition = var.role_name != null ? var.role_name : "${var.role_name_prefix}*"
+  default_description = var.attach_external_dns_policy ? "Provides OIDC provider access to Route53" :
+                        var.attach_aws_gateway_controller_policy ? "Provides OIDC provider access to AWS Gateway Controller" :
+                        var.attach_cert_manager_policy ? "Provides OIDC provider access to Cert Manager" :
+                        var.attach_cluster_autoscaler_policy ? "Provides OIDC provider access to Cluster Autoscaler" :
+                        var.attach_ebs_csi_policy ? "Provides OIDC provider access to EBS CSI" :
+                        var.attach_efs_csi_policy ? "Provides OIDC provider access to EFS CSI" :
+                        var.attach_external_secrets_policy ? "Provides OIDC provider access to Secrets Manager" :
+                        var.attach_fsx_lustre_csi_policy ? "Provides OIDC provider access to FSX" :
+                        var.attach_karpenter_controller_policy ? "Provides Karpenter access to EC2" :
+                        var.attach_load_balancer_controller_policy ? "Provides OIDC provider access to EC2 and Load Balancing" :
+                        var.attach_appmesh_controller_policy ? "Provides OIDC provider access to Appmesh, ACM, Service Discovery, and Route53" :
+                        var.attach_appmesh_envoy_proxy_policy ? "Provides OIDC provider access to Appmesh and ACM" :
+                        var.attach_amazon_managed_service_prometheus_policy ? "Provides OIDC provider access to APS" :
+                        var.attach_velero_policy ? "Provides OIDC provider access to EC2 and S3" :
+                        var.attach_vpc_cni_policy ? "Provides OIDC provider access to EC2" :
+                        var.attach_node_termination_handler_policy ? "Provides OIDC provider access to EC2 and SQS" :
+                        var.attach_cloudwatch_observability_policy ? "Provides OIDC provider access to CloudWatch and Xray" :
+                        null
+  role_description    = var.role_description == null ? local.default_description : var.role_description
 }
 
 data "aws_iam_policy_document" "this" {
@@ -70,7 +89,7 @@ resource "aws_iam_role" "this" {
   name        = var.role_name
   name_prefix = var.role_name_prefix
   path        = var.role_path
-  description = var.role_description
+  description = local.role_description
 
   assume_role_policy    = data.aws_iam_policy_document.this[0].json
   max_session_duration  = var.max_session_duration


### PR DESCRIPTION
## Description
Checks the `attach_*_policy` variable to add a fitting description for the role. Improvement on #453 

## Motivation and Context
Add a useful default description for the IAM role added

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
