### PR TITLE
fix: Split EFS CSI Driver role to Node and Controller IAM roles

### DIFF
--- a/examples/iam-role-for-service-accounts/main.tf
+++ b/examples/iam-role-for-service-accounts/main.tf
@@ -109,14 +109,12 @@ module "efs_csi_irsa" {
 
   name = "efs-csi"
 
-  attach_efs_csi_policy = true
-
-  oidc_providers = {
-    this = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:efs-csi-controller-sa"]
-    }
-  }
+  # Creates dedicated `${name}-controller` and `${name}-node` IAM roles with the
+  # upstream AWS managed policies attached. Trust is pinned to the standard install
+  # SAs (`kube-system:efs-csi-controller-sa` / `kube-system:efs-csi-node-sa`).
+  # Consume `efs_csi_controller_iam_role_arn` and `efs_csi_node_iam_role_arn`
+  # outputs to annotate the EFS CSI Helm chart's ServiceAccounts.
+  enable_efs_split_roles = true
 
   tags = local.tags
 }

--- a/modules/iam-role-for-service-accounts/README.md
+++ b/modules/iam-role-for-service-accounts/README.md
@@ -134,10 +134,14 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.efs_csi_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.efs_csi_node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.amazon_cloudwatch_observability](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.efs_csi_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.efs_csi_node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.amazon_managed_service_prometheus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -146,6 +150,7 @@ No modules.
 | [aws_iam_policy_document.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.efs_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.efs_csi_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.external_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.fsx_lustre_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -175,7 +180,7 @@ No modules.
 | <a name="input_attach_cloudwatch_observability_policy"></a> [attach\_cloudwatch\_observability\_policy](#input\_attach\_cloudwatch\_observability\_policy) | Determines whether to attach the Amazon CloudWatch Observability IAM policies to the role | `bool` | `false` | no |
 | <a name="input_attach_cluster_autoscaler_policy"></a> [attach\_cluster\_autoscaler\_policy](#input\_attach\_cluster\_autoscaler\_policy) | Determines whether to attach the Cluster Autoscaler IAM policy to the role | `bool` | `false` | no |
 | <a name="input_attach_ebs_csi_policy"></a> [attach\_ebs\_csi\_policy](#input\_attach\_ebs\_csi\_policy) | Determines whether to attach the EBS CSI IAM policy to the role | `bool` | `false` | no |
-| <a name="input_attach_efs_csi_policy"></a> [attach\_efs\_csi\_policy](#input\_attach\_efs\_csi\_policy) | Determines whether to attach the EFS CSI IAM policy to the role | `bool` | `false` | no |
+| <a name="input_attach_efs_csi_policy"></a> [attach\_efs\_csi\_policy](#input\_attach\_efs\_csi\_policy) | Determines whether to attach the EFS CSI IAM policy to the role. | `bool` | `false` | no |
 | <a name="input_attach_external_dns_policy"></a> [attach\_external\_dns\_policy](#input\_attach\_external\_dns\_policy) | Determines whether to attach the External DNS IAM policy to the role | `bool` | `false` | no |
 | <a name="input_attach_external_secrets_policy"></a> [attach\_external\_secrets\_policy](#input\_attach\_external\_secrets\_policy) | Determines whether to attach the External Secrets policy to the role | `bool` | `false` | no |
 | <a name="input_attach_fsx_lustre_csi_policy"></a> [attach\_fsx\_lustre\_csi\_policy](#input\_attach\_fsx\_lustre\_csi\_policy) | Determines whether to attach the FSx for Lustre CSI Driver IAM policy to the role | `bool` | `false` | no |
@@ -193,6 +198,7 @@ No modules.
 | <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | Whether to create an IAM policy that is attached to the IAM role created | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description of the role | `string` | `null` | no |
 | <a name="input_ebs_csi_kms_cmk_arns"></a> [ebs\_csi\_kms\_cmk\_arns](#input\_ebs\_csi\_kms\_cmk\_arns) | KMS CMK ARNs to allow EBS CSI to manage encrypted volumes | `list(string)` | `[]` | no |
+| <a name="input_enable_efs_split_roles"></a> [enable\_efs\_split\_roles](#input\_enable\_efs\_split\_roles) | Determines whether to create dedicated EFS CSI controller and node IAM roles with the upstream AWS managed policies attached (v3 driver split) | `bool` | `false` | no |
 | <a name="input_external_dns_hosted_zone_arns"></a> [external\_dns\_hosted\_zone\_arns](#input\_external\_dns\_hosted\_zone\_arns) | Route53 hosted zone ARNs to allow External DNS to manage records | `list(string)` | `[]` | no |
 | <a name="input_external_secrets_kms_key_arns"></a> [external\_secrets\_kms\_key\_arns](#input\_external\_secrets\_kms\_key\_arns) | List of KMS Key ARNs that are used by Secrets Manager that contain secrets to mount using External Secrets | `list(string)` | `[]` | no |
 | <a name="input_external_secrets_secrets_manager_arns"></a> [external\_secrets\_secrets\_manager\_arns](#input\_external\_secrets\_secrets\_manager\_arns) | List of Secrets Manager ARNs that contain secrets to mount using External Secrets | `list(string)` | `[]` | no |
@@ -236,6 +242,10 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of IAM role |
+| <a name="output_efs_csi_controller_iam_role_arn"></a> [efs\_csi\_controller\_iam\_role\_arn](#output\_efs\_csi\_controller\_iam\_role\_arn) | ARN of the EFS CSI controller IAM role |
+| <a name="output_efs_csi_controller_iam_role_name"></a> [efs\_csi\_controller\_iam\_role\_name](#output\_efs\_csi\_controller\_iam\_role\_name) | Name of the EFS CSI controller IAM role |
+| <a name="output_efs_csi_node_iam_role_arn"></a> [efs\_csi\_node\_iam\_role\_arn](#output\_efs\_csi\_node\_iam\_role\_arn) | ARN of the EFS CSI node IAM role |
+| <a name="output_efs_csi_node_iam_role_name"></a> [efs\_csi\_node\_iam\_role\_name](#output\_efs\_csi\_node\_iam\_role\_name) | Name of the EFS CSI node IAM role |
 | <a name="output_iam_policy"></a> [iam\_policy](#output\_iam\_policy) | The policy document |
 | <a name="output_iam_policy_arn"></a> [iam\_policy\_arn](#output\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_name"></a> [name](#output\_name) | Name of IAM role |

--- a/modules/iam-role-for-service-accounts/main.tf
+++ b/modules/iam-role-for-service-accounts/main.tf
@@ -262,3 +262,55 @@ resource "aws_iam_role_policy" "inline" {
   name_prefix = var.use_name_prefix ? "${var.name}-" : null
   policy      = data.aws_iam_policy_document.inline[0].json
 }
+
+################################################################################
+# IAM Role for EFS CSI Driver Split Roles
+################################################################################
+data "aws_iam_policy_document" "efs_csi_assume" {
+  count = var.create && var.enable_efs_split_roles ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "efs_csi_controller" {
+  count = var.create && var.enable_efs_split_roles ? 1 : 0
+
+  name        = var.use_name_prefix ? null : "${var.name}-controller"
+  name_prefix = var.use_name_prefix ? "${var.name}-controller-" : null
+  path        = var.path
+  description = "EFS CSI controller IAM role"
+
+  assume_role_policy    = data.aws_iam_policy_document.efs_csi_assume[0].json
+  max_session_duration  = var.max_session_duration
+  permissions_boundary  = var.permissions_boundary
+  force_detach_policies = true
+
+  tags = var.tags
+}
+
+resource "aws_iam_role" "efs_csi_node" {
+  count = var.create && var.enable_efs_split_roles ? 1 : 0
+
+  name        = var.use_name_prefix ? null : "${var.name}-node"
+  name_prefix = var.use_name_prefix ? "${var.name}-node-" : null
+  path        = var.path
+  description = "EFS CSI node IAM role"
+
+  assume_role_policy    = data.aws_iam_policy_document.efs_csi_assume[0].json
+  max_session_duration  = var.max_session_duration
+  permissions_boundary  = var.permissions_boundary
+  force_detach_policies = true
+
+  tags = var.tags
+}

--- a/modules/iam-role-for-service-accounts/outputs.tf
+++ b/modules/iam-role-for-service-accounts/outputs.tf
@@ -35,3 +35,27 @@ output "iam_policy" {
   description = "The policy document"
   value       = try(aws_iam_policy.this[0].policy, null)
 }
+
+################################################################################
+# EFS CSI Driver Roles (v3 split)
+################################################################################
+
+output "efs_csi_controller_iam_role_arn" {
+  description = "ARN of the EFS CSI controller IAM role"
+  value       = try(aws_iam_role.efs_csi_controller[0].arn, null)
+}
+
+output "efs_csi_controller_iam_role_name" {
+  description = "Name of the EFS CSI controller IAM role"
+  value       = try(aws_iam_role.efs_csi_controller[0].name, null)
+}
+
+output "efs_csi_node_iam_role_arn" {
+  description = "ARN of the EFS CSI node IAM role"
+  value       = try(aws_iam_role.efs_csi_node[0].arn, null)
+}
+
+output "efs_csi_node_iam_role_name" {
+  description = "Name of the EFS CSI node IAM role"
+  value       = try(aws_iam_role.efs_csi_node[0].name, null)
+}

--- a/modules/iam-role-for-service-accounts/policies.tf
+++ b/modules/iam-role-for-service-accounts/policies.tf
@@ -374,9 +374,8 @@ data "aws_iam_policy_document" "ebs_csi" {
 }
 
 ################################################################################
-# EFS CSI Driver Policy
+# EFS CSI Driver Policy - v2 and below
 ################################################################################
-
 # https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/iam-policy-example.json
 data "aws_iam_policy_document" "efs_csi" {
   count = var.create && var.attach_efs_csi_policy ? 1 : 0
@@ -424,6 +423,35 @@ data "aws_iam_policy_document" "efs_csi" {
       values   = ["true"]
     }
   }
+}
+
+################################################################################
+# EFS CSI Driver SA Policies - v3 driver split with dedicated controller and node IAM roles, each with the upstream AWS managed policies attached.
+################################################################################
+
+# https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/iam-policy-create.md
+# v3 driver split: dedicated controller and node IAM roles, each with the
+# upstream AWS managed policies attached. Trust policies pin to the standard
+# install SAs (`efs-csi-controller-sa` / `efs-csi-node-sa` in `kube-system`).
+
+resource "aws_iam_role_policy_attachment" "efs_csi_controller" {
+  for_each = { for k, v in {
+    AmazonEFSCSIDriverPolicy     = "arn:${local.partition}:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy"
+    AmazonS3FilesCSIDriverPolicy = "arn:${local.partition}:iam::aws:policy/service-role/AmazonS3FilesCSIDriverPolicy"
+  } : k => v if var.create && var.enable_efs_split_roles }
+
+  role       = aws_iam_role.efs_csi_controller[0].name
+  policy_arn = each.value
+}
+
+resource "aws_iam_role_policy_attachment" "efs_csi_node" {
+  for_each = { for k, v in {
+    AmazonS3ReadOnlyAccess        = "arn:${local.partition}:iam::aws:policy/AmazonS3ReadOnlyAccess"
+    AmazonElasticFileSystemsUtils = "arn:${local.partition}:iam::aws:policy/AmazonElasticFileSystemsUtils"
+  } : k => v if var.create && var.enable_efs_split_roles }
+
+  role       = aws_iam_role.efs_csi_node[0].name
+  policy_arn = each.value
 }
 
 ################################################################################

--- a/modules/iam-role-for-service-accounts/variables.tf
+++ b/modules/iam-role-for-service-accounts/variables.tf
@@ -229,7 +229,13 @@ variable "mountpoint_s3_csi_path_arns" {
 
 # EFS CSI
 variable "attach_efs_csi_policy" {
-  description = "Determines whether to attach the EFS CSI IAM policy to the role"
+  description = "Determines whether to attach the EFS CSI IAM policy to the role."
+  type        = bool
+  default     = false
+}
+
+variable "enable_efs_split_roles" {
+  description = "Determines whether to create dedicated EFS CSI controller and node IAM roles with the upstream AWS managed policies attached (v3 driver split)"
   type        = bool
   default     = false
 }

--- a/wrappers/iam-role-for-service-accounts/main.tf
+++ b/wrappers/iam-role-for-service-accounts/main.tf
@@ -28,6 +28,7 @@ module "wrapper" {
   create_policy                                                   = try(each.value.create_policy, var.defaults.create_policy, true)
   description                                                     = try(each.value.description, var.defaults.description, null)
   ebs_csi_kms_cmk_arns                                            = try(each.value.ebs_csi_kms_cmk_arns, var.defaults.ebs_csi_kms_cmk_arns, [])
+  enable_efs_split_roles                                          = try(each.value.enable_efs_split_roles, var.defaults.enable_efs_split_roles, false)
   external_dns_hosted_zone_arns                                   = try(each.value.external_dns_hosted_zone_arns, var.defaults.external_dns_hosted_zone_arns, [])
   external_secrets_kms_key_arns                                   = try(each.value.external_secrets_kms_key_arns, var.defaults.external_secrets_kms_key_arns, [])
   external_secrets_secrets_manager_arns                           = try(each.value.external_secrets_secrets_manager_arns, var.defaults.external_secrets_secrets_manager_arns, [])


### PR DESCRIPTION
## Description
Changes to create 2 dedicated IAM roles and attached AWS managed policies as per changes in EFS CSI driver v3 - one for controller SA and another one for Node SA. It is backward compatible as existing inline policy left untouched to support users still running on v2 and below.

## Motivation and Context
Fix #637

## Breaking Changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
