### PR TITLE
fix: Fix creation of inline polices

### DIFF
--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -279,6 +279,6 @@ resource "aws_iam_role_policy" "inline" {
   count = local.create_iam_role_inline_policy ? 1 : 0
 
   role        = aws_iam_role.this[0].name
-  name_prefix = "${try(coalesece(var.role_name, var.role_name_prefix), "")}_inline_"
+  name_prefix = "${try(coalesce(var.role_name, var.role_name_prefix), "")}_inline_"
   policy      = data.aws_iam_policy_document.inline[0].json
 }


### PR DESCRIPTION
## Description
Change `coalesece` to `coalesce` 

## Motivation and Context
`coalesece` is a non existing method in terraform so all inline policies are named `_inline_`

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
