### PR TITLE
fix: Allow user to change own password when no MFA is present

### DIFF
--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -167,7 +167,8 @@ data "aws_iam_policy_document" "iam_self_management" {
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "sts:GetSessionToken"
+        "sts:GetSessionToken",
+        "iam:ChangePassword"
       ]
       resources = ["*"]
 


### PR DESCRIPTION
## Description
This allows a user to change their own password when no MFA is present on the account. This is only needed in once situation: when a new users signs in, and is then forced to choose a new password. The MFA isn't set up at that point, and the changing of the password is blocked.

## Motivation and Context
Currently users created with the iam_user and iam_group_with_policies are not able to sign in.
- Resolves #471 

## Breaking Changes
Don't think so

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request

I tested this manually using a new account
