### PR TITLE
feat: Update IAM policy for AWS Gateway API Controller to v2.0.0

### DIFF
--- a/modules/iam-role-for-service-accounts/policies.tf
+++ b/modules/iam-role-for-service-accounts/policies.tf
@@ -40,7 +40,7 @@ data "aws_service_principal" "delivery_logs" {
 data "aws_iam_policy_document" "aws_gateway_controller" {
   count = var.create && var.attach_aws_gateway_controller_policy ? 1 : 0
 
-  # https://github.com/aws/aws-application-networking-k8s/blob/v1.1.0/files/controller-installation/recommended-inline-policy.json
+  # https://github.com/aws/aws-application-networking-k8s/blob/v2.0.0/files/controller-installation/recommended-inline-policy.json
   statement {
     actions = [
       "vpc-lattice:*",
@@ -60,6 +60,8 @@ data "aws_iam_policy_document" "aws_gateway_controller" {
       "firehose:TagDeliveryStream",
       "s3:GetBucketPolicy",
       "s3:PutBucketPolicy",
+      "tag:TagResources",
+      "tag:UntagResources"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Description
Update IAM policy for AWS Gateway API Controller to v2.0.0

## Motivation and Context
Adds missing permissions introduced in https://github.com/aws/aws-application-networking-k8s/pull/837

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
