### PR TITLE
fix: Update deprecated reference

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -6,7 +6,7 @@ locals {
   account_id          = data.aws_caller_identity.current.account_id
   partition           = data.aws_partition.current.partition
   dns_suffix          = data.aws_partition.current.dns_suffix
-  region              = data.aws_region.current.name
+  region              = data.aws_region.current.region
   role_name_condition = var.role_name != null ? var.role_name : "${var.role_name_prefix}*"
 }
 


### PR DESCRIPTION
data.aws_region.current.name is deprecated, now we need to reference data.aws_region.current.region.

See https://registry.terraform.io/providers/hashicorp/aws/6.5.0/docs/data-sources/region