### PR TITLE
feat: Update IAM policy for AWS Load Balancer Controller to support Listener Attributes

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -846,6 +846,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "elasticloadbalancing:DescribeTargetHealth",
       "elasticloadbalancing:DescribeTags",
       "elasticloadbalancing:DescribeTrustStores",
+      "elasticloadbalancing:DescribeListenerAttributes"
     ]
     resources = ["*"]
   }
@@ -1007,6 +1008,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "elasticloadbalancing:ModifyTargetGroup",
       "elasticloadbalancing:ModifyTargetGroupAttributes",
       "elasticloadbalancing:DeleteTargetGroup",
+      "elasticloadbalancing:ModifyListenerAttributes"
     ]
     resources = ["*"]
 

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -1008,7 +1008,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "elasticloadbalancing:ModifyTargetGroup",
       "elasticloadbalancing:ModifyTargetGroupAttributes",
       "elasticloadbalancing:DeleteTargetGroup",
-      "elasticloadbalancing:ModifyListenerAttributes"
+      "elasticloadbalancing:ModifyListenerAttributes",
     ]
     resources = ["*"]
 

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -846,7 +846,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "elasticloadbalancing:DescribeTargetHealth",
       "elasticloadbalancing:DescribeTags",
       "elasticloadbalancing:DescribeTrustStores",
-      "elasticloadbalancing:DescribeListenerAttributes"
+      "elasticloadbalancing:DescribeListenerAttributes",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR is to update the iam-role-for-service-accounts-eks module to add additional permissions when attach_load_balancer_controller_policy is set to true.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses https://github.com/terraform-aws-modules/terraform-aws-iam/issues/524.  Stems from upstream updates to https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json that have not yet been ported into this module.

Resolves #524 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [ x ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ x ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
