### PR TITLE
fix: Remove duplicate API permission for Karpenter IRSA policy

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -670,7 +670,6 @@ data "aws_iam_policy_document" "karpenter_controller" {
       "ec2:CreateTags",
       "ec2:DescribeAvailabilityZones",
       "ec2:DescribeImages",
-      "ec2:DescribeImages",
       "ec2:DescribeInstances",
       "ec2:DescribeInstanceTypeOfferings",
       "ec2:DescribeInstanceTypes",


### PR DESCRIPTION
## Description
Remove a duplicate line

## Motivation and Context
Found a duplicate line, does not affect anything but readability.

## Breaking Changes
None

## How Has This Been Tested?
Implemented this change in my AWS IAM Policy with no issues (line is a duplicate).
