### PR TITLE
docs: Add IAM role with inline policy example

### DIFF
--- a/examples/iam-role/README.md
+++ b/examples/iam-role/README.md
@@ -70,6 +70,13 @@ No inputs.
 | <a name="output_github_oidc_iam_role_arn"></a> [github\_oidc\_iam\_role\_arn](#output\_github\_oidc\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the IAM role |
 | <a name="output_github_oidc_iam_role_name"></a> [github\_oidc\_iam\_role\_name](#output\_github\_oidc\_iam\_role\_name) | The name of the IAM role |
 | <a name="output_github_oidc_iam_role_unique_id"></a> [github\_oidc\_iam\_role\_unique\_id](#output\_github\_oidc\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
+| <a name="output_inline_policy_iam_instance_profile_arn"></a> [inline\_policy\_iam\_instance\_profile\_arn](#output\_inline\_policy\_iam\_instance\_profile\_arn) | ARN assigned by AWS to the instance profile |
+| <a name="output_inline_policy_iam_instance_profile_id"></a> [inline\_policy\_iam\_instance\_profile\_id](#output\_inline\_policy\_iam\_instance\_profile\_id) | Instance profile's ID |
+| <a name="output_inline_policy_iam_instance_profile_name"></a> [inline\_policy\_iam\_instance\_profile\_name](#output\_inline\_policy\_iam\_instance\_profile\_name) | Name of IAM instance profile |
+| <a name="output_inline_policy_iam_instance_profile_unique_id"></a> [inline\_policy\_iam\_instance\_profile\_unique\_id](#output\_inline\_policy\_iam\_instance\_profile\_unique\_id) | Stable and unique string identifying the IAM instance profile |
+| <a name="output_inline_policy_iam_role_arn"></a> [inline\_policy\_iam\_role\_arn](#output\_inline\_policy\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the IAM role |
+| <a name="output_inline_policy_iam_role_name"></a> [inline\_policy\_iam\_role\_name](#output\_inline\_policy\_iam\_role\_name) | The name of the IAM role |
+| <a name="output_inline_policy_iam_role_unique_id"></a> [inline\_policy\_iam\_role\_unique\_id](#output\_inline\_policy\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
 | <a name="output_instance_profile_iam_instance_profile_arn"></a> [instance\_profile\_iam\_instance\_profile\_arn](#output\_instance\_profile\_iam\_instance\_profile\_arn) | ARN assigned by AWS to the instance profile |
 | <a name="output_instance_profile_iam_instance_profile_id"></a> [instance\_profile\_iam\_instance\_profile\_id](#output\_instance\_profile\_iam\_instance\_profile\_id) | Instance profile's ID |
 | <a name="output_instance_profile_iam_instance_profile_name"></a> [instance\_profile\_iam\_instance\_profile\_name](#output\_instance\_profile\_iam\_instance\_profile\_name) | Name of IAM instance profile |

--- a/examples/iam-role/main.tf
+++ b/examples/iam-role/main.tf
@@ -196,8 +196,7 @@ module "iam_role_inline_policy" {
 
   name = "${local.name}-inline-policy"
 
-  create               = true
-  create_inline_policy = true
+  create_instance_profile = true
 
   trust_policy_permissions = {
     ec2 = {
@@ -212,6 +211,7 @@ module "iam_role_inline_policy" {
     }
   }
 
+  create_inline_policy = true
   inline_policy_permissions = {
     S3ReadAccess = {
       effect = "Allow"

--- a/examples/iam-role/outputs.tf
+++ b/examples/iam-role/outputs.tf
@@ -153,3 +153,42 @@ output "saml_iam_instance_profile_unique_id" {
   description = "Stable and unique string identifying the IAM instance profile"
   value       = module.iam_role_saml.instance_profile_unique_id
 }
+
+################################################################################
+# IAM Role - Inline Policy
+################################################################################
+
+output "inline_policy_iam_role_name" {
+  description = "The name of the IAM role"
+  value       = module.iam_role_inline_policy.name
+}
+
+output "inline_policy_iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the IAM role"
+  value       = module.iam_role_inline_policy.arn
+}
+
+output "inline_policy_iam_role_unique_id" {
+  description = "Stable and unique string identifying the IAM role"
+  value       = module.iam_role_inline_policy.unique_id
+}
+
+output "inline_policy_iam_instance_profile_arn" {
+  description = "ARN assigned by AWS to the instance profile"
+  value       = module.iam_role_inline_policy.instance_profile_arn
+}
+
+output "inline_policy_iam_instance_profile_id" {
+  description = "Instance profile's ID"
+  value       = module.iam_role_inline_policy.instance_profile_id
+}
+
+output "inline_policy_iam_instance_profile_name" {
+  description = "Name of IAM instance profile"
+  value       = module.iam_role_inline_policy.instance_profile_name
+}
+
+output "inline_policy_iam_instance_profile_unique_id" {
+  description = "Stable and unique string identifying the IAM instance profile"
+  value       = module.iam_role_inline_policy.instance_profile_unique_id
+}


### PR DESCRIPTION
## Description
Adds an example of an IAM role with an inline policy and demonstrates the need for a trust policy 

## Motivation and Context

Provides a documented working sample for:
- https://github.com/terraform-aws-modules/terraform-aws-iam/issues/611
- https://github.com/terraform-aws-modules/terraform-aws-iam/issues/612

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request