### PR TITLE
feat: Allow removing KMS and SSM permissions from EKS IRSA external secrets policy

### DIFF
--- a/examples/iam-role-for-service-accounts-eks/README.md
+++ b/examples/iam-role-for-service-accounts-eks/README.md
@@ -45,7 +45,6 @@ Run `terraform destroy` when you don't need these resources.
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 19.21 |
 | <a name="module_external_dns_irsa_role"></a> [external\_dns\_irsa\_role](#module\_external\_dns\_irsa\_role) | ../../modules/iam-role-for-service-accounts-eks | n/a |
 | <a name="module_external_secrets_irsa_role"></a> [external\_secrets\_irsa\_role](#module\_external\_secrets\_irsa\_role) | ../../modules/iam-role-for-service-accounts-eks | n/a |
-| <a name="module_external_secrets_without_kms_or_ssm_irsa_role"></a> [external\_secrets\_without\_kms\_or\_ssm\_irsa\_role](#module\_external\_secrets\_without\_kms\_or\_ssm\_irsa\_role) | ../../modules/iam-role-for-service-accounts-eks | n/a |
 | <a name="module_fsx_lustre_csi_irsa_role"></a> [fsx\_lustre\_csi\_irsa\_role](#module\_fsx\_lustre\_csi\_irsa\_role) | ../../modules/iam-role-for-service-accounts-eks | n/a |
 | <a name="module_iam_eks_role"></a> [iam\_eks\_role](#module\_iam\_eks\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | n/a |
 | <a name="module_iam_policy"></a> [iam\_policy](#module\_iam\_policy) | terraform-aws-modules/iam/aws//modules/iam-policy | n/a |

--- a/examples/iam-role-for-service-accounts-eks/main.tf
+++ b/examples/iam-role-for-service-accounts-eks/main.tf
@@ -191,26 +191,6 @@ module "external_secrets_irsa_role" {
   tags = local.tags
 }
 
-module "external_secrets_without_kms_or_ssm_irsa_role" {
-  source = "../../modules/iam-role-for-service-accounts-eks"
-
-  role_name                                          = "external-secrets"
-  attach_external_secrets_policy                     = true
-  external_secrets_ssm_parameter_arns                = []
-  external_secrets_secrets_manager_arns              = ["arn:aws:secretsmanager:*:*:secret:bar"]
-  external_secrets_kms_key_arns                      = []
-  external_secrets_secrets_manager_create_permission = false
-
-  oidc_providers = {
-    ex = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["default:kubernetes-external-secrets"]
-    }
-  }
-
-  tags = local.tags
-}
-
 module "fsx_lustre_csi_irsa_role" {
   source = "../../modules/iam-role-for-service-accounts-eks"
 

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -110,6 +110,7 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
   dynamic "statement" {
     # TODO - remove *_ids at next breaking change
     for_each = toset(coalescelist(var.cluster_autoscaler_cluster_ids, var.cluster_autoscaler_cluster_names))
+
     content {
       actions = [
         "autoscaling:SetDesiredCapacity",
@@ -306,6 +307,7 @@ data "aws_iam_policy_document" "ebs_csi" {
 
   dynamic "statement" {
     for_each = length(var.ebs_csi_kms_cmk_ids) > 0 ? [1] : []
+
     content {
       actions = [
         "kms:CreateGrant",
@@ -325,6 +327,7 @@ data "aws_iam_policy_document" "ebs_csi" {
 
   dynamic "statement" {
     for_each = length(var.ebs_csi_kms_cmk_ids) > 0 ? [1] : []
+
     content {
       actions = [
         "kms:Encrypt",
@@ -455,6 +458,7 @@ data "aws_iam_policy_document" "mountpoint_s3_csi" {
 
   dynamic "statement" {
     for_each = length(var.mountpoint_s3_csi_kms_arns) > 0 ? [1] : []
+
     content {
       actions = [
         "kms:GenerateDataKey",
@@ -578,6 +582,7 @@ data "aws_iam_policy_document" "external_secrets" {
 
   dynamic "statement" {
     for_each = var.external_secrets_secrets_manager_create_permission ? [1] : []
+
     content {
       actions = [
         "secretsmanager:CreateSecret",
@@ -590,9 +595,11 @@ data "aws_iam_policy_document" "external_secrets" {
 
   dynamic "statement" {
     for_each = var.external_secrets_secrets_manager_create_permission ? [1] : []
+
     content {
       actions   = ["secretsmanager:DeleteSecret"]
       resources = var.external_secrets_secrets_manager_arns
+
       condition {
         test     = "StringEquals"
         variable = "secretsmanager:ResourceTag/managed-by"
@@ -640,6 +647,7 @@ data "aws_iam_policy_document" "fsx_lustre_csi" {
   statement {
     actions   = ["iam:CreateServiceLinkedRole"]
     resources = ["*"]
+
     condition {
       test     = "StringLike"
       variable = "iam:AWSServiceName"
@@ -1210,6 +1218,7 @@ data "aws_iam_policy_document" "appmesh_controller" {
       "iam:CreateServiceLinkedRole"
     ]
     resources = ["arn:${local.partition}:iam::*:role/aws-service-role/appmesh.${local.dns_suffix}/AWSServiceRoleForAppMesh"]
+
     condition {
       test     = "StringLike"
       variable = "iam:AWSServiceName"
@@ -1468,6 +1477,7 @@ data "aws_iam_policy_document" "vpc_cni" {
   # arn:${local.partition}:iam::aws:policy/AmazonEKS_CNI_Policy
   dynamic "statement" {
     for_each = var.vpc_cni_enable_ipv4 ? [1] : []
+
     content {
       sid = "IPV4"
       actions = [
@@ -1491,6 +1501,7 @@ data "aws_iam_policy_document" "vpc_cni" {
   # https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html#cni-iam-role-create-ipv6-policy
   dynamic "statement" {
     for_each = var.vpc_cni_enable_ipv6 ? [1] : []
+
     content {
       sid = "IPV6"
       actions = [
@@ -1507,6 +1518,7 @@ data "aws_iam_policy_document" "vpc_cni" {
   # https://docs.aws.amazon.com/eks/latest/userguide/cni-network-policy.html#cni-network-policy-setup
   dynamic "statement" {
     for_each = var.vpc_cni_enable_cloudwatch_logs ? [1] : []
+
     content {
       sid = "CloudWatchLogs"
       actions = [


### PR DESCRIPTION
## Description
I'd like the option to remove access to KMS and SSM permissions on my IRSA roles while still providing the ability to use this module with the default encryption key provided by AWS.  When I attempt to provide an empty list, the IAM policy is invalid because a resource definition is required.

```
Error: updating IAM Policy (arn:aws:iam:::policy/role-External_Secrets_Policy-20190815225516998100000001): MalformedPolicyDocument: Policy statement must contain resources.
	status code: 400, request id: <id>
```

## Motivation and Context
Most of the secrets in my environment have been created with the default encryption key, so they don't need any special access to KMS or SSM.  When attempting to remove this permission I ran into an error applying the configuration because the policy document was malformed.

Resolves #557 

## Breaking Changes
No, this is not a breaking change as the existing default remains intact.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
