### PR TITLE
feat: Add `ec2:DescribeInstanceTypes` to EBS CSI driver policy

### DIFF
--- a/modules/iam-role-for-service-accounts/policies.tf
+++ b/modules/iam-role-for-service-accounts/policies.tf
@@ -171,6 +171,7 @@ data "aws_iam_policy_document" "ebs_csi" {
   statement {
     actions = [
       "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeInstanceTypes",
       "ec2:DescribeInstances",
       "ec2:DescribeSnapshots",
       "ec2:DescribeTags",


### PR DESCRIPTION
## Description
Add `ec2:DescribeInstanceTypes` to the EBS CSI driver IRSA policy.

## Motivation and Context
The EBS CSI driver will require `ec2:DescribeInstanceTypes` in a future release to determine instance capabilities at runtime (e.g., NVMe support).

See: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md#describeinstancetypes-at-runtime

## Breaking Changes
None.