### PR TITLE
fix: Attach policies to IAM user (not role)

### DIFF
--- a/modules/iam-user/README.md
+++ b/modules/iam-user/README.md
@@ -50,9 +50,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_access_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
-| [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_login_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_login_profile) | resource |
+| [aws_iam_user_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_ssh_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_ssh_key) | resource |
 
 ## Inputs

--- a/modules/iam-user/main.tf
+++ b/modules/iam-user/main.tf
@@ -13,10 +13,10 @@ resource "aws_iam_user" "this" {
   tags = var.tags
 }
 
-resource "aws_iam_role_policy_attachment" "additional" {
+resource "aws_iam_user_policy_attachment" "additional" {
   for_each = { for k, v in var.policies : k => v if var.create }
 
-  role       = aws_iam_user.this[0].name
+  user       = aws_iam_user.this[0].name
   policy_arn = each.value
 }
 


### PR DESCRIPTION
## Description
Replace the incorrect resource type aws_iam_role_policy_attachment with aws_iam_user_policy_attachment.

Update arguments accordingly (role -> user) so attachments target the created IAM user (aws_iam_user.this[0].name).

No changes to input variables: var.policies remains a map and the for_each logic is unchanged.

## Motivation and Context
The previous implementation attempted to attach policies using the role attachment resource for an IAM user, which is invalid.

## Breaking Changes
Resource address change: from aws_iam_role_policy_attachment.additional to aws_iam_user_policy_attachment.additional.
Terraform will plan to replace these attachment resources on the next apply (destroy old, create new).

Impact: Brief re‑creation of policy attachments during apply. No persistent permission loss is expected.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
