### PR TITLE
feat: Create group with optional assumable roles

### DIFF
--- a/examples/iam-group-w-policy-and-opt-roles/README.md
+++ b/examples/iam-group-w-policy-and-opt-roles/README.md
@@ -1,0 +1,56 @@
+# IAM Group with policies and optional assumable roles
+
+Configuration in this directory creates IAM group with users who have IAM policies AND 
+optionally assumable roles.
+
+This is a combination of `iam-group-with-assumable-roles-policy` and `iam-group-with-policies` 
+exampled. The difference from the "complete" example is that assumable-roles list can be empty.  
+
+# Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_iam_group_complete"></a> [iam\_group\_complete](#module\_iam\_group\_complete) | ../../modules/iam-group-with-assumable-roles-policy | n/a |
+| <a name="module_iam_group_complete_with_custom_policy"></a> [iam\_group\_complete\_with\_custom\_policy](#module\_iam\_group\_complete\_with\_custom\_policy) | ../../modules/iam-group-with-policies | n/a |
+| <a name="module_iam_user1"></a> [iam\_user1](#module\_iam\_user1) | ../../modules/iam-user | n/a |
+| <a name="module_iam_user2"></a> [iam\_user2](#module\_iam\_user2) | ../../modules/iam-user | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_assumable_roles"></a> [assumable\_roles](#output\_assumable\_roles) | List of ARNs of IAM roles which members of IAM group can assume |
+| <a name="output_group_users"></a> [group\_users](#output\_group\_users) | List of IAM users in IAM group |
+| <a name="output_policy_arn"></a> [policy\_arn](#output\_policy\_arn) | Assume role policy ARN for IAM group |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam-group-w-policy-and-opt-roles/README.md
+++ b/examples/iam-group-w-policy-and-opt-roles/README.md
@@ -1,10 +1,10 @@
 # IAM Group with policies and optional assumable roles
 
-Configuration in this directory creates IAM group with users who have IAM policies AND 
+Configuration in this directory creates IAM group with users who have IAM policies AND
 optionally assumable roles.
 
-This is a combination of `iam-group-with-assumable-roles-policy` and `iam-group-with-policies` 
-exampled. The difference from the "complete" example is that assumable-roles list can be empty.  
+This is a combination of `iam-group-with-assumable-roles-policy` and `iam-group-with-policies`
+exampled. The difference from the "complete" example is that assumable-roles list can be empty.
 
 # Usage
 
@@ -33,8 +33,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_group_complete"></a> [iam\_group\_complete](#module\_iam\_group\_complete) | ../../modules/iam-group-with-assumable-roles-policy | n/a |
-| <a name="module_iam_group_complete_with_custom_policy"></a> [iam\_group\_complete\_with\_custom\_policy](#module\_iam\_group\_complete\_with\_custom\_policy) | ../../modules/iam-group-with-policies | n/a |
+| <a name="module_iam_group_optional_assumable_roles"></a> [iam\_group\_optional\_assumable\_roles](#module\_iam\_group\_optional\_assumable\_roles) | ../../modules/iam-group-with-assumable-roles-policy | n/a |
+| <a name="module_iam_group_with_custom_policy"></a> [iam\_group\_with\_custom\_policy](#module\_iam\_group\_with\_custom\_policy) | ../../modules/iam-group-with-policies | n/a |
 | <a name="module_iam_user1"></a> [iam\_user1](#module\_iam\_user1) | ../../modules/iam-user | n/a |
 | <a name="module_iam_user2"></a> [iam\_user2](#module\_iam\_user2) | ../../modules/iam-user | n/a |
 
@@ -44,7 +44,9 @@ No resources.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_assumable_roles"></a> [assumable\_roles](#input\_assumable\_roles) | (possibly empty) List of ARNS for roles assumable by this group | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/examples/iam-group-w-policy-and-opt-roles/main.tf
+++ b/examples/iam-group-w-policy-and-opt-roles/main.tf
@@ -1,0 +1,49 @@
+############
+# IAM users
+############
+module "iam_user1" {
+  source = "../../modules/iam-user"
+
+  name = "user1"
+
+  create_iam_user_login_profile = false
+  create_iam_access_key         = false
+}
+
+module "iam_user2" {
+  source = "../../modules/iam-user"
+
+  name = "user2"
+
+  create_iam_user_login_profile = false
+  create_iam_access_key         = false
+}
+
+####################################################
+# Extending policies of IAM group production-admins
+####################################################
+module "iam_group_with_custom_policy" {
+  source = "../../modules/iam-group-with-policies"
+
+  name = "production-admins"
+
+  custom_group_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+  ]
+  group_users = [
+    module.iam_user1.iam_user_name,
+    module.iam_user2.iam_user_name,
+  ]
+}
+
+#############################################################################################
+# IAM group where user1 and user2 are allowed to assume admin role in production AWS account
+#############################################################################################
+module "iam_group_optional_assumable_roles" {
+  source = "../../modules/iam-group-with-assumable-roles-policy"
+
+  name            = module.iam_group_with_custom_policy.group_name
+  create_group    = length(var.assumable_roles) > 0
+  assumable_roles = var.assumable_roles
+}
+

--- a/examples/iam-group-w-policy-and-opt-roles/main.tf
+++ b/examples/iam-group-w-policy-and-opt-roles/main.tf
@@ -46,4 +46,3 @@ module "iam_group_optional_assumable_roles" {
   create_group    = length(var.assumable_roles) > 0
   assumable_roles = var.assumable_roles
 }
-

--- a/examples/iam-group-w-policy-and-opt-roles/outputs.tf
+++ b/examples/iam-group-w-policy-and-opt-roles/outputs.tf
@@ -1,0 +1,14 @@
+output "group_users" {
+  description = "List of IAM users in IAM group"
+  value       = module.iam_group_with_custom_policy.group_users
+}
+
+output "assumable_roles" {
+  description = "List of ARNs of IAM roles which members of IAM group can assume"
+  value       = module.iam_group_optional_assumable_roles.assumable_roles
+}
+
+output "policy_arn" {
+  description = "Assume role policy ARN for IAM group"
+  value       = module.iam_group_optional_assumable_roles.policy_arn
+}

--- a/examples/iam-group-w-policy-and-opt-roles/terraform.tfvars
+++ b/examples/iam-group-w-policy-and-opt-roles/terraform.tfvars
@@ -1,0 +1,2 @@
+# assumable_roles = ["arn:aws:iam::111111111111:role/admin"]
+assumable_roles = []

--- a/examples/iam-group-w-policy-and-opt-roles/variables.tf
+++ b/examples/iam-group-w-policy-and-opt-roles/variables.tf
@@ -1,0 +1,5 @@
+variable "assumable_roles" {
+  type        = list(string)
+  description = "List of ARNS for roles assumable by this group"
+  default     = []
+}

--- a/examples/iam-group-w-policy-and-opt-roles/variables.tf
+++ b/examples/iam-group-w-policy-and-opt-roles/variables.tf
@@ -1,5 +1,5 @@
 variable "assumable_roles" {
   type        = list(string)
-  description = "List of ARNS for roles assumable by this group"
+  description = "(possibly empty) List of ARNS for roles assumable by this group"
   default     = []
 }

--- a/examples/iam-group-w-policy-and-opt-roles/versions.tf
+++ b/examples/iam-group-w-policy-and-opt-roles/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.0"
+}

--- a/modules/iam-group-with-assumable-roles-policy/README.md
+++ b/modules/iam-group-with-assumable-roles-policy/README.md
@@ -28,6 +28,7 @@ No modules.
 | [aws_iam_group_membership.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_membership) | resource |
 | [aws_iam_group_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_group.ref_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_group) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -36,6 +37,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_assumable_roles"></a> [assumable\_roles](#input\_assumable\_roles) | List of IAM roles ARNs which can be assumed by the group | `list(string)` | `[]` | no |
 | <a name="input_assumable_roles_policy_name_suffix"></a> [assumable\_roles\_policy\_name\_suffix](#input\_assumable\_roles\_policy\_name\_suffix) | Append this name to the policy name that will be created for assuming the given roles (default: null -- the policy name will be group name) | `string` | `""` | no |
+| <a name="input_create_group"></a> [create\_group](#input\_create\_group) | Whether to create IAM group | `bool` | `true` | no |
 | <a name="input_group_users"></a> [group\_users](#input\_group\_users) | List of IAM users to have in an IAM group which can assume the role | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of IAM policy and IAM group | `string` | n/a | yes |
 | <a name="input_path"></a> [path](#input\_path) | Path of IAM policy and IAM group | `string` | `"/"` | no |

--- a/modules/iam-group-with-assumable-roles-policy/main.tf
+++ b/modules/iam-group-with-assumable-roles-policy/main.tf
@@ -1,3 +1,7 @@
+locals {
+  group_name = var.create_group ? aws_iam_group.this[0].id : var.name
+}
+
 data "aws_iam_policy_document" "assume_role" {
   statement {
     effect    = "Allow"
@@ -7,7 +11,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_policy" "this" {
-  name        = "${var.name}${var.assumable_roles_policy_name_suffix}"
+  name        = "${local.group_name}${var.assumable_roles_policy_name_suffix}"
   path        = var.path
   description = "Allows to assume role in another AWS account"
   policy      = data.aws_iam_policy_document.assume_role.json
@@ -16,19 +20,21 @@ resource "aws_iam_policy" "this" {
 }
 
 resource "aws_iam_group" "this" {
+  count = var.create_group ? 1 : 0
+
   name = var.name
   path = var.path
 }
 
 resource "aws_iam_group_policy_attachment" "this" {
-  group      = aws_iam_group.this.id
+  group      = local.group_name
   policy_arn = aws_iam_policy.this.id
 }
 
 resource "aws_iam_group_membership" "this" {
   count = length(var.group_users) > 0 ? 1 : 0
 
-  group = aws_iam_group.this.id
-  name  = var.name
+  group = local.group_name
+  name  = local.group_name
   users = var.group_users
 }

--- a/modules/iam-group-with-assumable-roles-policy/outputs.tf
+++ b/modules/iam-group-with-assumable-roles-policy/outputs.tf
@@ -15,10 +15,15 @@ output "policy_arn" {
 
 output "group_name" {
   description = "IAM group name"
-  value       = aws_iam_group.this.name
+  value       = local.group_name
+}
+
+data "aws_iam_group" "ref_group" {
+  count = var.create_group ? 0 : 1
+  group_name = var.name
 }
 
 output "group_arn" {
   description = "IAM group arn"
-  value       = aws_iam_group.this.arn
+  value       = try(aws_iam_group.this[0].arn, data.aws_iam_group.ref_group[0].arn)
 }

--- a/modules/iam-group-with-assumable-roles-policy/outputs.tf
+++ b/modules/iam-group-with-assumable-roles-policy/outputs.tf
@@ -19,7 +19,7 @@ output "group_name" {
 }
 
 data "aws_iam_group" "ref_group" {
-  count = var.create_group ? 0 : 1
+  count      = var.create_group ? 0 : 1
   group_name = var.name
 }
 

--- a/modules/iam-group-with-assumable-roles-policy/variables.tf
+++ b/modules/iam-group-with-assumable-roles-policy/variables.tf
@@ -1,3 +1,9 @@
+variable "create_group" {
+  description = "Whether to create IAM group"
+  type        = bool
+  default     = true
+}
+
 variable "name" {
   description = "Name of IAM policy and IAM group"
   type        = string

--- a/wrappers/iam-group-with-assumable-roles-policy/main.tf
+++ b/wrappers/iam-group-with-assumable-roles-policy/main.tf
@@ -5,6 +5,7 @@ module "wrapper" {
 
   assumable_roles                    = try(each.value.assumable_roles, var.defaults.assumable_roles, [])
   assumable_roles_policy_name_suffix = try(each.value.assumable_roles_policy_name_suffix, var.defaults.assumable_roles_policy_name_suffix, "")
+  create_group                       = try(each.value.create_group, var.defaults.create_group, true)
   group_users                        = try(each.value.group_users, var.defaults.group_users, [])
   name                               = try(each.value.name, var.defaults.name)
   path                               = try(each.value.path, var.defaults.path, "/")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add `create_group` to `iam-group-with-assumable-roles-policy`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Sorry this is a bit long, because I need to show by example. 

Currently, `iam-group-with-policies` has `create_group` but `iam-group-with-assumable-roles-policy` does not, yet `iam-group-with-assumable-roles-policy` fails plan if its list of assumable roles is empty. We need IAM groups that can have policies and *optionally* have assumable roles, which from your _master_ branch, we achieved by using the `iam-group-complete` example as basis and editing:
```
locals {
  create_group_with_assumable_roles = (var.assumable_roles != [])
}

module "iam_group2" {
  count = local.create_group_with_assumable_roles ? 1 : 0

  source = "../../modules/iam-group-with-assumable-roles-policy"
  name   = var.group_name

  assumable_roles = var.assumable_roles
}

module "iam_group_default2" {
  source       = "../../modules/iam-group-with-policies"
  name         = local.create_group_with_assumable_roles ? module.iam_group2[0].group_name : var.group_name
  create_group = !local.create_group_with_assumable_roles

  attach_iam_self_management_policy = false
  custom_group_policy_arns          = var.policy_arns
}
```
This has a local because the expression would otherwise be used in 3 places, it has a module count, and conditional logic on 2 attributes of the group-with-policies. 

Sufficient code to achieve same on PR branch, where `create_group` is available on the `iam-group-with-assumable-roles-policy`:
```
module "iam_group3" {
  source = "../../modules/iam-group-with-policies"
  name   = var.group_name

  attach_iam_self_management_policy = false
  custom_group_policy_arns          = var.policy_arns
}

module "iam_group_roles3" {
  source       = "../../modules/iam-group-with-assumable-roles-policy"
  name         = module.iam_group3.group_name
  create_group = length(var.assumable_roles) > 0

  assumable_roles = var.assumable_roles
}
```
No local, count, or logic. It is clean and simple to understand what is happening for anyone maintaining this code.

Note: I alternatively considered extending the `iam-group-with-assumable-roles-policy` module to allow an empty list of roles instead of `create_group`. However, I believe it is more natural to think of the "basic" group as a group with policies (when do you ever have a group without at least one policy!), and assumable roles as *extra* for the subset of groups where members need ability to assume roles. 

That being said, the iam-group-with-policies has `create_group` AND supports empty list of policies, why shouldn't `iam-group-with-assumable-roles-policy` have both too? In this PR, I only implemented `create_group`. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None, at least for terraform [1.1+ since even in 1.1 it had the ability to auto propose](https://developer.hashicorp.com/terraform/language/v1.1.x/modules/develop/refactoring) `resource` -> `resource[0]` after adding a count to an existing resource, which is what happened here for the `aws_iam_group.this`. None of the existing examples break, as I verified for terraform 1.8 as explained below. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I verified by terraform apply on master with tf 1.8, then switching to my branch and running terraform plan: terraform auto detects the need for some moves and plans no changes, this is a documented feature. 