### PR TITLE
fix: Add output guards

### DIFF
--- a/modules/iam-role-for-service-accounts/outputs.tf
+++ b/modules/iam-role-for-service-accounts/outputs.tf
@@ -5,11 +5,23 @@
 output "arn" {
   description = "ARN of IAM role"
   value       = try(aws_iam_role.this[0].arn, null)
+
+  depends_on = [
+    aws_iam_role_policy_attachment.this,
+    aws_iam_role_policy_attachment.additional,
+    aws_iam_role_policy.inline,
+  ]
 }
 
 output "name" {
   description = "Name of IAM role"
   value       = try(aws_iam_role.this[0].name, null)
+
+  depends_on = [
+    aws_iam_role_policy_attachment.this,
+    aws_iam_role_policy_attachment.additional,
+    aws_iam_role_policy.inline,
+  ]
 }
 
 output "path" {
@@ -20,6 +32,12 @@ output "path" {
 output "unique_id" {
   description = "Unique ID of IAM role"
   value       = try(aws_iam_role.this[0].unique_id, null)
+
+  depends_on = [
+    aws_iam_role_policy_attachment.this,
+    aws_iam_role_policy_attachment.additional,
+    aws_iam_role_policy.inline,
+  ]
 }
 
 ################################################################################

--- a/modules/iam-role/outputs.tf
+++ b/modules/iam-role/outputs.tf
@@ -5,16 +5,31 @@
 output "name" {
   description = "The name of the IAM role"
   value       = try(aws_iam_role.this[0].name, null)
+
+  depends_on = [
+    aws_iam_role_policy_attachment.this,
+    aws_iam_role_policy.inline,
+  ]
 }
 
 output "arn" {
   description = "The Amazon Resource Name (ARN) specifying the IAM role"
   value       = try(aws_iam_role.this[0].arn, null)
+
+  depends_on = [
+    aws_iam_role_policy_attachment.this,
+    aws_iam_role_policy.inline,
+  ]
 }
 
 output "unique_id" {
   description = "Stable and unique string identifying the IAM role"
   value       = try(aws_iam_role.this[0].unique_id, null)
+
+  depends_on = [
+    aws_iam_role_policy_attachment.this,
+    aws_iam_role_policy.inline,
+  ]
 }
 
 ################################################################################


### PR DESCRIPTION
Hi guys,
I was testing apply/destroy for eks project which uses the module and noticed that destroy order for EBS is broken.

I use arn output to pass the role into ebs addon. And it means that terraform only sees arn as ref. When you destroy (or replace), you'll have the situation when the role still exist and waits for workload to be gracefully deleted, but attachment and policy are gone.

```
Case A — current module (no depends_on):
  destroyed-attachment -- permissions gone
  destroyed-policy
  destroyed-workload   <-- workload still running, failing to perform finalizers
  destroyed-role

  Case B — with depends_on on the output:
  destroyed-workload   <-- drains first
  destroyed-attachment
  destroyed-policy
  destroyed-role
```

the same problem is applicable to pod-identity module (I haven't migrated yet)

Thanks!