### PR TITLE
fix: Remove any `secretsmanager:*` permissions if no secret ARNs are provided to IRSA external-secrets permissions

### DIFF
--- a/modules/iam-role-for-service-accounts/policies.tf
+++ b/modules/iam-role-for-service-accounts/policies.tf
@@ -483,14 +483,19 @@ data "aws_iam_policy_document" "external_secrets" {
     resources = ["*"]
   }
 
-  statement {
-    actions = [
-      "secretsmanager:GetResourcePolicy",
-      "secretsmanager:GetSecretValue",
-      "secretsmanager:DescribeSecret",
-      "secretsmanager:ListSecretVersionIds"
-    ]
-    resources = var.external_secrets_secrets_manager_arns
+  dynamic "statement" {
+    for_each = length(var.external_secrets_secrets_manager_arns) > 0 ? [1] : []
+
+    content {
+      actions = [
+        "secretsmanager:GetResourcePolicy",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecretVersionIds"
+      ]
+
+      resources = var.external_secrets_secrets_manager_arns
+    }
   }
 
   dynamic "statement" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Applies the same dynamic trick to the secretsmanager part of the external secrets role policy, so that if we don't grant access to any secrets we don't end up with an apply error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without supplying any values for `var.external_secrets_secrets_manager_arns` we end up with a policy statement like this:
```
                  + {
                      + Action = [
                          + "secretsmanager:ListSecretVersionIds",
                          + "secretsmanager:GetSecretValue",
                          + "secretsmanager:GetResourcePolicy",
                          + "secretsmanager:DescribeSecret",
                        ]
                      + Effect = "Allow"
                    },
```
This is invalid since it lacks resources and cannot be applied.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking change.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
It's such a trivial change I don't believe these are necessary but can circle back to these if you like.