### PR TITLE
feat: Allow adding iss for the oidc assumable role

### DIFF
--- a/modules/iam-assumable-role-with-oidc/main.tf
+++ b/modules/iam-assumable-role-with-oidc/main.tf
@@ -71,6 +71,12 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
         }
       }
 
+      condition {
+        test     = "ForAllValues:StringEquals"
+        variable = "${statement.value}:iss"
+        values   = ["https://${statement.value}"]
+      }
+
       dynamic "condition" {
         for_each = length(var.oidc_fully_qualified_audiences) > 0 ? local.urls : []
 


### PR DESCRIPTION
## Description
Add the `iss` condition to the assumable OIDC role.

## Motivation and Context
The current implementation of the assumable OIDC role does not include the `iss` condition in the trust policy. This update follows the pattern introduced in [OIDC role PR #507](https://github.com/terraform-aws-modules/terraform-aws-iam/pull/507) to ensure consistency and compatibility with common OIDC providers.

## Breaking Changes
None. This change is backward-compatible as it only adds an additional condition without altering existing functionality.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
![pre-commit-result](https://github.com/user-attachments/assets/5cea99ff-f4a1-449b-a368-23fb698d87d0)
