### PR TITLE
feat: Support new mTLS feature in awslb IAM policy

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -788,6 +788,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "elasticloadbalancing:DescribeTargetGroupAttributes",
       "elasticloadbalancing:DescribeTargetHealth",
       "elasticloadbalancing:DescribeTags",
+      "elasticloadbalancing:DescribeTrustStores",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Description

Closes #457

## Motivation and Context

A new feature was added to [aws-load-balancer-controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller) in v2.7.0: [mutual TLS authentication support for Ingress](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3532).

This feature requires a new IAM policy permission: `elasticloadbalancing:DescribeTrustStores`.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
