### PR TITLE
fix: Remove deprecated-attribute

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -6,7 +6,7 @@ locals {
   account_id          = data.aws_caller_identity.current.account_id
   partition           = data.aws_partition.current.partition
   dns_suffix          = data.aws_partition.current.dns_suffix
-  region              = data.aws_region.current.name
+  region              = data.aws_region.current.region
   role_name_condition = var.role_name != null ? var.role_name : "${var.role_name_prefix}*"
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updates the `iam-role-for-service-accounts-eks` module to address the deprecated attribute warning mentioned in #574. This requires removing the version restrictions on the AWS provider for this module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
