### PR TITLE
fix: Add missing `ec2:DescribeSecurityGroups` IPv4 VPC CNI IRSA permissions

### DIFF
--- a/modules/iam-role-for-service-accounts/policies.tf
+++ b/modules/iam-role-for-service-accounts/policies.tf
@@ -1088,6 +1088,7 @@ data "aws_iam_policy_document" "vpc_cni" {
         "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",
         "ec2:UnassignPrivateIpAddresses"


### PR DESCRIPTION
Add missing ec2:DescribeSecurityGroups permissions

## Description
Add missing ec2:DescribeSecurityGroups to iam-role-for-service-account VPC CNI policy

## Motivation and Context
Closes #645
VPC CNI add-on upgrades fail because of missing IAM permissions

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
