### PR TITLE
Remove excess SQS permissions

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -760,7 +760,6 @@ data "aws_iam_policy_document" "karpenter_controller" {
     content {
       actions = [
         "sqs:DeleteMessage",
-        "sqs:GetQueueAttributes",
         "sqs:GetQueueUrl",
         "sqs:ReceiveMessage",
       ]


### PR DESCRIPTION
This permission is no longer required per karpenter documentation: https://github.com/aws/karpenter-provider-aws/blob/v0.35.2/website/content/en/docs/reference/cloudformation.md?plain=1#L345-L354

## Description
Removed a single line providing excess permissions for Karpenter per Karpenter documentation: https://github.com/aws/karpenter-provider-aws/blob/v0.35.2/website/content/en/docs/reference/cloudformation.md?plain=1#L345-L354

## Motivation and Context
Came across this difference when setting up Karpenter SQS based spot interruption monitoring

## Breaking Changes
Removing this line brings the code in line with the official Karpenter documentation. Removing it does not have any negative effects on functionality when tested on my Karpenter deployment.

## How Has This Been Tested?
Removing this line does not have any negative effects on functionality when tested on my Karpenter deployment
