### PR TITLE
feat: Allow changing iss for the github oidc role

### DIFF
--- a/modules/iam-github-oidc-role/main.tf
+++ b/modules/iam-github-oidc-role/main.tf
@@ -31,8 +31,8 @@ data "aws_iam_policy_document" "this" {
 
     condition {
       test     = "ForAllValues:StringEquals"
-      variable = "token.actions.githubusercontent.com:iss"
-      values   = ["https://token.actions.githubusercontent.com"]
+      variable = "${local.provider_url}:iss"
+      values   = ["https://${local.provider_url}"]
     }
 
     condition {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

We are in need of having the enterprise suffix in our github oidc. This change should allow us to use the terraform-aws-iam submodule with ease.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There are github users which use the enterprise path in the github issuer field.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
