### PR TITLE
feat: Add `BatchGet*` to IAM read only policy

### DIFF
--- a/modules/iam-read-only-policy/main.tf
+++ b/modules/iam-read-only-policy/main.tf
@@ -25,6 +25,7 @@ data "aws_iam_policy_document" "allowed_services" {
       actions = [
         "${statement.value}:List*",
         "${statement.value}:Get*",
+        "${statement.value}:BatchGet*",
         "${statement.value}:Describe*",
         "${statement.value}:View*",
       ]


### PR DESCRIPTION
## Description
`docker pull` does API request to ECR and requires [BatchGetImage](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_BatchGetImage.html). With Read Only policy we expect that we can pull image from the registry.  

This PR adds `BatchGet*` action to address this problem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
