### PR TITLE
feat: Update policie for External Secrets 0.12.1

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -558,6 +558,7 @@ data "aws_iam_policy_document" "external_secrets" {
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",
       "secretsmanager:ListSecretVersionIds",
+      "secretsmanager:BatchGetSecretValue",
     ]
     resources = var.external_secrets_secrets_manager_arns
   }


### PR DESCRIPTION
## Description
This pull request includes a change to the IAM policy document for external secrets in the `modules/iam-role-for-service-accounts-eks/policies.tf` file. The change adds a new permission to the policy.

* Added `secretsmanager:BatchGetSecretValue` permission to the `data "aws_iam_policy_document" "external_secrets"` block to allow batch retrieval of secret values.

## Motivation and Context
External Secrets 0.12.1 introduces the use of BulkFetch to fetch secrets from the AWS Secret Manager.
https://github.com/external-secrets/external-secrets/releases
https://github.com/external-secrets/external-secrets/blob/main/docs/provider/aws-secrets-manager.md?plain=1

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the examples/* to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided examples/* projects
- [x] I have executed pre-commit run -a on my pull request

