### PR TITLE
fix: IAM policy for External-DNS policy

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -501,7 +501,7 @@ data "aws_iam_policy_document" "external_dns" {
     actions = [
       "route53:ListHostedZones",
       "route53:ListResourceRecordSets",
-      "route53:ListTagsForResource",
+      "route53:ListTagsForResources",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
## Description
IAM policy for External-DNS has changed.

`route53:ListTagsForResource` => `route53:ListTagsForResource`**s**

See https://github.com/kubernetes-sigs/external-dns/commit/658d1efb76d7ce1f454cec9e8e92192c6c19d6fb


## Motivation and Context
The policy does not work with recent external-dns version. It aligns the policy with the doc

## Breaking Changes
The policy will not work with older version. We could provide backward compatibility by either providing both actions `ListTagsForResources` and `ListTagsForResource`, or a toggle.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
