### PR TITLE
fix migration moved-blocks

### DIFF
--- a/modules/iam-role-for-service-accounts/migrations.tf
+++ b/modules/iam-role-for-service-accounts/migrations.tf
@@ -10,7 +10,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.aws_gateway_controller
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # Cert Manager
@@ -21,7 +21,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.cert_manager
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # Cluster Autoscaler
@@ -32,7 +32,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.cluster_autoscaler
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # EBS CSI
@@ -43,7 +43,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.ebs_csi
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # EFS CSI
@@ -54,7 +54,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.efs_csi
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # Mountpoint S3 CSI
@@ -65,7 +65,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.mountpoint_s3_csi
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # External DNS
@@ -76,7 +76,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.external_dns
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # External Secrets
@@ -87,7 +87,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.external_secrets
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # FSx OpenZFS CSI
@@ -98,7 +98,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.fsx_openzfs_csi
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # AWS Load Balancer Controller
@@ -109,7 +109,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.load_balancer_controller
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # AWS Load Balancer Controller - Target Group Binding Only
@@ -120,7 +120,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.load_balancer_controller_targetgroup_only
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # Amazon Managed Service for Prometheus
@@ -131,7 +131,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.amazon_managed_service_prometheus
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # Node Termination Handler
@@ -142,7 +142,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.node_termination_handler
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # Velero
@@ -153,7 +153,7 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.velero
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }
 
 # VPC CNI
@@ -164,5 +164,5 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.vpc_cni
-  to   = aws_iam_policy.this
+  to   = aws_iam_role_policy_attachment.this
 }


### PR DESCRIPTION
## Description
Fix migration moved blocks

## Motivation and Context
It should fix https://github.com/terraform-aws-modules/terraform-aws-iam/issues/586

## Breaking Changes
Yes because the current major version will lead to https://github.com/terraform-aws-modules/terraform-aws-iam/issues/586 for users who upgrade from v5 to v6.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
