### PR TITLE
CamelCase key names for inline permissions

### DIFF
--- a/examples/iam-user/main.tf
+++ b/examples/iam-user/main.tf
@@ -47,7 +47,7 @@ module "iam_user2" {
 
   create_inline_policy = true
   inline_policy_permissions = {
-    s3_read_access = {
+    S3ReadAccess = {
       effect = "Allow"
       actions = [
         "s3:GetObject",
@@ -58,7 +58,7 @@ module "iam_user2" {
         "arn:aws:s3:::example-bucket/*"
       ]
     }
-    cloudwatch_logs = {
+    CloudwatchLogs = {
       effect = "Allow"
       actions = [
         "logs:CreateLogGroup",


### PR DESCRIPTION
## Description

Changes the IAM User example to use camel case 

## Motivation and Context
for this observed Malformed Document error
https://github.com/terraform-aws-modules/terraform-aws-iam/issues/612

## Breaking Changes
No, only modifies examples

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [  ] I have executed `pre-commit run -a` on my pull request