### PR TITLE
fix remove the need for the policy count variable

### DIFF
--- a/modules/iam-assumable-role/main.tf
+++ b/modules/iam-assumable-role/main.tf
@@ -186,10 +186,10 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom" {
-  count = var.create_role ? coalesce(var.number_of_custom_role_policy_arns, length(var.custom_role_policy_arns)) : 0
+  for_each = var.custom_role_policy_arns != null ? toset(var.custom_role_policy_arns) : toset([])
 
   role       = aws_iam_role.this[0].name
-  policy_arn = element(var.custom_role_policy_arns, count.index)
+  policy_arn = each.value
 }
 
 resource "aws_iam_role_policy_attachment" "admin" {

--- a/modules/iam-assumable-role/variables.tf
+++ b/modules/iam-assumable-role/variables.tf
@@ -104,12 +104,6 @@ variable "create_custom_role_trust_policy" {
   default     = false
 }
 
-variable "number_of_custom_role_policy_arns" {
-  description = "Number of IAM policies to attach to IAM role"
-  type        = number
-  default     = null
-}
-
 variable "inline_policy_statements" {
   description = "List of inline policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) to attach to IAM role as an inline policy"
   type        = any


### PR DESCRIPTION
## Description
Removed the need for number_of_custom_role_policy_arns variable.

## Motivation and Context
The extra variable did not make sense and now when new policies are added you only need to update the list.
## Breaking Changes
N/A

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
