### PR TITLE
feat: Add default IRSA policy name, fix incorrect policy attachment for `iam-user`

### DIFF
--- a/modules/iam-role-for-service-accounts/main.tf
+++ b/modules/iam-role-for-service-accounts/main.tf
@@ -25,6 +25,28 @@ locals {
     var.attach_velero_policy ? "Provides Velero permissions to backup and restore cluster resources" : null,
     var.attach_vpc_cni_policy ? "Provides the Amazon VPC CNI Plugin (amazon-vpc-cni-k8s) the permissions it requires to modify the IPv4/IPv6 address configuration on your EKS worker nodes" : null,
   ), null)
+
+  policy_name = try(coalesce(
+    var.policy_name,
+    var.attach_aws_gateway_controller_policy ? "AWS_Gateway_Controller" : null,
+    var.attach_cert_manager_policy ? "Cert_Manager" : null,
+    var.attach_cluster_autoscaler_policy ? "Cluster_Autoscaler" : null,
+    var.attach_ebs_csi_policy ? "EBS_CSI" : null,
+    var.attach_efs_csi_policy ? "EFS_CSI" : null,
+    var.attach_mountpoint_s3_csi_policy ? "Mountpoint_S3_CSI" : null,
+    var.attach_external_dns_policy ? "External_DNS" : null,
+    var.attach_external_secrets_policy ? "External_Secrets" : null,
+    var.attach_fsx_lustre_csi_policy ? "FSX_Lustre_CSI" : null,
+    var.attach_fsx_openzfs_csi_policy ? "FSX_OpenZFS_CSI" : null,
+    var.attach_load_balancer_controller_policy ? "AWS_Load_Balancer_Controller" : null,
+    var.attach_load_balancer_controller_targetgroup_binding_only_policy ? "AWS_LBC_TargetGroup_Binding_Only" : null,
+    var.attach_amazon_managed_service_prometheus_policy ? "Amazon_Managed_Service_Prometheus" : null,
+    var.attach_node_termination_handler_policy ? "Node_Termination_Handler" : null,
+    var.attach_velero_policy ? "Velero" : null,
+    var.attach_vpc_cni_policy ? "VPC_CNI_${var.vpc_cni_enable_ipv4 ? "IPv4" : "IPv6"}" : null,
+    var.name,
+    "default"
+  ))
 }
 
 ################################################################################
@@ -159,10 +181,6 @@ data "aws_iam_policy_document" "this" {
       }
     }
   }
-}
-
-locals {
-  policy_name = try(coalesce(var.policy_name, var.name), "")
 }
 
 resource "aws_iam_policy" "this" {

--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -50,9 +50,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_access_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
-| [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_login_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_login_profile) | resource |
+| [aws_iam_user_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_ssh_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_ssh_key) | resource |
 
 ## Inputs

--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -13,10 +13,10 @@ resource "aws_iam_user" "this" {
   tags = var.tags
 }
 
-resource "aws_iam_role_policy_attachment" "additional" {
+resource "aws_iam_user_policy_attachment" "additional" {
   for_each = { for k, v in var.policies : k => v if var.create }
 
-  role       = aws_iam_user.this[0].name
+  user       = aws_iam_user.this[0].name
   policy_arn = each.value
 }
 


### PR DESCRIPTION
## Description
- Add default IRSA policy name for canned policies if a more specific name is not provided
- Fix incorrect policy attachment for `iam-user`

## Motivation and Context
- Resolves #593

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
