### PR TITLE
fix: Correct `iam-group` variable name mis-spelling

### DIFF
--- a/docs/UPGRADE-6.0.md
+++ b/docs/UPGRADE-6.0.md
@@ -134,7 +134,7 @@ stateDiagram
         - None
     - `iam-group`
         - `create_group` -> `create`
-        - `group_users` -> `group`
+        - `group_users` -> `users`
         - `custom_group_policy_arns` -> `policies`
         - `attach_iam_self_management_policy` -> `create_policy`
         - `iam_self_management_policy_name_prefix` -> `policy_name_prefix`

--- a/modules/iam-group/README.md
+++ b/modules/iam-group/README.md
@@ -72,7 +72,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | Whether to create IAM policy for IAM group | `bool` | `true` | no |
-| <a name="input_enable_mfa_enforcment"></a> [enable\_mfa\_enforcment](#input\_enable\_mfa\_enforcment) | Determines whether permissions are added to the policy which requires the groups IAM users to use MFA | `bool` | `true` | no |
+| <a name="input_enable_mfa_enforcement"></a> [enable\_mfa\_enforcement](#input\_enable\_mfa\_enforcement) | Determines whether permissions are added to the policy which requires the groups IAM users to use MFA | `bool` | `true` | no |
 | <a name="input_enable_self_management_permissions"></a> [enable\_self\_management\_permissions](#input\_enable\_self\_management\_permissions) | Determines whether permissions are added to the policy which allow the groups IAM users to manage their credentials and MFA | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.` | `string` | `""` | no |
 | <a name="input_path"></a> [path](#input\_path) | Path in which to create the group | `string` | `null` | no |

--- a/modules/iam-group/main.tf
+++ b/modules/iam-group/main.tf
@@ -171,7 +171,7 @@ data "aws_iam_policy_document" "this" {
   }
 
   dynamic "statement" {
-    for_each = var.enable_self_management_permissions && var.enable_mfa_enforcment ? [1] : []
+    for_each = var.enable_self_management_permissions && var.enable_mfa_enforcement ? [1] : []
 
     content {
       sid    = "DenyAllExceptListedIfNoMFA"

--- a/modules/iam-group/variables.tf
+++ b/modules/iam-group/variables.tf
@@ -48,7 +48,7 @@ variable "enable_self_management_permissions" {
   default     = true
 }
 
-variable "enable_mfa_enforcment" {
+variable "enable_mfa_enforcement" {
   description = "Determines whether permissions are added to the policy which requires the groups IAM users to use MFA"
   type        = bool
   default     = true

--- a/wrappers/iam-group/main.tf
+++ b/wrappers/iam-group/main.tf
@@ -5,7 +5,7 @@ module "wrapper" {
 
   create                             = try(each.value.create, var.defaults.create, true)
   create_policy                      = try(each.value.create_policy, var.defaults.create_policy, true)
-  enable_mfa_enforcment              = try(each.value.enable_mfa_enforcment, var.defaults.enable_mfa_enforcment, true)
+  enable_mfa_enforcement             = try(each.value.enable_mfa_enforcement, var.defaults.enable_mfa_enforcement, true)
   enable_self_management_permissions = try(each.value.enable_self_management_permissions, var.defaults.enable_self_management_permissions, true)
   name                               = try(each.value.name, var.defaults.name, "")
   path                               = try(each.value.path, var.defaults.path, null)


### PR DESCRIPTION
## Description
- Correct `iam-group` variable name mis-spelling

## Motivation and Context
- Resolves #608

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
