### PR TITLE
feat: Update VPC CNI policy to 3/4/24

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -1443,9 +1443,10 @@ data "aws_iam_policy_document" "vpc_cni" {
         "ec2:DescribeTags",
         "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeInstanceTypes",
+        "ec2:DescribeSubnets",
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",
-        "ec2:UnassignPrivateIpAddresses",
+        "ec2:UnassignPrivateIpAddresses"
       ]
       resources = ["*"]
     }


### PR DESCRIPTION
Update VPC CNI policy to version released on 3/4/24. https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEKS_CNI_Policy.html

## Description
The VPC CNI policy is missing `ec2:DescribeSubnets ` from the updated policy.

## Motivation and Context
The AWS managed VPC CNI 1.18.0 uses ec2:DescribeSubnets.

## Breaking Changes
Updates VPC CNI policy.
Open issue: https://github.com/terraform-aws-modules/terraform-aws-iam/issues/474

## How Has This Been Tested?
- I have tested with a local project. This is the Terraform plan. It shows `ec2:DescribeSubnets` being added.
```
# module.eks.module.vpc_cni_irsa_role.aws_iam_policy.vpc_cni[0] will be updated in-place
  ~ resource "aws_iam_policy" "vpc_cni" {
        id          = "arn:aws:iam::<redacted>:policy/AmazonEKS_CNI_Policy-20240117193907447200000001"
        name        = "AmazonEKS_CNI_Policy-20240117193907447200000001"
      ~ policy      = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action   = [
                            # (3 unchanged elements hidden)
                            "ec2:DescribeTags",
                          + "ec2:DescribeSubnets",
                            "ec2:DescribeNetworkInterfaces",
                            # (6 unchanged elements hidden)
                        ]
                        # (3 unchanged attributes hidden)
                    },
                    {
                        Action   = "ec2:CreateTags"
                        Effect   = "Allow"
                        Resource = "arn:aws:ec2:*:*:network-interface/*"
                        Sid      = "CreateTags"
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags        = {}
        # (6 unchanged attributes hidden)
    }
```
