### PR TITLE
feat: Allow modifying the `iam-github-oidc-role` subject condition

### DIFF
--- a/modules/iam-github-oidc-role/README.md
+++ b/modules/iam-github-oidc-role/README.md
@@ -93,6 +93,7 @@ No modules.
 | <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `null` | no |
 | <a name="input_policies"></a> [policies](#input\_policies) | Policies to attach to the IAM role in `{'static_name' = 'policy_arn'}` format | `map(string)` | `{}` | no |
 | <a name="input_provider_url"></a> [provider\_url](#input\_provider\_url) | The URL of the identity provider. Corresponds to the iss claim | `string` | `"token.actions.githubusercontent.com"` | no |
+| <a name="input_subject_condition"></a> [subject\_condition](#input\_subject\_condition) | Condition to use for the GitHub OIDC role. Defaults to `StringLike` | `string` | `"StringLike"` | no |
 | <a name="input_subjects"></a> [subjects](#input\_subjects) | List of GitHub OIDC subjects that are permitted by the trust policy. You do not need to prefix with `repo:` as this is provided. Example: `['my-org/my-repo:*', 'octo-org/octo-repo:ref:refs/heads/octo-branch']` | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources created | `map(any)` | `{}` | no |
 

--- a/modules/iam-github-oidc-role/main.tf
+++ b/modules/iam-github-oidc-role/main.tf
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "this" {
     }
 
     condition {
-      test     = "StringLike"
+      test     = var.subject_condition
       variable = "${local.provider_url}:sub"
       # Strip `repo:` to normalize for cases where users may prepend it
       values = [for subject in var.subjects : "repo:${trimprefix(subject, "repo:")}"]

--- a/modules/iam-github-oidc-role/variables.tf
+++ b/modules/iam-github-oidc-role/variables.tf
@@ -68,6 +68,12 @@ variable "audience" {
   default     = "sts.amazonaws.com"
 }
 
+variable "subject_condition" {
+  description = "Condition to use for the GitHub OIDC role. Defaults to `StringLike`"
+  type        = string
+  default     = "StringLike"
+}
+
 variable "subjects" {
   description = "List of GitHub OIDC subjects that are permitted by the trust policy. You do not need to prefix with `repo:` as this is provided. Example: `['my-org/my-repo:*', 'octo-org/octo-repo:ref:refs/heads/octo-branch']`"
   type        = list(string)

--- a/wrappers/iam-github-oidc-role/main.tf
+++ b/wrappers/iam-github-oidc-role/main.tf
@@ -14,6 +14,7 @@ module "wrapper" {
   permissions_boundary_arn = try(each.value.permissions_boundary_arn, var.defaults.permissions_boundary_arn, null)
   policies                 = try(each.value.policies, var.defaults.policies, {})
   provider_url             = try(each.value.provider_url, var.defaults.provider_url, "token.actions.githubusercontent.com")
+  subject_condition        = try(each.value.subject_condition, var.defaults.subject_condition, "StringLike")
   subjects                 = try(each.value.subjects, var.defaults.subjects, [])
   tags                     = try(each.value.tags, var.defaults.tags, {})
 }


### PR DESCRIPTION
## Description
- Allow modifying the `iam-github-oidc-role` subject condition

## Motivation and Context
- Resolves #522

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
