### PR TITLE
fix: Use dynamic partition value

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -200,7 +200,7 @@ data "aws_iam_policy_document" "ebs_csi" {
 
   statement {
     actions   = ["ec2:CreateVolume"]
-    resources = ["arn:aws:ec2:*:*:volume/*"]
+    resources = ["arn:${local.partition}:ec2:*:*:volume/*"]
 
     condition {
       test     = "StringLike"
@@ -213,7 +213,7 @@ data "aws_iam_policy_document" "ebs_csi" {
 
   statement {
     actions   = ["ec2:CreateVolume"]
-    resources = ["arn:aws:ec2:*:*:volume/*"]
+    resources = ["arn:${local.partition}:ec2:*:*:volume/*"]
 
     condition {
       test     = "StringLike"
@@ -235,7 +235,7 @@ data "aws_iam_policy_document" "ebs_csi" {
 
   statement {
     actions   = ["ec2:CreateVolume"]
-    resources = ["arn:aws:ec2:*:*:snapshot/*"]
+    resources = ["arn:${local.partition}:ec2:*:*:snapshot/*"]
   }
 
   statement {


### PR DESCRIPTION
Add functionality to interpolate resource arns to use local.partition instead of hardcoded value of "aws" to prevent breaking non-commercial use cases.

## Description
<!--- Describe your changes in detail -->
Updated previously changed values to use local.partition instead of hardcoded 'aws' reference.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #531 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This shouldn't be a breaking change and is using a pattern that exists other places in the policies.tf file.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
Tested with project that was previously broken by a previous update to validate fix.
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
Ran 
![Screenshot 2024-10-22 at 13 32 26](https://github.com/user-attachments/assets/5274b20f-b772-4d78-90f7-0783da8a4a0c)


