### PR TITLE
feat: Allow setting cert thumbprints manually in OIDC provider

### DIFF
--- a/examples/iam-oidc-provider/README.md
+++ b/examples/iam-oidc-provider/README.md
@@ -38,6 +38,8 @@ No providers.
 | <a name="module_github_oidc_iam_provider"></a> [github\_oidc\_iam\_provider](#module\_github\_oidc\_iam\_provider) | ../../modules/iam-oidc-provider | n/a |
 | <a name="module_github_oidc_iam_role"></a> [github\_oidc\_iam\_role](#module\_github\_oidc\_iam\_role) | ../../modules/iam-role | n/a |
 | <a name="module_oidc_iam_provider_disabled"></a> [oidc\_iam\_provider\_disabled](#module\_oidc\_iam\_provider\_disabled) | ../../modules/iam-oidc-provider | n/a |
+| <a name="module_private_gitlab_oidc_iam_provider"></a> [private\_gitlab\_oidc\_iam\_provider](#module\_private\_gitlab\_oidc\_iam\_provider) | ../../modules/iam-oidc-provider | n/a |
+| <a name="module_private_gitlab_oidc_iam_role"></a> [private\_gitlab\_oidc\_iam\_role](#module\_private\_gitlab\_oidc\_iam\_role) | ../../modules/iam-role | n/a |
 
 ## Resources
 

--- a/examples/iam-oidc-provider/main.tf
+++ b/examples/iam-oidc-provider/main.tf
@@ -23,6 +23,16 @@ module "github_oidc_iam_provider" {
   tags = local.tags
 }
 
+module "private_gitlab_oidc_iam_provider" {
+  source = "../../modules/iam-oidc-provider"
+
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html#oidc-obtain-thumbprint explains how to obtain thumbprints using openssl.
+  thumbprint_list = ["ae801ed1c55bb579d79208b0d772acfb8cc3a208"]
+  url             = "https://example.com"
+
+  tags = local.tags
+}
+
 module "oidc_iam_provider_disabled" {
   source = "../../modules/iam-oidc-provider"
 
@@ -36,7 +46,7 @@ module "oidc_iam_provider_disabled" {
 module "github_oidc_iam_role" {
   source = "../../modules/iam-role"
 
-  name = local.name
+  name = "${local.name}-github"
 
   enable_github_oidc = true
 
@@ -45,6 +55,26 @@ module "github_oidc_iam_role" {
     # You can prepend with `repo:` but it is not required
     "repo:terraform-aws-modules/terraform-aws-iam:pull_request",
     "terraform-aws-modules/terraform-aws-iam:ref:refs/heads/master",
+  ]
+
+  policies = {
+    S3ReadOnly = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  }
+
+  tags = local.tags
+}
+
+module "private_gitlab_oidc_iam_role" {
+  source = "../../modules/iam-role"
+
+  name = "${local.name}-private-gitlab"
+
+  enable_oidc        = true
+  oidc_provider_urls = [module.private_gitlab_oidc_iam_provider.url]
+
+  # This should be updated to suit your organization, repository, references/branches, etc.
+  oidc_subjects = [
+    "project_path:mygroup/myproject:ref_type:branch:ref:main",
   ]
 
   policies = {

--- a/modules/iam-oidc-provider/README.md
+++ b/modules/iam-oidc-provider/README.md
@@ -73,6 +73,7 @@ No modules.
 | <a name="input_client_id_list"></a> [client\_id\_list](#input\_client\_id\_list) | List of client IDs (also known as audiences) for the IAM OIDC provider. Defaults to STS service if no values are provided | `list(string)` | `[]` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources created | `map(any)` | `{}` | no |
+| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | A list of server certificate thumbprints (max 5) for the OpenID Connect (OIDC) identity provider’s server certificates | `list(string)` | `[]` | no |
 | <a name="input_url"></a> [url](#input\_url) | The URL of the identity provider. Corresponds to the iss claim | `string` | `"https://token.actions.githubusercontent.com"` | no |
 
 ## Outputs

--- a/modules/iam-oidc-provider/main.tf
+++ b/modules/iam-oidc-provider/main.tf
@@ -11,7 +11,7 @@ locals {
 ################################################################################
 
 data "tls_certificate" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && length(var.thumbprint_list) == 0 ? 1 : 0
 
   url = var.url
 }
@@ -21,7 +21,7 @@ resource "aws_iam_openid_connect_provider" "this" {
 
   url             = var.url
   client_id_list  = coalescelist(var.client_id_list, ["sts.${local.dns_suffix}"])
-  thumbprint_list = data.tls_certificate.this[0].certificates[*].sha1_fingerprint
+  thumbprint_list = coalescelist(var.thumbprint_list, try(data.tls_certificate.this[0].certificates[*].sha1_fingerprint, []))
 
   tags = var.tags
 }

--- a/modules/iam-oidc-provider/variables.tf
+++ b/modules/iam-oidc-provider/variables.tf
@@ -20,6 +20,12 @@ variable "client_id_list" {
   default     = []
 }
 
+variable "thumbprint_list" {
+  description = "A list of server certificate thumbprints (max 5) for the OpenID Connect (OIDC) identity provider’s server certificates"
+  type        = list(string)
+  default     = []
+}
+
 variable "url" {
   description = "The URL of the identity provider. Corresponds to the iss claim"
   type        = string

--- a/wrappers/iam-oidc-provider/main.tf
+++ b/wrappers/iam-oidc-provider/main.tf
@@ -3,8 +3,9 @@ module "wrapper" {
 
   for_each = var.items
 
-  client_id_list = try(each.value.client_id_list, var.defaults.client_id_list, [])
-  create         = try(each.value.create, var.defaults.create, true)
-  tags           = try(each.value.tags, var.defaults.tags, {})
-  url            = try(each.value.url, var.defaults.url, "https://token.actions.githubusercontent.com")
+  client_id_list  = try(each.value.client_id_list, var.defaults.client_id_list, [])
+  create          = try(each.value.create, var.defaults.create, true)
+  tags            = try(each.value.tags, var.defaults.tags, {})
+  thumbprint_list = try(each.value.thumbprint_list, var.defaults.thumbprint_list, [])
+  url             = try(each.value.url, var.defaults.url, "https://token.actions.githubusercontent.com")
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
With this change you can manually set cert thumbprints of an OIDC provider.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to prevent service disruptions, you have to to add cert thumbprints before actually switching certs, at least when you use certs that do not chain to certs in IAM's internal trust store. Apart from that, using the data source `tls_certificate` to determine cert thumbprints can be problematic because the server/intermediate/root cert will usually change from time to time thus leading to a diff or because the machine running _terraform apply_ might not be able to reach the OIDC provider or only through an SSL termination proxy.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
