### PR TITLE
feat: Add dynamic block to support job_workflow_ref

### DIFF
--- a/examples/iam-github-oidc/README.md
+++ b/examples/iam-github-oidc/README.md
@@ -35,6 +35,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_iam_github_oidc_job_workflow_refs"></a> [iam\_github\_oidc\_job\_workflow\_refs](#module\_iam\_github\_oidc\_job\_workflow\_refs) | ../../modules/iam-github-oidc-role | n/a |
 | <a name="module_iam_github_oidc_provider"></a> [iam\_github\_oidc\_provider](#module\_iam\_github\_oidc\_provider) | ../../modules/iam-github-oidc-provider | n/a |
 | <a name="module_iam_github_oidc_provider_disabled"></a> [iam\_github\_oidc\_provider\_disabled](#module\_iam\_github\_oidc\_provider\_disabled) | ../../modules/iam-github-oidc-provider | n/a |
 | <a name="module_iam_github_oidc_role"></a> [iam\_github\_oidc\_role](#module\_iam\_github\_oidc\_role) | ../../modules/iam-github-oidc-role | n/a |

--- a/examples/iam-github-oidc/main.tf
+++ b/examples/iam-github-oidc/main.tf
@@ -61,6 +61,33 @@ module "iam_github_oidc_role_disabled" {
 }
 
 ################################################################################
+# GitHub OIDC Role w/ fine-grained job_workflow_refs
+################################################################################
+
+module "iam_github_oidc_job_workflow_refs" {
+  source = "../../modules/iam-github-oidc-role"
+
+  name   = "${local.name}-job-workflow-refs"
+  create = true
+
+  policies = {
+    S3ReadOnly = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  }
+
+  # We can still say "I only want these repos to be the only principals"
+  subjects = [
+    "repo:terraform-aws-modules/terraform-aws-iam:pull_request",
+    "terraform-aws-modules/terraform-aws-iam:ref:refs/heads/master",
+  ]
+
+  # But we can now say "Only allow them to be the principal if they're running an approved workflow from this branch"
+  job_workflow_refs = [
+    "terraform-aws-modules/terraform-aws-iam/.github/workflows/pre-commit.yml@refs/heads/main",
+    "terraform-aws-modules/terraform-aws-iam/.github/workflows/pr-title@refs/heads/main",
+  ]
+}
+
+################################################################################
 # Supporting Resources
 ################################################################################
 

--- a/modules/iam-github-oidc-role/README.md
+++ b/modules/iam-github-oidc-role/README.md
@@ -86,6 +86,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | IAM Role description | `string` | `null` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `true` | no |
+| <a name="input_job_workflow_refs"></a> [job\_workflow\_refs](#input\_job\_workflow\_refs) | List of references to workflows that should be allowed to assume an OIDC role. Allows fine-grained workflow access to an AWS account. Example `['octo-org/reusable-workflows/.github/workflows/ci-terraform.yml@refs/heads/main']` | `list(string)` | `[]` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of IAM role | `string` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | IAM role name prefix | `string` | `null` | no |

--- a/modules/iam-github-oidc-role/main.tf
+++ b/modules/iam-github-oidc-role/main.tf
@@ -47,6 +47,15 @@ data "aws_iam_policy_document" "this" {
       # Strip `repo:` to normalize for cases where users may prepend it
       values = [for subject in var.subjects : "repo:${trimprefix(subject, "repo:")}"]
     }
+
+    dynamic "condition" {
+      for_each = length(var.job_workflow_refs) > 0 ? [1] : []
+      content {
+        test     = "ForAllValues:StringEquals"
+        variable = "${local.provider_url}:job_workflow_ref"
+        values   = var.job_workflow_ref
+      }
+    }
   }
 }
 

--- a/modules/iam-github-oidc-role/variables.tf
+++ b/modules/iam-github-oidc-role/variables.tf
@@ -74,6 +74,12 @@ variable "subjects" {
   default     = []
 }
 
+variable "job_workflow_refs" {
+  description = "List of references to workflows that should be allowed to assume an OIDC role. Allows fine-grained workflow access to an AWS account. Example `['octo-org/reusable-workflows/.github/workflows/ci-terraform.yml@refs/heads/main']`"
+  type        = list(string)
+  default     = []
+}
+
 variable "provider_url" {
   description = "The URL of the identity provider. Corresponds to the iss claim"
   type        = string

--- a/wrappers/iam-github-oidc-role/main.tf
+++ b/wrappers/iam-github-oidc-role/main.tf
@@ -7,6 +7,7 @@ module "wrapper" {
   create                   = try(each.value.create, var.defaults.create, true)
   description              = try(each.value.description, var.defaults.description, null)
   force_detach_policies    = try(each.value.force_detach_policies, var.defaults.force_detach_policies, true)
+  job_workflow_refs        = try(each.value.job_workflow_refs, var.defaults.job_workflow_refs, [])
   max_session_duration     = try(each.value.max_session_duration, var.defaults.max_session_duration, null)
   name                     = try(each.value.name, var.defaults.name, null)
   name_prefix              = try(each.value.name_prefix, var.defaults.name_prefix, null)


### PR DESCRIPTION
## Description
This PR adds a dynamic block and optional variable to support specifying a set of allowed `job_workflow_ref` to allow fine-grained access to a github OIDC role.

## Motivation and Context
Currently, the github OIDC role module doesn't support passing `job_workflow_ref` to explicitly allow a limited set of workflows to assume an AWS IAM role through OIDC. The potential impact of this is that using this module, someone would be able to fork one of our github workflows, change the business logic and still have no issues assuming the IAM role.

At HPE, we have a local version of this module which allows us to say "only allow a workflow to assume this IAM role if it's coming from the main branch of our organisation-wide reusable-workflows", which isn't possible in the main branch of this module due to the lack of support.

## Breaking Changes
n/a, this adds a new optional variable so should extend the current functionality for those who require this feature

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] This is running in production at HPE
- [x] I have executed pre-commit run -a on my pull request
