### PR TITLE
fix: Replace deprecated aws_region data source name attribute

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -6,7 +6,7 @@ locals {
   account_id          = data.aws_caller_identity.current.account_id
   partition           = data.aws_partition.current.partition
   dns_suffix          = data.aws_partition.current.dns_suffix
-  region              = data.aws_region.current.name
+  region              = data.aws_region.current.region
   role_name_condition = var.role_name != null ? var.role_name : "${var.role_name_prefix}*"
 }
 


### PR DESCRIPTION
Replaces the deprecated `data.aws_region.current.name` with `data.aws_region.current.region` in the IAM Role for Service Accounts EKS module.

## Description
- Updated `modules/iam-role-for-service-accounts-eks/main.tf` to use the non-deprecated `region` attribute instead of `name`
- 
## Motivation and Context
The `name` attribute of the `aws_region` data source has been deprecated by the AWS provider. This change ensures compatibility with current and future versions of the AWS provider.
