### PR TITLE
chore: Use optimized action to purge unnecessary CI files for disk space

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 env:
-  TERRAFORM_DOCS_VERSION: v0.19.0
-  TFLINT_VERSION: v0.53.0
+  TERRAFORM_DOCS_VERSION: v0.20.0
+  TFLINT_VERSION: v0.57.0
 
 jobs:
   collectInputs:
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get root directories
         id: dirs
-        uses: clowdhaus/terraform-composite-actions/directories@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/directories@v1.11.1
 
   preCommitMinVersions:
     name: Min TF pre-commit
@@ -32,20 +32,15 @@ jobs:
       matrix:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
-      # https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
-      - name: Delete huge unnecessary tools folder
-        run: |
-          rm -rf /opt/hostedtoolcache/CodeQL
-          rm -rf /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk
-          rm -rf /opt/hostedtoolcache/Ruby
-          rm -rf /opt/hostedtoolcache/go
+      - name: Delete unnecessary files
+        uses: xd009642/ci-hoover@0.1.1
 
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.1
+        uses: clowdhaus/terraform-min-max@v1.3.2
         with:
           directory: ${{ matrix.directory }}
 
@@ -72,30 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: collectInputs
     steps:
-      # https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
-      - name: Delete huge unnecessary tools folder
-        run: |
-          df -h
-          rm -rf /opt/hostedtoolcache/CodeQL
-          rm -rf /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk
-          rm -rf /opt/hostedtoolcache/Ruby
-          rm -rf /opt/hostedtoolcache/go
-          # And a little bit more
-          sudo apt-get -qq remove -y 'azure-.*'
-          sudo apt-get -qq remove -y 'cpp-.*'
-          sudo apt-get -qq remove -y 'dotnet-runtime-.*'
-          sudo apt-get -qq remove -y 'google-.*'
-          sudo apt-get -qq remove -y 'libclang-.*'
-          sudo apt-get -qq remove -y 'libllvm.*'
-          sudo apt-get -qq remove -y 'llvm-.*'
-          sudo apt-get -qq remove -y 'mysql-.*'
-          sudo apt-get -qq remove -y 'postgresql-.*'
-          sudo apt-get -qq remove -y 'php.*'
-          sudo apt-get -qq remove -y 'temurin-.*'
-          sudo apt-get -qq remove -y kubectl firefox mono-devel
-          sudo apt-get -qq autoremove -y
-          sudo apt-get -qq clean
-          df -h
+      - name: Delete unnecessary files
+        uses: xd009642/ci-hoover@0.1.1
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -105,7 +78,7 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.1
+        uses: clowdhaus/terraform-min-max@v1.3.2
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1


### PR DESCRIPTION
## Description
- Use optimized action to purge unnecessary CI files for disk space

## Motivation and Context
- Faster than prior method - see https://xd009642.github.io/2024/10/26/debloating-github-actions-with-rust.html

### Before - `39GB` available

[Took 2m39s](https://github.com/terraform-aws-modules/terraform-aws-iam/actions/runs/14959202136/job/42018920152?pr=565)

<img width="440" alt="image" src="https://github.com/user-attachments/assets/b1165de7-c7bb-4021-b69b-b92c9d088d4b" />

### After - :fire: `53.8GB` available

Took 14-16s

<img width="411" alt="image" src="https://github.com/user-attachments/assets/ba3e790e-6ff5-45f2-ab65-f6e433048641" />

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
