### PR TITLE
feat: Add support for trusted roles in iam-assumable-role-with-oidc

### DIFF
--- a/examples/iam-assumable-role-with-oidc/README.md
+++ b/examples/iam-assumable-role-with-oidc/README.md
@@ -34,6 +34,8 @@ No providers.
 | <a name="module_iam_assumable_role_inline_policy"></a> [iam\_assumable\_role\_inline\_policy](#module\_iam\_assumable\_role\_inline\_policy) | ../../modules/iam-assumable-role-with-oidc | n/a |
 | <a name="module_iam_assumable_role_provider_trust_policy_conditions"></a> [iam\_assumable\_role\_provider\_trust\_policy\_conditions](#module\_iam\_assumable\_role\_provider\_trust\_policy\_conditions) | ../../modules/iam-assumable-role-with-oidc | n/a |
 | <a name="module_iam_assumable_role_self_assume"></a> [iam\_assumable\_role\_self\_assume](#module\_iam\_assumable\_role\_self\_assume) | ../../modules/iam-assumable-role-with-oidc | n/a |
+| <a name="module_iam_assumable_role_with_trusted_actions"></a> [iam\_assumable\_role\_with\_trusted\_actions](#module\_iam\_assumable\_role\_with\_trusted\_actions) | ../../modules/iam-assumable-role-with-oidc | n/a |
+| <a name="module_iam_assumable_role_with_trusted_roles"></a> [iam\_assumable\_role\_with\_trusted\_roles](#module\_iam\_assumable\_role\_with\_trusted\_roles) | ../../modules/iam-assumable-role-with-oidc | n/a |
 
 ## Resources
 

--- a/examples/iam-assumable-role-with-oidc/main.tf
+++ b/examples/iam-assumable-role-with-oidc/main.tf
@@ -120,3 +120,57 @@ module "iam_assumable_role_provider_trust_policy_conditions" {
     }
   ]
 }
+
+#####################################
+# IAM assumable role with trusted role
+#####################################
+module "iam_assumable_role_with_trusted_roles" {
+  source = "../../modules/iam-assumable-role-with-oidc"
+
+  create_role = true
+  role_name   = "role-with-trusted-roles"
+
+  tags = {
+    Role = "role-with-trusted-roles"
+  }
+
+  provider_url                   = "oidc.circleci.com/org/<CIRCLECI_ORG_UUID>"
+  oidc_fully_qualified_audiences = ["<CIRCLECI_ORG_UUID>"]
+
+  trusted_role_arns = [
+    "arn:aws:iam::307990089504:root",
+  ]
+
+  role_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser",
+  ]
+}
+
+#####################################
+# IAM assumable role with trusted role
+#####################################
+module "iam_assumable_role_with_trusted_actions" {
+  source = "../../modules/iam-assumable-role-with-oidc"
+
+  create_role = true
+  role_name   = "role-with-trusted-actions"
+
+  tags = {
+    Role = "role-with-trusted-actions"
+  }
+
+  provider_url                   = "oidc.circleci.com/org/<CIRCLECI_ORG_UUID>"
+  oidc_fully_qualified_audiences = ["<CIRCLECI_ORG_UUID>"]
+
+  trusted_role_arns = [
+    "arn:aws:iam::307990089504:root",
+  ]
+
+  trusted_role_actions = [
+    "sts:AssumeRole"
+  ]
+
+  role_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser",
+  ]
+}

--- a/modules/iam-assumable-role-with-oidc/README.md
+++ b/modules/iam-assumable-role-with-oidc/README.md
@@ -60,6 +60,8 @@ No modules.
 | <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `""` | no |
 | <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of ARNs of IAM policies to attach to IAM role | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
+| <a name="input_trusted_role_actions"></a> [trusted\_role\_actions](#input\_trusted\_role\_actions) | Additional trusted role actions | `list(string)` | <pre>[<br>  "sts:AssumeRole",<br>  "sts:TagSession"<br>]</pre> | no |
+| <a name="input_trusted_role_arns"></a> [trusted\_role\_arns](#input\_trusted\_role\_arns) | ARNs of AWS entities who can assume these roles | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -39,6 +39,20 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
   }
 
   dynamic "statement" {
+    for_each = length(var.trusted_role_arns) > 0 ? [1] : []
+
+    content {
+      effect  = "Allow"
+      actions = var.trusted_role_actions
+
+      principals {
+        type        = "AWS"
+        identifiers = var.trusted_role_arns
+      }
+    }
+  }
+
+  dynamic "statement" {
     for_each = local.urls
 
     content {

--- a/modules/iam-assumable-role-with-oidc/variables.tf
+++ b/modules/iam-assumable-role-with-oidc/variables.tf
@@ -22,6 +22,18 @@ variable "aws_account_id" {
   default     = ""
 }
 
+variable "trusted_role_actions" {
+  description = "Additional trusted role actions"
+  type        = list(string)
+  default     = ["sts:AssumeRole", "sts:TagSession"]
+}
+
+variable "trusted_role_arns" {
+  description = "ARNs of AWS entities who can assume these roles"
+  type        = list(string)
+  default     = []
+}
+
 variable "tags" {
   description = "A map of tags to add to IAM role resources"
   type        = map(string)

--- a/wrappers/iam-assumable-role-with-oidc/main.tf
+++ b/wrappers/iam-assumable-role-with-oidc/main.tf
@@ -23,4 +23,6 @@ module "wrapper" {
   role_permissions_boundary_arn    = try(each.value.role_permissions_boundary_arn, var.defaults.role_permissions_boundary_arn, "")
   role_policy_arns                 = try(each.value.role_policy_arns, var.defaults.role_policy_arns, [])
   tags                             = try(each.value.tags, var.defaults.tags, {})
+  trusted_role_actions             = try(each.value.trusted_role_actions, var.defaults.trusted_role_actions, ["sts:AssumeRole", "sts:TagSession"])
+  trusted_role_arns                = try(each.value.trusted_role_arns, var.defaults.trusted_role_arns, [])
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Extended functionality of `iam-assumable-role-with-oidc` to also allow assuming the role by trusted AWS principals
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In some cases, it's needed to extend the trust policy of a role that gets assumed with OIDC to also be assumed by trusted principals in AWS. In my case, I need to allow some principals to assume the target roles locally without using OIDC, while maintaining the ability for a federated assumed role and without duplicating the role with different trust policies.
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None
## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
