### PR TITLE
feat: Allow users to set and read own access keys description (iam-group-with-policies)

### DIFF
--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -53,7 +53,10 @@ data "aws_iam_policy_document" "iam_self_management" {
       "iam:DeleteAccessKey",
       "iam:ListAccessKeys",
       "iam:UpdateAccessKey",
-      "iam:GetAccessKeyLastUsed"
+      "iam:GetAccessKeyLastUsed",
+      "iam:TagUser",
+      "iam:ListUserTags",
+      "iam:UntagUser",
     ]
 
     resources = [


### PR DESCRIPTION
## Description
This PR fixes default IAM permissions for user group created by `iam-group-with-policies` module, extending it to allow users set and read own access keys description when creating them via AWS Console.

## Motivation and Context
The issue with missing permissions was already addressed before by PR #287 , but the lines looks like were just lost after some major changes.

## Breaking Changes
None.

## How Has This Been Tested?
By applying the change to existing policies and checking AWS console.
