### PR TITLE
feat: add support for custom IAM Instance Profile name

### DIFF
--- a/modules/iam-role/main.tf
+++ b/modules/iam-role/main.tf
@@ -378,7 +378,7 @@ resource "aws_iam_instance_profile" "this" {
 
   role = aws_iam_role.this[0].name
 
-  name        = var.use_name_prefix ? null : var.name
+  name        = var.use_name_prefix ? null : coalesce(var.instance_profile_name,var.name)
   name_prefix = var.use_name_prefix ? "${var.name}-" : null
   path        = var.path
 

--- a/modules/iam-role/variables.tf
+++ b/modules/iam-role/variables.tf
@@ -239,3 +239,9 @@ variable "create_instance_profile" {
   type        = bool
   default     = false
 }
+
+variable "instance_profile_name" {
+  description = "Custom name for the IAM Instance Profile. If null, the role name will be used."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary

This change adds support for specifying a custom IAM Instance Profile name when `create_instance_profile` is enabled.

## Motivation

Some users create IAM roles with custom names but need the associated IAM Instance Profile to follow a different naming convention. Currently, the module always creates the instance profile using the IAM role name, making it impossible to customize the instance profile name independently.

## Changes

* Added an optional `instance_profile_name` input variable.
* Uses the provided value when creating the IAM Instance Profile.
* Falls back to the IAM role name when `instance_profile_name` is not specified, preserving the current behavior.

## Backward Compatibility

This change is fully backward compatible. If `instance_profile_name` is not provided, the module continues to create the IAM Instance Profile using the IAM role name, ensuring no impact on existing users.
