### PR TITLE
fix: Modify BitBucket provider URL extraction to be more robust when none or multiple URLs are provided

### DIFF
--- a/modules/iam-role/main.tf
+++ b/modules/iam-role/main.tf
@@ -10,7 +10,7 @@ locals {
   partition  = try(data.aws_partition.current[0].partition, "")
 
   oidc_providers     = [for url in var.oidc_provider_urls : replace(url, "https://", "")]
-  bitbucket_provider = var.enable_bitbucket_oidc ? one(local.oidc_providers) : null
+  bitbucket_provider = try(element(local.oidc_providers, 0), null)
 }
 
 ################################################################################

--- a/modules/iam-role/main.tf
+++ b/modules/iam-role/main.tf
@@ -10,7 +10,7 @@ locals {
   partition  = try(data.aws_partition.current[0].partition, "")
 
   oidc_providers     = [for url in var.oidc_provider_urls : replace(url, "https://", "")]
-  bitbucket_provider = one(local.oidc_providers)
+  bitbucket_provider = var.enable_bitbucket_oidc ? one(local.oidc_providers) : null
 }
 
 ################################################################################


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
- Adding a check for local.bitbucket_provider to check for provider url only when enable_bitbucket_oidc is enabled.
- Fix for issue  https://github.com/terraform-aws-modules/terraform-aws-iam/issues/604
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the 6.x version of the module, when oidc_provider_urls has multiple provider urls a bitbucket check fails and prevents plan for other generic providers as well.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
