### PR TITLE
fix: Handle null role name with name prefix

### DIFF
--- a/modules/iam-role/main.tf
+++ b/modules/iam-role/main.tf
@@ -11,6 +11,7 @@ locals {
 
   oidc_providers     = [for url in var.oidc_provider_urls : replace(url, "https://", "")]
   bitbucket_provider = try(element(local.oidc_providers, 0), null)
+  name_prefix        = var.name != null ? "${var.name}-" : null
 }
 
 ################################################################################
@@ -285,7 +286,7 @@ resource "aws_iam_role" "this" {
   count = var.create ? 1 : 0
 
   name        = var.use_name_prefix ? null : var.name
-  name_prefix = var.use_name_prefix ? "${var.name}-" : null
+  name_prefix = var.use_name_prefix ? local.name_prefix : null
   path        = var.path
   description = var.description
 
@@ -365,7 +366,7 @@ resource "aws_iam_role_policy" "inline" {
 
   role        = aws_iam_role.this[0].name
   name        = var.use_name_prefix ? null : var.name
-  name_prefix = var.use_name_prefix ? "${var.name}-" : null
+  name_prefix = var.use_name_prefix ? local.name_prefix : null
   policy      = data.aws_iam_policy_document.inline[0].json
 }
 
@@ -379,7 +380,7 @@ resource "aws_iam_instance_profile" "this" {
   role = aws_iam_role.this[0].name
 
   name        = var.use_name_prefix ? null : var.name
-  name_prefix = var.use_name_prefix ? "${var.name}-" : null
+  name_prefix = var.use_name_prefix ? local.name_prefix : null
   path        = var.path
 
   tags = var.tags


### PR DESCRIPTION
## Description
This change updates modules/iam-role to handle `name = null` when `use_name_prefix = true`.

The module now derives name_prefix from a local value that is only set when var.name is non-null, instead of interpolating var.name directly. This avoids passing an invalid prefix to IAM resources.

## Motivation and Context
This fixes a Terraform plan failure caused by interpolating `null` into `name_prefix`:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Invalid template interpolation value
│ 
│   on modules/iam-role/main.tf line 288, in resource "aws_iam_role" "this":
│  288:   name_prefix = var.use_name_prefix ? "${var.name}-" : null
│     ├────────────────
│     │ var.name is null
│ 
│ The expression result is null. Cannot include a null value in a string template.
```

## Breaking Changes
None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
