### PR TITLE
feat: Update AWS Load Balancer controller policy to match v2.13 of the upstream project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.0
+    rev: v1.99.1
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -851,6 +851,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "ec2:DescribeVpcs",
       "ec2:DescribeVpcPeeringConnections",
       "ec2:DescribeSubnets",
+      "ec2:DescribeRouteTables",
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeInstances",
       "ec2:DescribeNetworkInterfaces",

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -17,7 +17,6 @@ data "aws_iam_policy_document" "aws_gateway_controller" {
   }
 }
 
-
 resource "aws_iam_policy" "aws_gateway_controller" {
   count = var.create_role && var.attach_aws_gateway_controller_policy ? 1 : 0
 
@@ -851,7 +850,6 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "ec2:DescribeVpcs",
       "ec2:DescribeVpcPeeringConnections",
       "ec2:DescribeSubnets",
-      "ec2:DescribeRouteTables",
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeInstances",
       "ec2:DescribeNetworkInterfaces",
@@ -860,6 +858,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "ec2:DescribeCoipPools",
       "ec2:GetSecurityGroupsForVpc",
       "ec2:DescribeIpamPools",
+      "ec2:DescribeRouteTables",
       "elasticloadbalancing:DescribeLoadBalancers",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",
       "elasticloadbalancing:DescribeListeners",
@@ -904,6 +903,12 @@ data "aws_iam_policy_document" "load_balancer_controller" {
     actions = [
       "ec2:AuthorizeSecurityGroupIngress",
       "ec2:RevokeSecurityGroupIngress",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
       "ec2:CreateSecurityGroup",
     ]
     resources = ["*"]
@@ -963,7 +968,6 @@ data "aws_iam_policy_document" "load_balancer_controller" {
 
   statement {
     actions = [
-      "elasticloadbalancing:AddTags",
       "elasticloadbalancing:CreateLoadBalancer",
       "elasticloadbalancing:CreateTargetGroup",
     ]
@@ -978,7 +982,6 @@ data "aws_iam_policy_document" "load_balancer_controller" {
 
   statement {
     actions = [
-      "elasticloadbalancing:AddTags",
       "elasticloadbalancing:CreateListener",
       "elasticloadbalancing:DeleteListener",
       "elasticloadbalancing:CreateRule",


### PR DESCRIPTION
## Description
Latest release of AWS LBC (v2.13.x) adds this permission `ec2:DescribeRouteTables`

## Motivation and Context
latest IAM Policy for AWS LBC: https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json

## Breaking Changes
No.

## Testing
- Tested using my fork:

```
module "aws_load_balancer_controller_irsa" {
  source = "git::https://github.com/RafiGreenberg/terraform-aws-iam//modules/iam-role-for-service-accounts-eks"

  role_name = "aws-load-balancer-controller"

  attach_load_balancer_controller_policy = true
  oidc_providers = {
    main = {
      provider_arn               = module.eks.oidc_provider_arn
      namespace_service_accounts = ["kube-system:aws-load-balancer-controller"]
    }
  }
}
```

- Plan:
```
$ tf plan
~ resource "aws_iam_policy" "load_balancer_controller" {
        id               = "arn:aws:iam::xxxxx:policy/AmazonEKS_AWS_Load_Balancer_Controller-20250603185119521400000001"
        name             = "AmazonEKS_AWS_Load_Balancer_Controller-20250603185119521400000001"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                    {
                        Action    = "iam:CreateServiceLinkedRole"
                        Condition = {
                            StringEquals = {
                                "iam:AWSServiceName" = "elasticloadbalancing.amazonaws.com"
                            }
                        }
                        Effect    = "Allow"
                        Resource  = "*"
                    },
                  ~ {
                      ~ Action   = [
                            # (19 unchanged elements hidden)
                            "ec2:DescribeSecurityGroups",
                          + "ec2:DescribeRouteTables",
                            "ec2:DescribeNetworkInterfaces",
                            # (7 unchanged elements hidden)
                        ]
                        # (2 unchanged attributes hidden)
                    },
                    {
                        Action   = [
                            "wafv2:GetWebACLForResource",
                            "wafv2:GetWebACL",
                            "wafv2:DisassociateWebACL",
                            "wafv2:AssociateWebACL",
                            "waf-regional:GetWebACLForResource",
                            "waf-regional:GetWebACL",
                            "waf-regional:DisassociateWebACL",
                            "waf-regional:AssociateWebACL",
                            "shield:GetSubscriptionState",
                            "shield:DescribeProtection",
                            "shield:DeleteProtection",
                            "shield:CreateProtection",
                            "iam:ListServerCertificates",
                            "iam:GetServerCertificate",
                            "cognito-idp:DescribeUserPoolClient",
                            "acm:ListCertificates",
                            "acm:DescribeCertificate",
                        ]
                        Effect   = "Allow"
                        Resource = "*"
                    },
                    # (12 unchanged elements hidden)
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags             = {}
        # (7 unchanged attributes hidden)
    }
Plan: 0 to add, 1 to change, 0 to destroy.
```

Tested successfully - ingress using ALB works now
```
Events:
  Type    Reason                  Age    From     Message
  ----    ------                  ----   ----     -------
  Normal  SuccessfullyReconciled  4m45s  ingress  Successfully reconciled
```
Closes: https://github.com/terraform-aws-modules/terraform-aws-iam/issues/568

