### PR TITLE
feat: Update EBS CSI IAM policy to match current upstream project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.1
+    rev: v1.99.4
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/examples/iam-eks-role/README.md
+++ b/examples/iam-eks-role/README.md
@@ -20,14 +20,14 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/iam-eks-role/versions.tf
+++ b/examples/iam-eks-role/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.0, < 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/iam-role-for-service-accounts-eks/README.md
+++ b/examples/iam-role-for-service-accounts-eks/README.md
@@ -20,13 +20,13 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0 |
 
 ## Modules
 

--- a/examples/iam-role-for-service-accounts-eks/versions.tf
+++ b/examples/iam-role-for-service-accounts-eks/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.0, < 6.0"
     }
   }
 }

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -211,15 +211,6 @@ data "aws_iam_policy_document" "ebs_csi" {
       "arn:${local.partition}:ec2:*:*:volume/*",
       "arn:${local.partition}:ec2:*:*:snapshot/*",
     ]
-
-    condition {
-      test     = "StringEquals"
-      variable = "ec2:CreateAction"
-      values = [
-        "CreateVolume",
-        "CreateSnapshot"
-      ]
-    }
   }
 
   statement {

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -217,7 +217,7 @@ data "aws_iam_policy_document" "ebs_csi" {
       variable = "ec2:CreateAction"
       values = [
         "CreateVolume",
-        "CreateSnapshot",
+        "CreateSnapshot"
       ]
     }
   }

--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -188,34 +188,66 @@ data "aws_iam_policy_document" "ebs_csi" {
 
   statement {
     actions = [
-      "ec2:CreateSnapshot",
-      "ec2:AttachVolume",
-      "ec2:DetachVolume",
-      "ec2:ModifyVolume",
       "ec2:DescribeAvailabilityZones",
       "ec2:DescribeInstances",
       "ec2:DescribeSnapshots",
       "ec2:DescribeTags",
       "ec2:DescribeVolumes",
       "ec2:DescribeVolumesModifications",
-      "ec2:EnableFastSnapshotRestores"
     ]
 
     resources = ["*"]
   }
 
   statement {
-    actions = ["ec2:CreateTags"]
+    actions = [
+      "ec2:CreateSnapshot",
+      "ec2:ModifyVolume",
+    ]
+
+    resources = ["arn:${local.partition}:ec2:*:*:volume/*"]
+  }
+
+  statement {
+    actions = [
+      "ec2:AttachVolume",
+      "ec2:DetachVolume",
+    ]
 
     resources = [
       "arn:${local.partition}:ec2:*:*:volume/*",
-      "arn:${local.partition}:ec2:*:*:snapshot/*",
+      "arn:${local.partition}:ec2:*:*:instance/*",
     ]
   }
 
   statement {
-    actions = ["ec2:DeleteTags"]
+    actions = [
+      "ec2:CreateVolume",
+      "ec2:EnableFastSnapshotRestores",
+    ]
 
+    resources = ["arn:${local.partition}:ec2:*:*:snapshot/*"]
+  }
+
+  statement {
+    actions = ["ec2:CreateTags"]
+    resources = [
+      "arn:${local.partition}:ec2:*:*:volume/*",
+      "arn:${local.partition}:ec2:*:*:snapshot/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:CreateAction"
+      values = [
+        "CreateVolume",
+        "CreateSnapshot",
+      ]
+    }
+  }
+
+  statement {
+    actions = ["ec2:DeleteTags"]
     resources = [
       "arn:${local.partition}:ec2:*:*:volume/*",
       "arn:${local.partition}:ec2:*:*:snapshot/*",
@@ -229,9 +261,7 @@ data "aws_iam_policy_document" "ebs_csi" {
     condition {
       test     = "StringLike"
       variable = "aws:RequestTag/ebs.csi.aws.com/cluster"
-      values = [
-        true
-      ]
+      values   = ["true"]
     }
   }
 
@@ -247,57 +277,30 @@ data "aws_iam_policy_document" "ebs_csi" {
   }
 
   statement {
-    actions   = ["ec2:CreateVolume"]
-    resources = ["*"]
-
-    condition {
-      test     = "StringLike"
-      variable = "aws:RequestTag/kubernetes.io/cluster/*"
-      values   = ["owned"]
-    }
-  }
-
-  statement {
-    actions   = ["ec2:CreateVolume"]
-    resources = ["arn:${local.partition}:ec2:*:*:snapshot/*"]
-  }
-
-  statement {
     actions   = ["ec2:DeleteVolume"]
-    resources = ["*"]
+    resources = ["arn:${local.partition}:ec2:*:*:volume/*"]
 
     condition {
       test     = "StringLike"
-      variable = "ec2:ResourceTag/ebs.csi.aws.com/cluster"
-      values   = [true]
+      variable = "aws:ResourceTag/ebs.csi.aws.com/cluster"
+      values   = ["true"]
     }
   }
 
   statement {
     actions   = ["ec2:DeleteVolume"]
-    resources = ["*"]
+    resources = ["arn:${local.partition}:ec2:*:*:volume/*"]
 
     condition {
       test     = "StringLike"
-      variable = "ec2:ResourceTag/CSIVolumeName"
+      variable = "aws:ResourceTag/CSIVolumeName"
       values   = ["*"]
     }
   }
 
   statement {
     actions   = ["ec2:DeleteVolume"]
-    resources = ["*"]
-
-    condition {
-      test     = "StringLike"
-      variable = "ec2:ResourceTag/kubernetes.io/cluster/*"
-      values   = ["owned"]
-    }
-  }
-
-  statement {
-    actions   = ["ec2:DeleteVolume"]
-    resources = ["*"]
+    resources = ["arn:${local.partition}:ec2:*:*:volume/*"]
 
     condition {
       test     = "StringLike"
@@ -307,24 +310,46 @@ data "aws_iam_policy_document" "ebs_csi" {
   }
 
   statement {
-    actions   = ["ec2:DeleteSnapshot"]
-    resources = ["*"]
+    actions   = ["ec2:CreateSnapshot"]
+    resources = ["arn:${local.partition}:ec2:*:*:snapshot/*"]
 
     condition {
       test     = "StringLike"
-      variable = "ec2:ResourceTag/CSIVolumeSnapshotName"
+      variable = "aws:RequestTag/CSIVolumeSnapshotName"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    actions   = ["ec2:CreateSnapshot"]
+    resources = ["arn:${local.partition}:ec2:*:*:snapshot/*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/ebs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    actions   = ["ec2:DeleteSnapshot"]
+    resources = ["arn:${local.partition}:ec2:*:*:snapshot/*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/CSIVolumeSnapshotName"
       values   = ["*"]
     }
   }
 
   statement {
     actions   = ["ec2:DeleteSnapshot"]
-    resources = ["*"]
+    resources = ["arn:${local.partition}:ec2:*:*:snapshot/*"]
 
     condition {
       test     = "StringLike"
-      variable = "ec2:ResourceTag/ebs.csi.aws.com/cluster"
-      values   = [true]
+      variable = "aws:ResourceTag/ebs.csi.aws.com/cluster"
+      values   = ["true"]
     }
   }
 


### PR DESCRIPTION
### Description

This PR removes the unnecessary `condition` block from the `ebs_csi` IAM policy document.
According to AWS documentation, this `condition` is not required and may cause permission issues when using the EBS CSI driver with IRSA.

Closes #562

### Reference
- AWS Docs: [EBS CSI IAM Policy](https://docs.aws.amazon.com/...)

### Impact
No impact on functionality. Simplifies the policy and aligns with AWS recommendations.
