### PR TITLE
fix!: Defaults `false` for `enable_mfa_enforcement` for IAM groups

### DIFF
--- a/modules/iam-group-with-policies/README.md
+++ b/modules/iam-group-with-policies/README.md
@@ -44,7 +44,7 @@ No modules.
 | <a name="input_create_group"></a> [create\_group](#input\_create\_group) | Whether to create IAM group | `bool` | `true` | no |
 | <a name="input_custom_group_policies"></a> [custom\_group\_policies](#input\_custom\_group\_policies) | List of maps of inline IAM policies to attach to IAM group. Should have `name` and `policy` keys in each element. | `list(map(string))` | `[]` | no |
 | <a name="input_custom_group_policy_arns"></a> [custom\_group\_policy\_arns](#input\_custom\_group\_policy\_arns) | List of IAM policies ARNs to attach to IAM group | `list(string)` | `[]` | no |
-| <a name="input_enable_mfa_enforcement"></a> [enable\_mfa\_enforcement](#input\_enable\_mfa\_enforcement) | Determines whether permissions are added to the policy which requires the groups IAM users to use MFA | `bool` | `true` | no |
+| <a name="input_enable_mfa_enforcement"></a> [enable\_mfa\_enforcement](#input\_enable\_mfa\_enforcement) | Determines whether permissions are added to the policy which requires the groups IAM users to use MFA. Warning: If set to `true`, users without MFA in this group will be denied access to resources, even though permissions are given. | `bool` | `false` | no |
 | <a name="input_group_users"></a> [group\_users](#input\_group\_users) | List of IAM users to have in an IAM group which can assume the role | `list(string)` | `[]` | no |
 | <a name="input_iam_self_management_policy_name_prefix"></a> [iam\_self\_management\_policy\_name\_prefix](#input\_iam\_self\_management\_policy\_name\_prefix) | Name prefix for IAM policy to create with IAM self-management permissions | `string` | `"IAMSelfManagement-"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of IAM group | `string` | `""` | no |

--- a/modules/iam-group-with-policies/variables.tf
+++ b/modules/iam-group-with-policies/variables.tf
@@ -35,9 +35,9 @@ variable "custom_group_policies" {
 }
 
 variable "enable_mfa_enforcement" {
-  description = "Determines whether permissions are added to the policy which requires the groups IAM users to use MFA"
+  description = "Determines whether permissions are added to the policy which requires the groups IAM users to use MFA. Warning: If set to `true`, users without MFA in this group will be denied access to resources, even though permissions are given."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "attach_iam_self_management_policy" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Resolves #509

Defaults `enable_mfa_enforcement` to `false` as it should be an opt-in feature.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Users migrating from older version (example version 5.3.1) to current version may find that IAM groups users with `attach_iam_self_management_policy` set to `true` suddenly lose access to their consoles, which can cause more harm than good.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

This change should maintain backward compatibility for users migrating from versions prior to 5.14.3. However, users having versions 5.14.3 and beyond may find that MFA enforcement no longer being enforced by default, requiring `enable_mfa_enforcement` to be explicitly set to `true`.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
