### PR TITLE
feat: Add ssm:GetParametersByPath for external secrets

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -598,6 +598,7 @@ data "aws_iam_policy_document" "external_secrets" {
       actions = [
         "ssm:GetParameter",
         "ssm:GetParameters",
+        "ssm:GetParametersByPath"
       ]
 
       resources = var.external_secrets_ssm_parameter_arns


### PR DESCRIPTION
## Description
Adds GetParametersByPath for external-secrets

## Motivation and Context
From the logs of external-secrets 
> :"GetParametersByPath: access denied. using fallback to describe parameters. It is recommended to add ssm:GetParametersByPath permissions"

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
